### PR TITLE
INF-956/feat: add Playwright e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,0 +1,92 @@
+name: Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: e2e-tests-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-tests:
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          service_account: ${{ vars.GCP_E2E_TESTS_SA_NAME_TWO_BETA }}
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER_PREFIX_TWO_BETA }}/${{ github.event.repository.name }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Fetch secrets
+        id: secrets
+        run: |
+          MERCHANT_API_KEY=$(gcloud secrets versions access latest --secret="STAGING_SHOP_MERCHANT_API_KEY_TILLITTESTUK" --project=two-beta)
+          echo "::add-mask::$MERCHANT_API_KEY"
+          echo "MERCHANT_API_KEY=$MERCHANT_API_KEY" >> $GITHUB_OUTPUT
+
+          TWO_ADMIN_PASSWORD=$(gcloud secrets versions access latest --secret="STAGING_TWO_ADMIN_PASSWORD" --project=two-beta)
+          echo "::add-mask::$TWO_ADMIN_PASSWORD"
+          echo "TWO_ADMIN_PASSWORD=$TWO_ADMIN_PASSWORD" >> $GITHUB_OUTPUT
+
+      - name: Generate Docker plugin config
+        run: |
+          mkdir -p docker/config
+          sed "s|\${MERCHANT_API_KEY}|${MERCHANT_API_KEY}|g" docker/config/staging-tillittestuk.json.tpl > docker/config/staging-tillittestuk.json
+        env:
+          MERCHANT_API_KEY: ${{ steps.secrets.outputs.MERCHANT_API_KEY }}
+
+      - name: Start WordPress
+        run: docker compose up -d
+
+      - name: Wait for bootstrap to complete
+        run: |
+          for i in $(seq 1 60); do
+            if docker compose logs wpcli 2>&1 | grep -q "sleep infinity"; then
+              echo "Bootstrap complete"
+              break
+            fi
+            echo "Waiting for wpcli bootstrap... ($i/60)"
+            sleep 5
+          done
+          docker compose logs wpcli 2>&1 | grep -q "sleep infinity" || (echo "Bootstrap failed" && docker compose logs && exit 1)
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install e2e dependencies
+        working-directory: tests/e2e
+        run: npm ci && npx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        working-directory: tests/e2e
+        run: npx playwright test
+        env:
+          MERCHANT_API_KEY: ${{ steps.secrets.outputs.MERCHANT_API_KEY }}
+          TWO_ADMIN_PASSWORD: ${{ steps.secrets.outputs.TWO_ADMIN_PASSWORD }}
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: tests/e2e/test-results/
+          retention-days: 7
+
+      - name: Stop WordPress
+        if: always()
+        run: docker compose down

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ vendor/
 coverage/
 .phpunit.result.cache
 .phpunit.cache/
+
+# Playwright
+tests/e2e/test-results/
+tests/e2e/playwright-report/

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,12 @@ bumpver-%:
 patch: bumpver-patch
 minor: bumpver-minor
 major: bumpver-major
+
+e2e-install:
+	cd tests/e2e && npm install && npx playwright install chromium
+
+e2e-test:
+	cd tests/e2e && npx playwright test
+
+e2e-test-headed:
+	cd tests/e2e && npx playwright test --headed

--- a/README.md
+++ b/README.md
@@ -74,6 +74,59 @@ docker-compose up -d
 
 Navigate to <http://localhost:8888/> on your browser to access the Wordpress site.
 
+## E2E tests
+
+Playwright e2e tests live in `tests/e2e/`. They run against the local Docker environment and verify the full checkout flow with Two payment.
+
+### Prerequisites
+
+- Docker running with the plugin config (see above)
+- Node.js 22+
+- A merchant API key (from GCP Secret Manager or your local config)
+- Two admin password (for the fulfilment batch trigger)
+
+### Setup
+
+```bash
+docker compose up -d
+# wait ~90s for wpcli bootstrap to finish (installs WooCommerce, creates products, activates plugin)
+
+make e2e-install
+```
+
+### Running
+
+```bash
+export MERCHANT_API_KEY=$(gcloud secrets versions access latest --secret=STAGING_SHOP_MERCHANT_API_KEY_TILLITTESTUK --project=two-beta)
+export TWO_ADMIN_PASSWORD=$(gcloud secrets versions access latest --secret=STAGING_TWO_ADMIN_PASSWORD --project=two-beta)
+
+make e2e-test              # headless
+make e2e-test-headed       # with browser visible
+```
+
+Or if you have a local `docker/config/staging-tillittestuk.json`:
+
+```bash
+export MERCHANT_API_KEY=$(python3 -c "import json; print(json.load(open('docker/config/staging-tillittestuk.json'))['api_key'])")
+```
+
+### Tests
+
+| Test                   | What it does                                                                                       |
+| ---------------------- | -------------------------------------------------------------------------------------------------- |
+| `order-flow.spec.ts`   | Place order → verify CONFIRMED → fulfil via WP admin → verify FULFILLED → refund → verify REFUNDED |
+| `cancel-order.spec.ts` | Place order → cancel via WP admin → verify CANCELLED                                               |
+| `max-limit.spec.ts`    | Add expensive product → expect rejection on checkout                                               |
+
+### Clean restart
+
+If products stop showing or the store behaves oddly between runs:
+
+```bash
+docker compose down -v && rm -rf volumes/
+docker compose up -d
+```
+
 ## Post installation optional steps
 
 Once Wordpress has been set up, a recommended plugin theme to install is:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,9 +18,16 @@ services:
     volumes:
       - ./volumes/wordpress:/var/www/html
       - .:/var/www/html/wp-content/plugins/tillit-payment-gateway
+      - ./docker/mu-plugins:/var/www/html/wp-content/mu-plugins
       - ./volumes/log/:/var/log/apache2/
     depends_on:
-      - mariadb
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost/ || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   wpcli:
     container_name: wpcli
@@ -39,17 +46,20 @@ services:
       WORDPRESS_ADMIN_PASSWORD: twoinb2b
       WORDPRESS_ADMIN_EMAIL: admin@two.inc
       WOOCOM_PLUGIN_CONFIG_JSON: docker/config/staging-tillittestuk.json
-      WOOCOM_CURRENCY: EUR
-      WOOCOM_DEFAULT_COUNTRY: NL
+      WOOCOM_CURRENCY: GBP
+      WOOCOM_DEFAULT_COUNTRY: GB
       WOOCOM_VERSION: 9.9.5
       # WOOCOM_VERSION: 8.9.5
       # WOOCOM_VERSION: 7.9.1
     volumes:
       - ./volumes/wordpress:/var/www/html
       - .:/opt/tillit-payment-gateway
+      - .:/var/www/html/wp-content/plugins/tillit-payment-gateway
     depends_on:
-      - mariadb
-      - wordpress
+      mariadb:
+        condition: service_healthy
+      wordpress:
+        condition: service_healthy
 
   mariadb:
     container_name: mariadb
@@ -62,3 +72,8 @@ services:
       MYSQL_RANDOM_ROOT_PASSWORD: "1"
     volumes:
       - ./volumes/mariadb:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "twocommerce", "-ptwocommerce"]
