### PR TITLE
KNA-3176/fix: field reset when checkout is cached too early

### DIFF
--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -75,12 +75,20 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                 if (
                     is_array($cached_fields) &&
                     isset($cached_fields['billing']) &&
+                    is_array($cached_fields['billing']) &&
                     !isset($cached_fields['billing']['company_id'])
                 ) {
                     $fields_property->setValue($checkout, null);
                 }
             } catch (ReflectionException $e) {
-                // Silently fail - cache clearing is a best-effort optimization
+                // Log the exception for debugging - helps identify issues if WooCommerce internals change
+                if (function_exists('wc_get_logger')) {
+                    wc_get_logger()->warning(
+                        'Two: Failed to clear checkout field cache due to ReflectionException: ' . $e->getMessage(),
+                        ['source' => 'two-payment-gateway']
+                    );
+                }
+                // Silently continue - cache clearing is a best-effort optimization
                 // The checkout will still work, just without Two's custom fields in edge cases
             }
         }

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -38,6 +38,51 @@ if (!class_exists('WC_Twoinc_Checkout')) {
 
             // Order pay page customization
             add_action('woocommerce_pay_order_before_submit', [$this, 'order_pay_page_customize'], 24);
+
+            // Fix for checkout field caching conflicts with other plugins (e.g., PPOM, Dokan)
+            // Some plugins trigger WC_Checkout::get_checkout_fields() early during wp_loaded,
+            // before Two's filters are registered, causing fields to be cached without Two's additions.
+            add_action('woocommerce_checkout_init', [$this, 'maybe_clear_checkout_field_cache'], 1);
+        }
+
+        /**
+         * Clear WooCommerce checkout field cache if Two's fields are missing.
+         *
+         * This fixes compatibility issues with plugins that trigger checkout field
+         * initialization before Two's filters are registered (e.g., PPOM, Dokan).
+         *
+         * @param WC_Checkout $checkout The checkout instance.
+         * @return void
+         */
+        public function maybe_clear_checkout_field_cache($checkout)
+        {
+            if (!$checkout instanceof WC_Checkout) {
+                return;
+            }
+
+            try {
+                $reflection = new ReflectionClass($checkout);
+
+                if (!$reflection->hasProperty('fields')) {
+                    return;
+                }
+
+                $fields_property = $reflection->getProperty('fields');
+                $fields_property->setAccessible(true);
+                $cached_fields = $fields_property->getValue($checkout);
+
+                // Only clear cache if fields are already set but Two's fields are missing
+                if (
+                    is_array($cached_fields) &&
+                    isset($cached_fields['billing']) &&
+                    !isset($cached_fields['billing']['company_id'])
+                ) {
+                    $fields_property->setValue($checkout, null);
+                }
+            } catch (ReflectionException $e) {
+                // Silently fail - cache clearing is a best-effort optimization
+                // The checkout will still work, just without Two's custom fields in edge cases
+            }
         }
 
         /**


### PR DESCRIPTION
Disruptive plugins that run at checkout trigger a caching of checkout fields before the Two plugin and custom fields we require for proper use resulting in fields such as company search and selection being disabled. 

This fix adds a fallback with safe failing when our required fields are missing when the checkout is already loaded.

In response to issue faced by Prima Profilering