### PR TITLE
Fix PHP Warning  - undefined `$wp_version`

### DIFF
--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -164,7 +164,7 @@ if (!class_exists('WC_Twoinc_Helper')) {
             } else {
                 return;
             }
-
+            global $wp_version;
             if ($wp_version > '5.0.0' && !wp_is_json_request()) {
                 wc_print_notices();
             }


### PR DESCRIPTION
`$wp_version` would always be undefined as it wasn't loaded in local scope. Updated reference to global variable to fix.