+      interval: 5s
+      timeout: 5s
+      retries: 10

--- a/docker/config/staging-tillittestuk.json.tpl
+++ b/docker/config/staging-tillittestuk.json.tpl
@@ -1,0 +1,22 @@
+{
+  "enabled": "yes",
+  "title": "Business invoice %s days",
+  "subtitle": "Receive the invoice via PDF and email",
+  "test_checkout_host": "https://api.staging.two.inc",
+  "clear_options_on_deactivation": "no",
+  "section_api_credentials": "",
+  "api_key": "${MERCHANT_API_KEY}",
+  "section_checkout_options": "",
+  "enable_order_intent": "yes",
+  "add_field_department": "yes",
+  "add_field_project": "yes",
+  "add_field_purchase_order_number": "yes",
+  "add_field_invoice_email": "yes",
+  "show_abt_link": "yes",
+  "invoice_fee_to_buyer": "no",
+  "section_auto_complete_settings": "",
+  "enable_company_search": "yes",
+  "enable_company_search_for_others": "yes",
+  "enable_address_lookup": "yes",
+  "merchant_id": "2e2bf194-a56e-44c3-af50-342fe9ebf32f"
+}

--- a/docker/mu-plugins/disable-sticky-cart.php
+++ b/docker/mu-plugins/disable-sticky-cart.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Disable Storefront sticky add-to-cart to avoid fatal error with WooCommerce 9.x.
+ * The storefront_sticky_single_add_to_cart function calls is_purchasable() on a
+ * string instead of a WC_Product object after order processing.
+ */
+add_action('init', function () {
+    remove_action('storefront_after_footer', 'storefront_sticky_single_add_to_cart', 999);
+});

