### PR TITLE
t-8802/feat: setting option to skip nonce auth in confirmation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.15.3
+current_version = 2.16.0
 tag_name = {new_version}
 commit = True
 tag = True

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -1578,17 +1578,19 @@ if (!class_exists('WC_Twoinc')) {
             // Get the order reference
             $order_reference = sanitize_text_field($_REQUEST['twoinc_confirm_order']);
 
-            // Get the nonce
-            $nonce = $_REQUEST['nonce'];
+            if ($this->get_option('skip_confirm_auth') !== 'yes') {
+                // Get the nonce
+                $nonce = $_REQUEST['nonce'];
 
-            // Stop if the code is not valid
-            if (!wp_verify_nonce($nonce, 'twoinc_confirm')) {
-                WC_Twoinc_Helper::send_twoinc_alert_email(
-                    "Invalid nonce:"
-                    . "\r\n- Request: Confirm order"
-                    . "\r\n- Order reference: " . $order_reference
-                    . "\r\n- Site: " . get_site_url());
-                wp_die(__('The security code is not valid.', 'twoinc-payment-gateway'));
+                // Stop if the code is not valid
+                if (!wp_verify_nonce($nonce, 'twoinc_confirm')) {
+                    WC_Twoinc_Helper::send_twoinc_alert_email(
+                        "Invalid nonce:"
+                        . "\r\n- Request: Confirm order"
+                        . "\r\n- Order reference: " . $order_reference
+                        . "\r\n- Site: " . get_site_url());
+                    wp_die(__('The security code is not valid.', 'twoinc-payment-gateway'));
+                }
             }
 
             /** @var wpdb $wpdb */
@@ -1972,6 +1974,12 @@ if (!class_exists('WC_Twoinc')) {
                 ],
                 'display_tooltips' => [
                     'title'       => __('Display input tooltips', 'twoinc-payment-gateway'),
+                    'label'       => ' ',
+                    'type'        => 'checkbox',
+                    'default'     => 'no'
+                ],
+                'skip_confirm_auth' => [
+                    'title'       => __('Skip user validation at order confirmation', 'twoinc-payment-gateway'),
                     'label'       => ' ',
                     'type'        => 'checkbox',
                     'default'     => 'no'

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Tags: payment request, woocommerce
 Requires at least: 4.7
 Tested up to: 5.9.1
 Requires PHP: 5.6
-Stable tag: 2.15.3
+Stable tag: 2.16.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -3,7 +3,7 @@
  * Plugin Name: Two - BNPL for businesses
  * Plugin URI: https://two.inc
  * Description: Integration between WooCommerce and Two
- * Version: 2.15.3
+ * Version: 2.16.0
  * Author: Two
  * Author URI: https://two.inc
  * Text Domain: twoinc-payment-gateway


### PR DESCRIPTION
**Background**
The buyer WordPress session did not pass an auth check. If the buyer used the same session throughout the checkout journey, probably the website has some plugin that prevents this auth from working properly.

**Proposed solution**
Add a checkbox in settings for merchant to skip the check that causes this.