### PR TITLE
Fix company search dependency for WooCommerce 9.8.5

### DIFF
--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -201,7 +201,13 @@ function wc_twoinc_enqueue_styles()
  */
 function wc_twoinc_enqueue_scripts()
 {
-    wp_enqueue_script('twoinc-payment-gateway-js', WC_TWOINC_PLUGIN_URL . '/assets/js/twoinc.js', ['jquery'], get_twoinc_plugin_version());
+    wp_enqueue_script(
+        'twoinc-payment-gateway-js',
+        WC_TWOINC_PLUGIN_URL . '/assets/js/twoinc.js',
+        ['jquery', 'selectWoo'],
+        get_twoinc_plugin_version()
+    );
+    wp_enqueue_style('select2');
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure SelectWoo assets load for company search

## Testing
- `pre-commit run --files tillit-payment-gateway.php`

------
https://chatgpt.com/codex/tasks/task_b_685d086e68f88329857b035018ea2b91