--- a/docker/wpcli.sh
+++ b/docker/wpcli.sh
@@ -7,17 +7,30 @@ wp core install --url="$WORDPRESS_URL" --title="$WORDPRESS_TITLE" --admin_user=$
 wp theme install storefront --activate
 wp plugin install loco-translate --activate
 wp plugin install woocommerce --version=$WOOCOM_VERSION --activate --force
-counter=$(($(wp post list --post_type=product --format=count) + 1))
-until [ $counter -gt 4 ]; do
-  product_id=$(wp post generate --post_type=product --count=1 --post_title="Product ${counter}" --format=ids)
-  random_price=$(shuf -i 100-200 -n 1)
-  wp media import 'https://picsum.photos/600/400.jpg' --post_id=$product_id --title="Image for Product ${counter}" --featured_image
-  wp post meta set $product_id _price $random_price
-  counter=$(($counter + 1))
-done
+existing_products=$(wp wc product list --user=admin --format=count 2>/dev/null || echo 0)
+if [ "$existing_products" -lt 4 ]; then
+  for i in 1 2 3 4; do
+    random_price=$(shuf -i 100-200 -n 1)
+    wp wc product create --user=admin --name="Product ${i}" --type=simple --regular_price=$random_price --manage_stock=true --stock_quantity=999 --status=publish
+  done
+  wp wc product create --user=admin --name="Expensive Product" --type=simple --regular_price=500000 --manage_stock=true --stock_quantity=999 --status=publish
+fi
 wp option update permalink_structure /%year%/%monthnum%/%day%/%postname%/
-#wp plugin activate tillit-payment-gateway
-wp option update woocommerce_woocommerce-gateway-tillit_settings --format=json </opt/tillit-payment-gateway/${WOOCOM_PLUGIN_CONFIG_JSON:-docker/config/local.json}
+set +e
+until wp plugin activate tillit-payment-gateway; do
+  echo "Waiting for tillit-payment-gateway plugin..."
+  sleep 2
+done
+set -e
+PLUGIN_CONFIG="/opt/tillit-payment-gateway/${WOOCOM_PLUGIN_CONFIG_JSON:-docker/config/local.json}"
+if [ -f "$PLUGIN_CONFIG" ]; then
+  wp option update woocommerce_woocommerce-gateway-tillit_settings --format=json <"$PLUGIN_CONFIG"
+else
+  echo "Warning: Plugin config not found at $PLUGIN_CONFIG, skipping settings load"
+fi
+wp post update $(wp option get woocommerce_checkout_page_id) --post_content='[woocommerce_checkout]'
+wp post update $(wp option get woocommerce_cart_page_id) --post_content='[woocommerce_cart]'
+wp option update woocommerce_coming_soon no
 wp option update woocommerce_currency $WOOCOM_CURRENCY
 wp option update woocommerce_default_country $WOOCOM_DEFAULT_COUNTRY
 sleep infinity

