### PR TITLE
fix: same buyer seller error not appeared

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1704,7 +1704,7 @@ class Twoinc {
                     displayMsgId = 'errored|.err-phone'
                     invalidFields.append('billing_phone_field')
                 } else if (errMsg === 'SAME_BUYER_SELLER_ERROR') {
-                    displayMsgId = 'errored|.buyer-same-seller'
+                    displayMsgId = 'errored|.err-buyer-same-seller'
                 } else {
                     displayMsgId = 'errored|.err-payment-default'
                 }

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -119,7 +119,7 @@ function wc_twoinc_enqueue_styles()
  */
 function wc_twoinc_enqueue_scripts()
 {
-    wp_enqueue_script('twoinc-payment-gateway-js', WC_TWOINC_PLUGIN_URL . '/assets/js/twoinc.js', ['jquery'], '2.4.5');
+    wp_enqueue_script('twoinc-payment-gateway-js', WC_TWOINC_PLUGIN_URL . '/assets/js/twoinc.js', ['jquery'], '2.4.6');
 }
 
 /**


### PR DESCRIPTION
From Greg:
The text for Two isn't displaying when an error message is displayed initially. To get this I:
1. Entered an ENK company (Data eyolf berg)
2. The error message showed correctly.
3. I then entered a different company (Two AS)
4. No message shows