### PR TITLE
T-8442/feat: Allow two.inc subdomains to use production company search

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -155,7 +155,11 @@ if (!class_exists('WC_Twoinc')) {
          */
         private function get_twoinc_search_host($countryCode){
             if (WC_Twoinc_Helper::is_twoinc_development()) {
-                return "https://{$countryCode}.staging.search.two.inc";
+                if ($this->get_option('use_prod_company_search') === 'yes') {
+                    return "https://{$countryCode}.search.two.inc";
+                } else {
+                    return "https://{$countryCode}.search.staging.two.inc";
+                }
             }
             return "https://{$countryCode}.search.two.inc";
         }
@@ -1703,7 +1707,7 @@ if (!class_exists('WC_Twoinc')) {
 
             if ($site_type === 'WOOCOMMERCE') {
 
-                $allowed_twoinc_checkout_hosts = array('https://api.two.inc/', 'https://staging.api.two.inc/', 'https://sandbox.api.two.inc/', 'http://localhost:8080');
+                $allowed_twoinc_checkout_hosts = array('https://api.two.inc/', 'https://api.staging.two.inc/', 'https://sandbox.api.two.inc/', 'http://localhost:8080');
                 if (!in_array($twoinc_checkout_host, $allowed_twoinc_checkout_hosts)) {
                     $error = new WP_Error(
                         'init_failed',
@@ -1755,6 +1759,7 @@ if (!class_exists('WC_Twoinc')) {
                     if (isset($body['clear_options_on_deactivation'])) $wc_twoinc_instance->update_option('clear_options_on_deactivation', $body['clear_options_on_deactivation'] ? 'yes' : 'no');
                     if (WC_Twoinc_Helper::is_twoinc_development()) {
                         $wc_twoinc_instance->update_option('test_checkout_host', $twoinc_checkout_host);
+                        if (isset($body['use_prod_company_search'])) $wc_twoinc_instance->update_option('use_prod_company_search', $body['use_prod_company_search'] ? 'yes' : 'no');
                     } else if (strpos($twoinc_checkout_host, 'sandbox.api.two.inc') !== false) {
                         $wc_twoinc_instance->update_option('checkout_env', 'SANDBOX');
                     } else {
@@ -1841,7 +1846,13 @@ if (!class_exists('WC_Twoinc')) {
                 'test_checkout_host' => [
                     'type'        => 'text',
                     'title'       => __('Two Test Server', 'twoinc-payment-gateway'),
-                    'default'     => 'https://staging.api.two.inc'
+                    'default'     => 'https://api.staging.two.inc'
+                ],
+                'use_prod_company_search' => [
+                    'type'        => 'select',
+                    'title'       => __('Use production company search`', 'twoinc-payment-gateway'),
+                    'type'        => 'checkbox',
+                    'default'     => 'no'
                 ],
                 'checkout_env' => [
                     'type'        => 'select',
@@ -1989,6 +2000,7 @@ if (!class_exists('WC_Twoinc')) {
                 unset($twoinc_form_fields['checkout_env']);
             } else {
                 unset($twoinc_form_fields['test_checkout_host']);
+                unset($twoinc_form_fields['use_prod_company_search']);
             }
 
             $this->form_fields = apply_filters('wc_two_form_fields', $twoinc_form_fields);

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -728,24 +728,18 @@ if (!class_exists('WC_Twoinc_Helper')) {
             $hostname = str_replace(array('http://', 'https://'), '', get_home_url());
 
             // Local or configured in env var
-            if (in_array($hostname, array('dev.tillitlocal.ai', 'localhost')) || substr($hostname, 0, 10) === 'localhost:') return true;
+            if (preg_match('/^localhost(?::[0-9]{1,5})?$/', $hostname) === 1) return true;
             $env_dev_hostnames = getenv('TWOINC_DEV_HOSTNAMES');
             if ($env_dev_hostnames && in_array($hostname, explode(',', $env_dev_hostnames))) return true;
 
-            // Production sites
-            if (strlen($hostname) > 8 && substr($hostname, -8) === '.two.inc') {
-                $twoinc_prod_sites = array('shop', 'morgenlevering', 'arkwrightx', 'paguro');
-                $host_prefix = substr($hostname, 0, -8);
-
-                foreach ($twoinc_prod_sites as $twoinc_prod_site) {
-                    if ($host_prefix === $twoinc_prod_site || $host_prefix === ('www.' . $twoinc_prod_site)) {
-                        // Twoinc site but not for development
-                        return false;
-                    }
+            if (str_ends_with($hostname, "two.inc")) {
+                // Production sites using two.inc subdomains
+                $twoinc_prod_sites = '/^(?:www\.)?(?:(?:.+\.)?(?:shop|demo)|tellit|iem|cubelighting|digg|morgenlevering|arkwrightx|kandidate|kandidate-internal)\.two\.inc$/';
+                if (preg_match($twoinc_prod_sites, $hostname) === 1){
+                    return false;
+                } else {
+                    return true;
                 }
-
-                // Twoinc development site
-                return true;
             }
 
             // Merchant's staging
@@ -753,7 +747,6 @@ if (!class_exists('WC_Twoinc_Helper')) {
 
             // Neither local nor twoinc development site
             return false;
-
         }
 
         /**

--- a/docker/config-staging.json
+++ b/docker/config-staging.json
@@ -2,7 +2,7 @@
   "enabled": "no",
   "title": "Business invoice %s days",
   "subtitle": "Receive the invoice via PDF and email",
-  "test_checkout_host": "https://staging.api.two.inc",
+  "test_checkout_host": "https://api.staging.two.inc",
   "clear_options_on_deactivation": "no",
   "section_api_credentials": "",
   "tillit_merchant_id": "tillitas",


### PR DESCRIPTION
Sometimes, we may want to use prod company search on our subdomains, e.g. on shop and demo sites which we don’t want to be affected by staging downtime. 