--- a/docs/e2e-test-plan.md
+++ b/docs/e2e-test-plan.md
@@ -1,0 +1,74 @@
+# INF-956: WooCommerce Plugin E2E Tests
+
+Linear: https://linear.app/tillit/issue/INF-956
+
+## Context
+
+WooCommerce e2e tests were deleted from the e2e-tests repo during the API migration (INF-940). They now live in the woocommerce-plugin repo, running against the local Docker dev environment (WordPress + WooCommerce + Two plugin at localhost:8888).
+
+Tests focus on plugin-specific behaviour: WooCommerce store checkout with Two payment, order lifecycle through WP admin, and Two API state verification.
+
+## Docker environment
+
+- Store: `http://localhost:8888` (Storefront theme, NL, EUR)
+- Admin: `http://localhost:8888/wp-admin` (admin / twoinb2b)
+- Products: "Product 1"–"Product 4", random prices 100–200
+- Plugin config: `docker/config/staging-tillittestuk.json` → `api.staging.two.inc`
+- Merchant: tillittestuk (UK, org 13078389) — has merchant-wide `skip_verification` rule
+
+## Checklist
+
+### Docker bootstrap
+
+- [x] **`docker/wpcli.sh`**: Uncomment plugin activation (line 19)
+- [x] Add `_regular_price` and `_stock_status` meta so products display correctly in Storefront
+
+### Test infrastructure (`tests/e2e/`)
+
+- [x] `package.json` — Playwright Test, TypeScript
+- [x] `playwright.config.ts` — chromium, baseURL localhost:8888, trace/video on failure
+- [x] `config.ts` — reads `MERCHANT_API_KEY` from env var, defaults to staging Two API
+- [x] `checkout-api.ts` — Two API client (get order state, verify, confirm, cancel)
+- [x] `docker/config/staging-tillittestuk.json.tpl` — template for Docker plugin config, populated at CI time
+
+### Page objects
+
+- [x] `pages/store.ts` — add product to cart, go to checkout
+- [x] `pages/checkout.ts` — select Two payment, company search (Select2), billing details, place order
+- [x] `pages/wp-admin.ts` — login, navigate to orders, change status, refund
+
+### Tests
+
+- [x] `tests/order-flow.spec.ts` — place order → verify CONFIRMED → fulfil via WP admin → verify FULFILLED → refund → verify REFUNDED
+- [x] `tests/cancel-order.spec.ts` — place order → cancel via WP admin → verify CANCELLED
+- [x] `tests/max-limit.spec.ts` — excessive quantity → rejection on checkout
+
+### CI/CD
+
+- [x] `.github/workflows/e2e-tests.yaml` — GCP auth via WIF, fetch API key from Secret Manager, generate Docker config, start WordPress, run Playwright tests, upload artifacts on failure
+- [x] Makefile targets: `e2e-install`, `e2e-test`, `e2e-test-headed`
+
+### Infrastructure
+
+- [x] Generated new API key for tillittestuk merchant via `POST /admin/v1/merchant/{id}/api_key`
+- [x] Stored as `STAGING_SHOP_MERCHANT_API_KEY_TILLITTESTUK` in GCP Secret Manager (two-beta)
+- [x] `GCP_E2E_TESTS_SA_NAME_TWO_BETA` org var: added woocommerce-plugin to selected repos
+- [x] `WORKLOAD_IDENTITY_PROVIDER_PREFIX_TWO_BETA` org var: changed from "private" to "selected", added e2e-tests + woocommerce-plugin
+- [ ] Verify CI passes end-to-end
+
+## Running locally
+
+```bash
+docker compose up -d
+# wait for wpcli to finish bootstrapping (~60s)
+make e2e-install
+MERCHANT_API_KEY=secret_test_xxx make e2e-test
+```
+
+The API key comes from your local `docker/config/staging-tillittestuk.json` (gitignored). In CI it's fetched from GCP Secret Manager.
+
+## Out of scope
+
+- Identity verification / SCA flow (covered in e2e-tests repo)
+- Merchant portal tests (covered in e2e-tests repo)
+- Multi-country support (single NL environment)

