### PR TITLE
INF-1561/chore: bump two-inc/git-hooks to 26.03.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         types:
           - php
   - repo: https://github.com/two-inc/git-hooks
-    rev: 25.06.20
+    rev: 26.03.10
     hooks:
       - id: commit-msg
         stages: [commit-msg]


### PR DESCRIPTION
Bumps `two-inc/git-hooks` pre-commit hook to `26.03.10`.

Part of the org-wide sweep tracked in [INF-1561](https://linear.app/tillit/issue/INF-1561/bump-two-incgit-hooks-pre-commit-hook-to-260310-org-wide).

Refs INF-1561