### PR TITLE
Comparison operator should be `OR`, not `AND`

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -344,7 +344,7 @@ if (!class_exists('WC_Twoinc')) {
         public function update_checkout_options()
         {
 
-            if (!isset($_POST['woocommerce_woocommerce-gateway-tillit_merchant_logo']) && !isset($_POST['woocommerce_woocommerce-gateway-tillit_tillit_merchant_id'])) return;
+            if (!isset($_POST['woocommerce_woocommerce-gateway-tillit_merchant_logo']) || !isset($_POST['woocommerce_woocommerce-gateway-tillit_tillit_merchant_id'])) return;
 
             $image_id = sanitize_text_field($_POST['woocommerce_woocommerce-gateway-tillit_merchant_logo']);
 


### PR DESCRIPTION
Comparison operator should be `OR`, not `AND`. Otherwise we try to run logic if just one of the parameters is true, resulting in PHP warning on unset `$_POST` value