--- a/tests/e2e/checkout-api.ts
+++ b/tests/e2e/checkout-api.ts
@@ -1,0 +1,91 @@
+import { expect } from "@playwright/test";
+
+import { API_BASE_URL, API_KEY, TWO_ADMIN_LOGIN, TWO_ADMIN_PASSWORD } from "./config.js";
+
+const headers = {
+  "X-API-Key": API_KEY,
+  "Content-Type": "application/json"
+};
+
+export async function getOrder(orderId: string): Promise<Record<string, unknown>> {
+  const res = await fetch(`${API_BASE_URL}/v1/order/${orderId}`, { headers });
+  if (!res.ok) throw new Error(`get order failed: ${res.status}`);
+  return res.json();
+}
+
+export async function getOrderState(orderId: string): Promise<string> {
+  const order = await getOrder(orderId);
+  return order.state as string;
+}
+
+export async function waitForOrderState(
+  orderId: string,
+  expectedState: string,
+  timeoutMs = 30_000,
+  intervalMs = 1_000
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        try {
+          return (await getOrder(orderId)).state as string;
+        } catch {
+          return null;
+        }
+      },
+      {
+        message: `Order ${orderId} did not reach ${expectedState}`,
+        timeout: timeoutMs,
+        intervals: [intervalMs]
+      }
+    )
+    .toBe(expectedState);
+}
+
+export async function verifyOrder(orderId: string): Promise<string> {
+  const res = await fetch(`${API_BASE_URL}/test/verify_order/${orderId}`, {
+    method: "POST",
+    headers
+  });
+  if (!res.ok) throw new Error(`verify order failed: ${res.status}`);
+  const data = await res.json();
+  return data.merchant_confirmation_url ?? "";
+}
+
+export async function confirmOrder(orderId: string): Promise<void> {
+  const res = await fetch(`${API_BASE_URL}/v1/order/${orderId}/confirm`, {
+    method: "POST",
+    headers
+  });
+  if (!res.ok) throw new Error(`confirm order failed: ${res.status}`);
+}
+
+export async function cancelOrder(orderId: string): Promise<void> {
+  const res = await fetch(`${API_BASE_URL}/v1/order/${orderId}/cancel`, {
+    method: "POST",
+    headers
+  });
+  if (!res.ok) throw new Error(`cancel order failed: ${res.status}`);
+}
+
+export async function triggerFulfilBatch(): Promise<void> {
+  if (!TWO_ADMIN_PASSWORD) throw new Error("TWO_ADMIN_PASSWORD env var not set");
+  const basic = Buffer.from(`${TWO_ADMIN_LOGIN}:${TWO_ADMIN_PASSWORD}`).toString("base64");
+  const loginRes = await fetch(`${API_BASE_URL}/admin/v1/login`, {
+    method: "POST",
+    headers: { Authorization: `Basic ${basic}` }
+  });
+  if (!loginRes.ok) {
+    const body = await loginRes.text();
+    throw new Error(`admin login failed: ${loginRes.status} ${body}`);
+  }
+
+  const cookies = loginRes.headers.getSetCookie?.() ?? [];
+  const cookieHeader = cookies.join("; ");
+
+  const res = await fetch(`${API_BASE_URL}/v1/batch/order_fulfillment_batch`, {
+    method: "POST",
+    headers: { Cookie: cookieHeader }
+  });
+  if (!res.ok) throw new Error(`trigger fulfil batch failed: ${res.status}`);
+}

