### PR TITLE
rework order edit

### DIFF
--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -646,6 +646,41 @@ if (!class_exists('WC_Twoinc_Helper')) {
         }
 
         /**
+         * Get Order Unsecured Hash
+         *
+         * @param $obj
+         *
+         * @return string
+         */
+        public static function hash_order($order, $twoinc_meta) {
+            $twoinc_order = WC_Twoinc_Helper::compose_twoinc_order(
+                $order,
+                $twoinc_meta['order_reference'],
+                $twoinc_meta['company_id'],
+                $twoinc_meta['department'],
+                $twoinc_meta['project'],
+                $twoinc_meta['purchase_order_number'],
+                $twoinc_meta['payment_reference_message'],
+                $twoinc_meta['payment_reference_ocr'],
+                $twoinc_meta['payment_reference'],
+                $twoinc_meta['payment_reference_type'],
+                ''
+            );
+            return WC_Twoinc_Helper::hash_obj($twoinc_order);
+        }
+
+        /**
+         * Get Unsecured Hash
+         *
+         * @param $obj
+         *
+         * @return string
+         */
+        public static function hash_obj($obj) {
+            return md5(json_encode(WC_Twoinc_Helper::utf8ize($obj)));
+        }
+
+        /**
          * Recursively compare arrays
          *
          * @param $src_arr


### PR DESCRIPTION
There are many types of edits that user can do in WooCommerce: post edit, address edit, field edit, line item add/remove/edit, fee add/remove/edit, shipping fee add/remove/edit, recalculate.
Order meta field edit does not work on certain sites, and we could not find all necessary before-after hooks for all types of edits.
We need to rework order edit for a more stable solution and easier to hook.
Now we hash the request body each time we send to Two, and only send edit request to Two if the hash is changed.