--- a/tests/e2e/config.ts
+++ b/tests/e2e/config.ts
@@ -1,0 +1,16 @@
+export const STORE_URL = "http://localhost:8888";
+export const ADMIN_URL = `${STORE_URL}/wp-admin`;
+export const ADMIN_USER = "admin";
+export const ADMIN_PASSWORD = "twoinb2b";
+
+export const API_BASE_URL = process.env.TWO_API_BASE_URL ?? "https://api.staging.two.inc";
+export const API_KEY = process.env.MERCHANT_API_KEY ?? "";
+export const TWO_ADMIN_LOGIN = "admin@two.inc";
+export const TWO_ADMIN_PASSWORD = process.env.TWO_ADMIN_PASSWORD ?? "";
+
+export const BUYER_COMPANY = "RESTAURANT 53 LTD";
+export const RECIPIENT_EMAIL = "bot@two.inc";
+export const PHONE_NUMBER = "+447777777777";
+
+export const DEFAULT_TIMEOUT = 15_000;
+export const LONG_TIMEOUT = 60_000;

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,111 @@
+{
+  "name": "woocommerce-plugin-e2e",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "woocommerce-plugin-e2e",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "woocommerce-plugin-e2e",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/e2e/pages/checkout.ts
+++ b/tests/e2e/pages/checkout.ts
@@ -1,0 +1,65 @@
+import { type Page, expect } from "@playwright/test";
+
+import { BUYER_COMPANY, LONG_TIMEOUT, PHONE_NUMBER, RECIPIENT_EMAIL } from "../config.js";
+
+export async function selectTwoPayment(page: Page) {
+  const radio = page.locator("#payment_method_woocommerce-gateway-tillit");
+  await radio.waitFor({ state: "attached" });
+  if (!(await radio.isChecked())) {
+    await radio.check({ force: true });
+  }
+}
+
+export async function fillCompanySearch(page: Page, companyName = BUYER_COMPANY, retries = 3) {
+  await page.waitForLoadState("networkidle");
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const container = page.locator("#select2-billing_company_display-container");
+      await container.waitFor({ state: "visible" });
+      await container.click();
+
+      const searchInput = page.locator(".select2-search__field");
+      await searchInput.waitFor({ state: "visible", timeout: 5_000 });
+      await searchInput.pressSequentially(companyName, { delay: 50 });
+
+      const result = page
+        .locator(".select2-results__option:not(.select2-results__message)")
+        .first();
+      await result.waitFor({ state: "visible", timeout: 10_000 });
+      await page.waitForTimeout(500);
+      await result.click();
+
+      await expect(page.locator("#billing_address_1")).not.toBeEmpty({ timeout: LONG_TIMEOUT });
+      return;
+    } catch (e) {
+      if (attempt === retries) throw e;
+      await page.keyboard.press("Escape");
+      await page.waitForTimeout(1_000);
+    }
+  }
+}
+
+export async function fillBillingDetails(page: Page, firstName: string, lastName: string) {
+  await page.locator("#billing_first_name").fill(firstName);
+  await page.locator("#billing_last_name").fill(lastName);
+  await page.locator("#billing_email").fill(RECIPIENT_EMAIL);
+  await page.locator("#billing_phone").fill(PHONE_NUMBER);
+}
+
+export async function placeOrder(page: Page): Promise<string> {
+  await page.locator("#place_order").click();
+
+  await expect(page).toHaveURL(/\/checkout\/order-received\/(\d+)\//, {
+    timeout: LONG_TIMEOUT
+  });
+
+  const match = page.url().match(/\/order-received\/(\d+)\//);
+  return match?.[1] ?? "";
+}
+
+export async function expectRejection(page: Page) {
+  await expect(page.locator(".twoinc-err-payment-default")).toBeVisible({
+    timeout: LONG_TIMEOUT
+  });
+}

--- a/tests/e2e/pages/store.ts
+++ b/tests/e2e/pages/store.ts
@@ -1,0 +1,19 @@
+import { type Page, expect } from "@playwright/test";
+
+export async function addProductToCart(page: Page, productName = "Product 1", quantity = 1) {
+  const slug = productName.toLowerCase().replace(/\s+/g, "-");
+  await page.goto(`/product/${slug}/`);
+  await page.waitForLoadState("load");
+
+  if (quantity !== 1) {
+    await page.locator("input.qty").fill(String(quantity));
+  }
+
+  await page.locator("button.single_add_to_cart_button").click();
+  await expect(page.locator(".woocommerce-message")).toBeVisible();
+}
+
+export async function goToCheckout(page: Page) {
+  await page.goto("/checkout/");
+  await page.waitForLoadState("load");
+}

--- a/tests/e2e/pages/wp-admin.ts
+++ b/tests/e2e/pages/wp-admin.ts
@@ -1,0 +1,47 @@
+import { type Page, expect } from "@playwright/test";
+
+import { ADMIN_PASSWORD, ADMIN_URL, ADMIN_USER } from "../config.js";
+
+export async function login(page: Page) {
+  await page.goto(`${ADMIN_URL}/`);
+  await page.locator("#user_login").fill(ADMIN_USER);
+  await page.locator("#user_pass").fill(ADMIN_PASSWORD);
+  await page.locator("#wp-submit").click();
+  await page.waitForLoadState("load");
+}
+
+export async function navigateToOrders(page: Page) {
+  await page.goto(`${ADMIN_URL}/edit.php?post_type=shop_order`);
+  await page.waitForLoadState("load");
+}
+
+export async function openOrder(page: Page, searchTerm: string) {
+  await page.locator(`a.order-view:has-text("${searchTerm}")`).first().click();
+  await page.waitForLoadState("load");
+}
+
+export async function getTwoOrderId(page: Page): Promise<string> {
+  const field = page.locator('textarea:right-of(input[value="twoinc_order_id"])').first();
+  await field.waitFor({ state: "visible" });
+  const value = await field.inputValue();
+  return value.trim();
+}
+
+export async function changeOrderStatus(page: Page, status: string) {
+  await page.locator("#order_status").selectOption({ label: status });
+  await page.locator("button.save_order").click();
+  await page.waitForLoadState("load");
+}
+
+export async function refundOrder(page: Page, quantity: number) {
+  await page.locator("button.refund-items").click();
+
+  const refundQty = page.locator(".refund_order_item_qty").first();
+  await refundQty.waitFor({ state: "visible" });
+  await refundQty.fill(String(quantity));
+
+  page.once("dialog", (dialog: { accept: () => Promise<void> }) => dialog.accept());
+  await page.locator(".do-api-refund").click();
+
+  await expect(page.locator(".refund").first()).toBeVisible();
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 180_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  use: {
+    baseURL: "http://localhost:8888",
+    viewport: { width: 1280, height: 720 },
+    actionTimeout: 15_000,
+    trace: "retain-on-failure",
+    video: "retain-on-failure"
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" }
+    }
+  ]
+});

--- a/tests/e2e/tests/cancel-order.spec.ts
+++ b/tests/e2e/tests/cancel-order.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+
+import { getOrderState } from "../checkout-api.js";
+import * as checkout from "../pages/checkout.js";
+import * as store from "../pages/store.js";
+import * as wpAdmin from "../pages/wp-admin.js";
+
+test("cancel order flow: place → cancel via WP admin", async ({ page }) => {
+  await store.addProductToCart(page, "Product 2");
+  await store.goToCheckout(page);
+
+  await checkout.fillBillingDetails(page, "Test", "E2ECancel");
+  await checkout.selectTwoPayment(page);
+  await checkout.fillCompanySearch(page);
+  await checkout.placeOrder(page);
+
+  await wpAdmin.login(page);
+  await wpAdmin.navigateToOrders(page);
+  await wpAdmin.openOrder(page, "E2ECancel");
+
+  const twoOrderId = await wpAdmin.getTwoOrderId(page);
+  expect(await getOrderState(twoOrderId)).toBe("CONFIRMED");
+
+  await wpAdmin.changeOrderStatus(page, "Cancelled");
+  expect(await getOrderState(twoOrderId)).toBe("CANCELLED");
+});

--- a/tests/e2e/tests/max-limit.spec.ts
+++ b/tests/e2e/tests/max-limit.spec.ts
@@ -1,0 +1,14 @@
+import { test } from "@playwright/test";
+
+import * as checkout from "../pages/checkout.js";
+import * as store from "../pages/store.js";
+
+test("max limit: excessive quantity is rejected", async ({ page }) => {
+  await store.addProductToCart(page, "Expensive Product");
+  await store.goToCheckout(page);
+
+  await checkout.fillBillingDetails(page, "Test", "E2EMaxLimit");
+  await checkout.selectTwoPayment(page);
+  await checkout.fillCompanySearch(page);
+  await checkout.expectRejection(page);
+});

--- a/tests/e2e/tests/order-flow.spec.ts
+++ b/tests/e2e/tests/order-flow.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+
+import { getOrderState, triggerFulfilBatch, waitForOrderState } from "../checkout-api.js";
+import * as checkout from "../pages/checkout.js";
+import * as store from "../pages/store.js";
+import * as wpAdmin from "../pages/wp-admin.js";
+
+test("normal order flow: place → fulfil → refund", async ({ page }) => {
+  await store.addProductToCart(page, "Product 1");
+  await store.goToCheckout(page);
+
+  await checkout.fillBillingDetails(page, "Test", "E2EOrder");
+  await checkout.selectTwoPayment(page);
+  await checkout.fillCompanySearch(page);
+  const wcOrderId = await checkout.placeOrder(page);
+
+  expect(wcOrderId).toBeTruthy();
+
+  await wpAdmin.login(page);
+  await wpAdmin.navigateToOrders(page);
+  await wpAdmin.openOrder(page, "E2EOrder");
+
+  const twoOrderId = await wpAdmin.getTwoOrderId(page);
+  expect(twoOrderId).toBeTruthy();
+
+  expect(await getOrderState(twoOrderId)).toBe("CONFIRMED");
+
+  await wpAdmin.changeOrderStatus(page, "Completed");
+  await triggerFulfilBatch();
+  expect(await getOrderState(twoOrderId)).toBe("FULFILLED");
+
+  await wpAdmin.refundOrder(page, 1);
+  await waitForOrderState(twoOrderId, "REFUNDED");
+});

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Context

WooCommerce e2e tests were removed from the e2e-tests repo during the API migration (INF-940). This PR adds them to the woocommerce-plugin repo, running against the local Docker dev environment.

## Changes

- Add TypeScript/Playwright e2e tests under `tests/e2e/`:
  - `order-flow.spec.ts` — place order → fulfil → refund (full lifecycle)
  - `cancel-order.spec.ts` — place order → cancel via WP admin
  - `max-limit.spec.ts` — excessive quantity → rejection on checkout
- Page objects for Storefront store, WooCommerce checkout (with Two payment Select2 company search), WP admin order management
- API client for Two checkout API state verification
- Fix Docker bootstrap: activate plugin, add `_regular_price` and `_stock_status` meta for products
- Add CI workflow: GCP auth via WIF, fetch API key from Secret Manager, start WordPress via Docker Compose, run tests
- Add Makefile targets: `e2e-install`, `e2e-test`, `e2e-test-headed`
- Config template `docker/config/staging-tillittestuk.json.tpl` for CI (populated with Secret Manager key)
- Org vars `GCP_E2E_TESTS_SA_NAME_TWO_BETA` and `WORKLOAD_IDENTITY_PROVIDER_PREFIX_TWO_BETA` now include woocommerce-plugin
- New API key generated for tillittestuk merchant, stored in Secret Manager as `STAGING_SHOP_MERCHANT_API_KEY_TILLITTESTUK`

## Scope / Non-goals

- No identity verification / SCA tests (covered in e2e-tests repo)
- No merchant portal tests (covered in e2e-tests repo)
- Single environment (NL, EUR, tillittestuk merchant on staging)

## Validation

- TypeScript compiles cleanly (`npx tsc --noEmit`)
- Playwright discovers all 3 tests (`npx playwright test --list`)
- CI workflow needs end-to-end validation on this PR

## Ticket

- <https://linear.app/tillit/issue/INF-956>