### PR TITLE
TWO-24745/feat: Base brand seams for the ABN overlay migration

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -39,20 +39,20 @@ jQuery(function ($) {
 
   $("body").on(
     "change",
-    "#woocommerce_woocommerce-gateway-tillit_enable_company_search",
+    "#woocommerce_" + twoinc_admin.gateway_id + "_enable_company_search",
     function (e) {
       toggleChildrenFields(
         $(this),
-        $("#woocommerce_woocommerce-gateway-tillit_enable_company_search_for_others")
+        $("#woocommerce_" + twoinc_admin.gateway_id + "_enable_company_search_for_others")
       );
       toggleChildrenFields(
         $(this),
-        $("#woocommerce_woocommerce-gateway-tillit_enable_address_lookup")
+        $("#woocommerce_" + twoinc_admin.gateway_id + "_enable_address_lookup")
       );
     }
   );
 
-  jQuery("[id*='woocommerce-gateway-tillit'].wc-settings-sub-title").append(
+  jQuery("[id*='" + twoinc_admin.gateway_id + "'].wc-settings-sub-title").append(
     '<a href="#" class="collapsed setting-dropdown"><span class="dashicons dashicons-arrow-down-alt2"></span></a>'
   );
   jQuery("h3.wc-settings-sub-title a").click(function (e) {
@@ -73,17 +73,17 @@ jQuery(function ($) {
   jQuery("h3.wc-settings-sub-title").next().hide();
 
   toggleChildrenFields(
-    $("#woocommerce_woocommerce-gateway-tillit_enable_company_search"),
-    $("#woocommerce_woocommerce-gateway-tillit_enable_company_search_for_others")
+    $("#woocommerce_" + twoinc_admin.gateway_id + "_enable_company_search"),
+    $("#woocommerce_" + twoinc_admin.gateway_id + "_enable_company_search_for_others")
   );
   toggleChildrenFields(
-    $("#woocommerce_woocommerce-gateway-tillit_enable_company_search"),
-    $("#woocommerce_woocommerce-gateway-tillit_enable_address_lookup")
+    $("#woocommerce_" + twoinc_admin.gateway_id + "_enable_company_search"),
+    $("#woocommerce_" + twoinc_admin.gateway_id + "_enable_address_lookup")
   );
 
   // API Key verification functionality
   let verificationTimeout;
-  const $apiKeyField = $("#woocommerce_woocommerce-gateway-tillit_api_key");
+  const $apiKeyField = $("#woocommerce_" + twoinc_admin.gateway_id + "_api_key");
   const $verificationIcon = $("#api-key-verification-icon");
   const $validIcon = $("#api-key-valid");
   const $invalidIcon = $("#api-key-invalid");

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -401,7 +401,7 @@ let twoincDomHelper = {
    * Deselect payment method and select the first available one
    */
   deselectPaymentMethod: function () {
-    const paymentMethodRadioObj = jQuery(':input[value="woocommerce-gateway-tillit"]');
+    const paymentMethodRadioObj = jQuery(':input[value="' + window.twoinc.gateway_id + '"]');
     // Deselect the current payment method
     if (paymentMethodRadioObj) {
       paymentMethodRadioObj.prop("checked", false);
@@ -583,7 +583,7 @@ let twoincDomHelper = {
    * Check if twoinc payment is currently selected
    */
   isTwoincSelected: function () {
-    return jQuery('input[name="payment_method"]:checked').val() === "woocommerce-gateway-tillit";
+    return jQuery('input[name="payment_method"]:checked').val() === window.twoinc.gateway_id;
   },
 
   /**
@@ -591,10 +591,10 @@ let twoincDomHelper = {
    */
   isTwoincVisible: function () {
     return (
-      jQuery("li.wc_payment_method.payment_method_woocommerce-gateway-tillit").css("display") !==
+      jQuery("li.wc_payment_method.payment_method_" + window.twoinc.gateway_id).css("display") !==
       "none"
     );
-    //return jQuery('#payment_method_woocommerce-gateway-tillit:visible').length !== 0
+    //return jQuery('#payment_method_' + window.twoinc.gateway_id + ':visible').length !== 0
   },
 
   /**
@@ -635,7 +635,7 @@ let twoincDomHelper = {
    * Rearrange descriptions in Twoinc payment to make it cleaner
    */
   rearrangeDescription: function () {
-    let twoincPaymentBox = jQuery(".payment_box.payment_method_woocommerce-gateway-tillit");
+    let twoincPaymentBox = jQuery(".payment_box.payment_method_" + window.twoinc.gateway_id);
     if (twoincPaymentBox.length > 0) {
       twoincPaymentBox.after(jQuery(".abt-twoinc"));
     }
@@ -1462,7 +1462,7 @@ let isTwoincSelected = null;
 jQuery(function () {
   if (window.twoinc) {
     if (window.twoinc.enable_order_intent === "yes") {
-      if (jQuery("#payment_method_woocommerce-gateway-tillit").length > 0) {
+      if (jQuery("#payment_method_" + window.twoinc.gateway_id).length > 0) {
         // Run Twoinc code if order intent is enabled
         Twoinc.getInstance().initialize(true);
       }
@@ -1476,7 +1476,7 @@ jQuery(function () {
         }
 
         // Run Twoinc code if Twoinc payment is selected
-        jQuery("#payment_method_woocommerce-gateway-tillit").on("change", function () {
+        jQuery("#payment_method_" + window.twoinc.gateway_id).on("change", function () {
           Twoinc.getInstance().initialize(false);
           Twoinc.getInstance().onUpdatedCheckout();
         });
@@ -1490,7 +1490,7 @@ jQuery(function () {
       );
       if (
         lastSelectedPayment &&
-        lastSelectedPayment.id === "payment_method_woocommerce-gateway-tillit"
+        lastSelectedPayment.id === "payment_method_" + window.twoinc.gateway_id
       ) {
         Twoinc.getInstance().initialize(true);
       }

--- a/brands/two.php
+++ b/brands/two.php
@@ -30,7 +30,9 @@ return [
     'meta_prefix' => 'twoinc',
     // Brand product constraints removing the gateway from checkout when
     // unmet: ['min_order_amount' => float, 'currency' => 'EUR',
-    // 'billing_countries' => ['NL']]. null = no gate (Two default).
+    // 'billing_countries' => ['NL']]. min_order_amount compares the NET
+    // basket (total minus tax) — the funding partner's server-side risk
+    // rule compares net. null = no gate (Two default).
     'availability_gate' => null,
     // Countries offered in the checkout company-search JS.
     'supported_buyer_countries' => ['NO', 'GB', 'SE', 'NL', 'FI', 'DK'],

--- a/brands/two.php
+++ b/brands/two.php
@@ -23,4 +23,15 @@ return [
     'gateway_id' => 'woocommerce-gateway-tillit',
     'logo_url' => WC_TWOINC_PLUGIN_URL . 'assets/images/two-logo.svg',
     'about_url' => 'https://www.two.inc/what-is-two',
+    // Order/user meta key prefix (e.g. _twoinc_order_reference,
+    // twoinc_order_id, twoinc_company_id) and the confirmation request
+    // param/nonce prefix. Live stores hold data under this prefix —
+    // an overlay MUST set the prefix its installed base already uses.
+    'meta_prefix' => 'twoinc',
+    // Brand product constraints removing the gateway from checkout when
+    // unmet: ['min_order_amount' => float, 'currency' => 'EUR',
+    // 'billing_countries' => ['NL']]. null = no gate (Two default).
+    'availability_gate' => null,
+    // Countries offered in the checkout company-search JS.
+    'supported_buyer_countries' => ['NO', 'GB', 'SE', 'NL', 'FI', 'DK'],
 ];

--- a/brands/two.php
+++ b/brands/two.php
@@ -34,4 +34,8 @@ return [
     'availability_gate' => null,
     // Countries offered in the checkout company-search JS.
     'supported_buyer_countries' => ['NO', 'GB', 'SE', 'NL', 'FI', 'DK'],
+    // Default for the payment-method Title setting on fresh installs
+    // (merchant-saved titles always win). sprintf'd with the invoice
+    // day count, so a brand default may carry one %s.
+    'title_default' => 'Business invoice - %s days',
 ];

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -50,12 +50,27 @@ if (!class_exists('WC_Twoinc')) {
                 __($this->get_option('title'), 'twoinc-payment-gateway'),
                 strval($this->get_merchant_default_days_on_invoice())
             );
-            $this->description = $this->get_pay_box_description() . $this->get_pay_subtitle();
+            /**
+             * Filter the checkout payment-box description so a brand
+             * overlay can replace the copy wholesale (the ABN edition
+             * ships its own bullet list).
+             *
+             * @param string $description Default description HTML.
+             */
+            $this->description = apply_filters(
+                'twoinc_payment_description',
+                $this->get_pay_box_description() . $this->get_pay_subtitle()
+            );
 
             // Skip hooks if another instance has already been created
             if (null !== self::$instance) {
                 return;
             }
+
+            // Brand product constraints (e.g. a minimum order value in a
+            // specific currency/market) remove the gateway from checkout
+            // when unmet. Config-driven; the Two brand sets no gate.
+            add_filter('woocommerce_available_payment_gateways', [$this, 'apply_brand_availability_gate']);
 
             if (is_admin()) {
                 // Notice banner if plugin is not setup properly
@@ -598,7 +613,7 @@ if (!class_exists('WC_Twoinc')) {
                 return false;
             }
 
-            $state = $order->get_meta('_twoinc_order_state', true);
+            $state = $order->get_meta(WC_Twoinc_Brand::meta_key('order_state'), true);
             $skip = ["FULFILLING", "FULFILLED", "DELIVERED", "CANCELLED", "REFUNDED", "PARTIALLY_REFUNDED"];
             if (in_array($state, $skip)) {
                 // $order->add_order_note(sprintf(__('Order is already fulfilled with Two.', 'twoinc-payment-gateway'), $twoinc_order_id));
@@ -638,7 +653,7 @@ if (!class_exists('WC_Twoinc')) {
 
             // Decode the response
             $body = json_decode($response['body'], true);
-            $order->update_meta_data('_twoinc_order_state', 'FULFILLING');
+            $order->update_meta_data(WC_Twoinc_Brand::meta_key('order_state'), 'FULFILLING');
             $order->save();
             do_action('twoinc_order_completed', $order, $body);
             return true;
@@ -669,7 +684,7 @@ if (!class_exists('WC_Twoinc')) {
                 return false;
             }
 
-            $state = $order->get_meta('_twoinc_order_state', true);
+            $state = $order->get_meta(WC_Twoinc_Brand::meta_key('order_state'), true);
             if ($state == 'CANCELLED') {
                 $order_note = sprintf(__('Order is already cancelled with %s.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name'));
                 $order->add_order_note($order_note);
@@ -695,7 +710,7 @@ if (!class_exists('WC_Twoinc')) {
                 return false;
             }
 
-            $order->update_meta_data('_twoinc_order_state', "CANCELLED");
+            $order->update_meta_data(WC_Twoinc_Brand::meta_key('order_state'), "CANCELLED");
             $order->save();
             do_action('twoinc_order_cancelled', $order, $response);
             return true;
@@ -710,7 +725,7 @@ if (!class_exists('WC_Twoinc')) {
         {
             // Get the order
             $order = wc_get_order($order_id);
-            $state = $order->get_meta('_twoinc_order_state', true);
+            $state = $order->get_meta(WC_Twoinc_Brand::meta_key('order_state'), true);
             if ($state == 'REFUNDED') {
                 return;
             }
@@ -737,19 +752,19 @@ if (!class_exists('WC_Twoinc')) {
                 <tr>
                     <th><label for="twoinc_billing_company"><?php _e('Billing Company name', 'twoinc-payment-gateway'); ?></label></th>
                     <td>
-                        <input type="text" name="twoinc_billing_company" id="twoinc_billing_company" value="<?php echo esc_attr(get_the_author_meta('twoinc_billing_company', $user->ID)); ?>" class="regular-text" />
+                        <input type="text" name="twoinc_billing_company" id="twoinc_billing_company" value="<?php echo esc_attr(get_the_author_meta(WC_Twoinc_Brand::prefixed_name('billing_company'), $user->ID)); ?>" class="regular-text" />
                     </td>
                 </tr>
                 <tr>
                     <th><label for="twoinc_company_id"><?php _e('Billing Company ID', 'twoinc-payment-gateway'); ?></label></th>
                     <td>
-                        <input type="text" name="twoinc_company_id" id="twoinc_company_id" value="<?php echo esc_attr(get_the_author_meta('twoinc_company_id', $user->ID)); ?>" class="regular-text" />
+                        <input type="text" name="twoinc_company_id" id="twoinc_company_id" value="<?php echo esc_attr(get_the_author_meta(WC_Twoinc_Brand::prefixed_name('company_id'), $user->ID)); ?>" class="regular-text" />
                     </td>
                 </tr>
                 <tr>
                     <th><label for="twoinc_department"><?php _e('Department', 'twoinc-payment-gateway'); ?></label></th>
                     <td>
-                        <input type="text" name="twoinc_department" id="twoinc_department" value="<?php echo esc_attr(get_the_author_meta('twoinc_department', $user->ID)); ?>" class="regular-text" />
+                        <input type="text" name="twoinc_department" id="twoinc_department" value="<?php echo esc_attr(get_the_author_meta(WC_Twoinc_Brand::prefixed_name('department'), $user->ID)); ?>" class="regular-text" />
                         <br />
                         <span class="description"><?php _e("The department displayed on the invoices"); ?></span>
                     </td>
@@ -757,7 +772,7 @@ if (!class_exists('WC_Twoinc')) {
                 <tr>
                     <th><label for="twoinc_project"><?php _e('Project', 'twoinc-payment-gateway'); ?></label></th>
                     <td>
-                        <input type="text" name="twoinc_project" id="twoinc_project" value="<?php echo esc_attr(get_the_author_meta('twoinc_project', $user->ID)); ?>" class="regular-text" />
+                        <input type="text" name="twoinc_project" id="twoinc_project" value="<?php echo esc_attr(get_the_author_meta(WC_Twoinc_Brand::prefixed_name('project'), $user->ID)); ?>" class="regular-text" />
                         <br />
                         <span class="description"><?php _e("The project displayed on the invoices"); ?></span>
                     </td>
@@ -784,10 +799,10 @@ if (!class_exists('WC_Twoinc')) {
                 return false;
             }
 
-            update_user_meta($user_id, 'twoinc_company_id', $_POST['twoinc_company_id']);
-            update_user_meta($user_id, 'twoinc_billing_company', $_POST['twoinc_billing_company']);
-            update_user_meta($user_id, 'twoinc_department', $_POST['twoinc_department']);
-            update_user_meta($user_id, 'twoinc_project', $_POST['twoinc_project']);
+            update_user_meta($user_id, WC_Twoinc_Brand::prefixed_name('company_id'), $_POST['twoinc_company_id']);
+            update_user_meta($user_id, WC_Twoinc_Brand::prefixed_name('billing_company'), $_POST['twoinc_billing_company']);
+            update_user_meta($user_id, WC_Twoinc_Brand::prefixed_name('department'), $_POST['twoinc_department']);
+            update_user_meta($user_id, WC_Twoinc_Brand::prefixed_name('project'), $_POST['twoinc_project']);
         }
 
         /**
@@ -797,6 +812,58 @@ if (!class_exists('WC_Twoinc')) {
          *
          * @return array
          */
+        /**
+         * Remove the gateway from checkout when the brand's availability
+         * gate (availability_gate in the brand config) is unmet. Mirrors
+         * the ABN fork's gate semantics: front-end only, minimum is
+         * inclusive (an exactly-minimum basket passes).
+         *
+         * @param array $available_gateways
+         *
+         * @return array
+         */
+        public function apply_brand_availability_gate($available_gateways)
+        {
+            $gate = WC_Twoinc_Brand::get('availability_gate');
+            if (!$gate || is_admin() || !isset($available_gateways[$this->id])) {
+                return $available_gateways;
+            }
+            if (!function_exists('WC') || !WC()->cart || !WC()->customer) {
+                return $available_gateways;
+            }
+
+            $satisfied = (float) WC()->cart->total >= (float) $gate['min_order_amount']
+                && get_woocommerce_currency() === $gate['currency']
+                && in_array(WC()->customer->get_billing_country(), $gate['billing_countries'], true);
+            if (!$satisfied) {
+                unset($available_gateways[$this->id]);
+            }
+
+            return $available_gateways;
+        }
+
+        /**
+         * Brand veto on payment processing, resolved via the
+         * twoinc_payment_validation_error filter (e.g. the ABN edition's
+         * required terms-acceptance checkbox). Returns the buyer-facing
+         * error message, or null to proceed.
+         *
+         * @param int $order_id
+         *
+         * @return string|null
+         */
+        public function get_brand_payment_validation_error($order_id)
+        {
+            /**
+             * Filter: a brand overlay vetoes payment with a buyer-facing
+             * error without overriding process_payment().
+             *
+             * @param string|null $error    Error message, or null to proceed.
+             * @param int         $order_id WooCommerce order id.
+             */
+            return apply_filters('twoinc_payment_validation_error', null, $order_id);
+        }
+
         public function process_payment($order_id)
         {
 
@@ -805,6 +872,12 @@ if (!class_exists('WC_Twoinc')) {
 
             // Check payment method
             if (!WC_Twoinc_Helper::is_twoinc_order($order)) {
+                return;
+            }
+
+            $brand_validation_error = $this->get_brand_payment_validation_error($order_id);
+            if ($brand_validation_error) {
+                WC_Twoinc_Helper::display_ajax_error($brand_validation_error);
                 return;
             }
 
@@ -826,8 +899,8 @@ if (!class_exists('WC_Twoinc')) {
             $invoice_emails = $invoice_email ? array_map('sanitize_text_field', explode(',', $invoice_email)) : [];
 
             // Store the order meta
-            $order->update_meta_data('_twoinc_order_reference', $order_reference);
-            $order->update_meta_data('_twoinc_merchant_id', $merchant_id);
+            $order->update_meta_data(WC_Twoinc_Brand::meta_key('order_reference'), $order_reference);
+            $order->update_meta_data(WC_Twoinc_Brand::meta_key('merchant_id'), $merchant_id);
             $order->update_meta_data('company_id', $company_id);
             $order->update_meta_data('department', $department);
             $order->update_meta_data('project', $project);
@@ -873,17 +946,17 @@ if (!class_exists('WC_Twoinc')) {
             // Save to user meta
             $user_id = wp_get_current_user()->ID;
             if ($user_id) {
-                if (!get_the_author_meta('twoinc_company_id', $user_id)) {
-                    update_user_meta($user_id, 'twoinc_company_id', $company_id);
+                if (!get_the_author_meta(WC_Twoinc_Brand::prefixed_name('company_id'), $user_id)) {
+                    update_user_meta($user_id, WC_Twoinc_Brand::prefixed_name('company_id'), $company_id);
                 }
-                if (!get_the_author_meta('twoinc_billing_company', $user_id)) {
-                    update_user_meta($user_id, 'twoinc_billing_company', $billing_company);
+                if (!get_the_author_meta(WC_Twoinc_Brand::prefixed_name('billing_company'), $user_id)) {
+                    update_user_meta($user_id, WC_Twoinc_Brand::prefixed_name('billing_company'), $billing_company);
                 }
-                if (!get_the_author_meta('twoinc_department', $user_id)) {
-                    update_user_meta($user_id, 'twoinc_department', $department);
+                if (!get_the_author_meta(WC_Twoinc_Brand::prefixed_name('department'), $user_id)) {
+                    update_user_meta($user_id, WC_Twoinc_Brand::prefixed_name('department'), $department);
                 }
-                if (!get_the_author_meta('twoinc_project', $user_id)) {
-                    update_user_meta($user_id, 'twoinc_project', $project);
+                if (!get_the_author_meta(WC_Twoinc_Brand::prefixed_name('project'), $user_id)) {
+                    update_user_meta($user_id, WC_Twoinc_Brand::prefixed_name('project'), $project);
                 }
             }
 
@@ -934,13 +1007,13 @@ if (!class_exists('WC_Twoinc')) {
             }
 
             // Store the Twoinc Order Id for future use
-            $order->update_meta_data('twoinc_order_id', $body['id']);
+            $order->update_meta_data(WC_Twoinc_Brand::prefixed_name('order_id'), $body['id']);
             $twoinc_meta = $this->get_save_twoinc_meta($order, $body['id']);
             $twoinc_updated_order_hash = WC_Twoinc_Helper::hash_order($order, $twoinc_meta);
-            $order->update_meta_data('_twoinc_req_body_hash', $twoinc_updated_order_hash);
+            $order->update_meta_data(WC_Twoinc_Brand::meta_key('req_body_hash'), $twoinc_updated_order_hash);
 
             if (isset($body['state'])) {
-                $order->update_meta_data('_twoinc_order_state', $body['state']);
+                $order->update_meta_data(WC_Twoinc_Brand::meta_key('order_state'), $body['state']);
             }
 
             $order->save();
@@ -988,7 +1061,7 @@ if (!class_exists('WC_Twoinc')) {
             }
 
             // Get and check refund data
-            $state = $order->get_meta('_twoinc_order_state', true);
+            $state = $order->get_meta(WC_Twoinc_Brand::meta_key('order_state'), true);
             if ($state === 'REFUNDED') {
                 return new WP_Error(
                     'invalid_twoinc_refund',
@@ -1076,7 +1149,7 @@ if (!class_exists('WC_Twoinc')) {
             }
             $order->add_order_note($order_note);
 
-            $order->update_meta_data('_twoinc_order_state', $state);
+            $order->update_meta_data(WC_Twoinc_Brand::meta_key('order_state'), $state);
             $order->save();
 
             do_action('twoinc_order_refunded', $order, $body);
@@ -1145,7 +1218,9 @@ if (!class_exists('WC_Twoinc')) {
         private function is_confirmation_page()
         {
 
-            if (isset($_REQUEST['order_id']) && isset($_REQUEST['twoinc_order_reference']) && isset($_REQUEST['twoinc_nonce'])) {
+            if (isset($_REQUEST['order_id'])
+                && isset($_REQUEST[WC_Twoinc_Brand::prefixed_name('order_reference')])
+                && isset($_REQUEST[WC_Twoinc_Brand::prefixed_name('nonce')])) {
                 return true;
                 // Temporarily commented out until we find a solution for redirect plugins
                 // $confirm_path = '/twoinc-payment-gateway/confirm';
@@ -1189,19 +1264,19 @@ if (!class_exists('WC_Twoinc')) {
             }
 
             // Get the order reference
-            $order_reference = sanitize_text_field($_REQUEST['twoinc_order_reference']);
+            $order_reference = sanitize_text_field($_REQUEST[WC_Twoinc_Brand::prefixed_name('order_reference')]);
 
             // Verify order reference
-            if (!$order_reference || $order_reference !== $order->get_meta('_twoinc_order_reference', true)) {
+            if (!$order_reference || $order_reference !== $order->get_meta(WC_Twoinc_Brand::meta_key('order_reference'), true)) {
                 wp_die(__('The security code is not valid.', 'twoinc-payment-gateway'));
             }
 
             if ($this->get_option('skip_confirm_auth') !== 'yes') {
                 // Get the nonce
-                $nonce = sanitize_text_field($_REQUEST['twoinc_nonce']);
+                $nonce = sanitize_text_field($_REQUEST[WC_Twoinc_Brand::prefixed_name('nonce')]);
 
                 // Stop if the code is not valid
-                if (!wp_verify_nonce($nonce, 'twoinc_confirm_' . $order_id)) {
+                if (!wp_verify_nonce($nonce, WC_Twoinc_Brand::prefixed_name('confirm_' . $order_id))) {
                     wp_die(__('The security code is not valid.', 'twoinc-payment-gateway'));
                 }
             }
@@ -1237,7 +1312,7 @@ if (!class_exists('WC_Twoinc')) {
             // Add note and update Two state
             $order_note = sprintf(__('Order ID %s has been placed with %s.', 'twoinc-payment-gateway'), $twoinc_order_id, WC_Twoinc_Brand::get('product_name'));
             $order->add_order_note($order_note);
-            $order->update_meta_data('_twoinc_order_state', 'CONFIRMED');
+            $order->update_meta_data(WC_Twoinc_Brand::meta_key('order_state'), 'CONFIRMED');
             $order->save();
 
             // Mark order as processing
@@ -1582,11 +1657,11 @@ if (!class_exists('WC_Twoinc')) {
                 }
             }
 
-            $order_reference = $order->get_meta('_twoinc_order_reference') ?? $order->get_meta('_tillit_order_reference');
-            $merchant_id = $order->get_meta('_twoinc_merchant_id');
+            $order_reference = $order->get_meta(WC_Twoinc_Brand::meta_key('order_reference')) ?? $order->get_meta('_tillit_order_reference');
+            $merchant_id = $order->get_meta(WC_Twoinc_Brand::meta_key('merchant_id'));
             if (!$merchant_id) {
                 $merchant_id = $order->get_meta('_tillit_merchant_id') ?? $this->get_merchant_id();
-                $order->update_meta_data('_twoinc_merchant_id', $merchant_id);
+                $order->update_meta_data(WC_Twoinc_Brand::meta_key('merchant_id'), $merchant_id);
                 $order->save();
             }
 
@@ -1664,11 +1739,11 @@ if (!class_exists('WC_Twoinc')) {
         private function process_update_twoinc_order($order, $twoinc_meta, $forced_reload = false)
         {
 
-            $twoinc_order_hash = $order->get_meta('_twoinc_req_body_hash');
+            $twoinc_order_hash = $order->get_meta(WC_Twoinc_Brand::meta_key('req_body_hash'));
             $twoinc_updated_order_hash = WC_Twoinc_Helper::hash_order($order, $twoinc_meta);
             if (!$twoinc_order_hash || $twoinc_order_hash != $twoinc_updated_order_hash) {
                 if ($this->update_twoinc_order($order)) {
-                    $order->update_meta_data('_twoinc_req_body_hash', $twoinc_updated_order_hash);
+                    $order->update_meta_data(WC_Twoinc_Brand::meta_key('req_body_hash'), $twoinc_updated_order_hash);
                     $order->save();
                 }
                 if ($forced_reload) {
@@ -1757,7 +1832,7 @@ if (!class_exists('WC_Twoinc')) {
         private function get_twoinc_order_id($order)
         {
 
-            $twoinc_order_id = $order->get_meta('twoinc_order_id');
+            $twoinc_order_id = $order->get_meta(WC_Twoinc_Brand::prefixed_name('order_id'));
 
             if (!$twoinc_order_id) {
                 $twoinc_order_id = $order->get_meta('tillit_order_id');

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -945,8 +945,17 @@ if (!class_exists('WC_Twoinc')) {
                     : (float) WC()->cart->total - (float) WC()->cart->get_total_tax();
             };
 
+            // The minimums judge the basket being purchased. On the
+            // pay-for-order page the session cart is not that basket (it
+            // is usually empty, and anything in it is unrelated to the
+            // order being paid), so only the billing-country gate applies
+            // there and in any other cartless context — the API still
+            // enforces the platform minimum at order creation.
+            $basket_is_judgeable = !WC()->cart->is_empty()
+                && !(function_exists('is_wc_endpoint_url') && is_wc_endpoint_url('order-pay'));
+
             $satisfied = true;
-            if ($platform_minimum) {
+            if ($platform_minimum && $basket_is_judgeable) {
                 // Fail closed on a basket in another currency: with no FX
                 // source in WooCommerce it cannot be proven to satisfy the
                 // funding partner's minimum.
@@ -956,7 +965,7 @@ if (!class_exists('WC_Twoinc')) {
             if ($satisfied && $gate) {
                 $satisfied = in_array(WC()->customer->get_billing_country(), $gate['billing_countries'], true);
             }
-            if ($satisfied && $merchant_minimum) {
+            if ($satisfied && $merchant_minimum && $basket_is_judgeable) {
                 $satisfied = get_woocommerce_currency() === $merchant_minimum['currency']
                     ? $basket_value($merchant_minimum['basis']) >= $merchant_minimum['amount']
                     // The merchant minimum is store-currency scoped; a

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -59,11 +59,14 @@ if (!class_exists('WC_Twoinc')) {
              * twoinc_brand_file, an overlay must register this filter no
              * later than plugins_loaded at default priority.
              *
-             * @param string $description Default description HTML.
+             * @param string     $description Default description HTML.
+             * @param WC_Twoinc  $gateway     The gateway instance (for
+             *                                get_option reads).
              */
             $this->description = apply_filters(
                 'twoinc_payment_description',
-                $this->get_pay_box_description() . $this->get_pay_subtitle()
+                $this->get_pay_box_description() . $this->get_pay_subtitle(),
+                $this
             );
 
             // Skip hooks if another instance has already been created
@@ -245,9 +248,23 @@ if (!class_exists('WC_Twoinc')) {
                     __('Buy now, receive your goods, pay your invoice later.', 'twoinc-payment-gateway'),
                     $abt_url,
                 );
-                return sprintf('<div class="abt-twoinc-text">%s</div><div class="abt-twoinc-link">%s</div>', $text, $link);
+                $html = sprintf('<div class="abt-twoinc-text">%s</div><div class="abt-twoinc-link">%s</div>', $text, $link);
+            } else {
+                $html = '';
             }
-            return '';
+
+            /**
+             * Filter the "about" block inside the payment-box subtitle —
+             * the piece of the description brand overlays actually
+             * replace (the ABN edition ships its own bullet list).
+             * Register by plugins_loaded (computed at gateway
+             * construction).
+             *
+             * @param string    $html    Default about-block HTML ('' when
+             *                           the merchant disabled the link).
+             * @param WC_Twoinc $gateway The gateway instance.
+             */
+            return apply_filters('twoinc_about_html', $html, $this);
         }
 
         /**
@@ -400,6 +417,7 @@ if (!class_exists('WC_Twoinc')) {
 
             // Localize script for AJAX
             wp_localize_script('twoinc.admin', 'twoinc_admin', [
+                'gateway_id' => $this->id,
                 'nonce' => wp_create_nonce('twoinc_admin_nonce'),
                 'ajax_url' => admin_url('admin-ajax.php')
             ]);

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -860,7 +860,11 @@ if (!class_exists('WC_Twoinc')) {
                 return $available_gateways;
             }
 
-            $satisfied = (float) WC()->cart->total >= (float) $gate['min_order_amount']
+            // Net basket value (total minus tax): the funding partner's
+            // server-side risk rule compares net, so a gross-compared gate
+            // would show the method on baskets the credit check declines.
+            $net_total = (float) WC()->cart->total - (float) WC()->cart->get_total_tax();
+            $satisfied = $net_total >= (float) $gate['min_order_amount']
                 && get_woocommerce_currency() === $gate['currency']
                 && in_array(WC()->customer->get_billing_country(), $gate['billing_countries'], true);
             if (!$satisfied) {
@@ -873,9 +877,9 @@ if (!class_exists('WC_Twoinc')) {
                     $logged = true;
                     wc_get_logger()->info(
                         sprintf(
-                            'Brand availability gate removed %s from checkout (total=%s currency=%s country=%s; gate requires min %s %s in %s)',
+                            'Brand availability gate removed %s from checkout (net_total=%s currency=%s country=%s; gate requires net min %s %s in %s)',
                             $this->id,
-                            WC()->cart->total,
+                            $net_total,
                             get_woocommerce_currency(),
                             WC()->customer->get_billing_country(),
                             $gate['min_order_amount'],

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -55,6 +55,10 @@ if (!class_exists('WC_Twoinc')) {
              * overlay can replace the copy wholesale (the ABN edition
              * ships its own bullet list).
              *
+             * Applied once at gateway construction: like
+             * twoinc_brand_file, an overlay must register this filter no
+             * later than plugins_loaded at default priority.
+             *
              * @param string $description Default description HTML.
              */
             $this->description = apply_filters(
@@ -828,6 +832,12 @@ if (!class_exists('WC_Twoinc')) {
             if (!$gate || is_admin() || !isset($available_gateways[$this->id])) {
                 return $available_gateways;
             }
+            if (!isset($gate['min_order_amount'], $gate['currency'], $gate['billing_countries'])) {
+                // A truthy but malformed gate must not judge with missing
+                // criteria; leave the gateway available and let the log
+                // below stay quiet (config bug, not a basket decision).
+                return $available_gateways;
+            }
             if (!function_exists('WC') || !WC()->cart || !WC()->customer) {
                 return $available_gateways;
             }
@@ -837,6 +847,26 @@ if (!class_exists('WC_Twoinc')) {
                 && in_array(WC()->customer->get_billing_country(), $gate['billing_countries'], true);
             if (!$satisfied) {
                 unset($available_gateways[$this->id]);
+                // Removing a payment method is invisible to the merchant —
+                // log the failing basket once per request so a gate
+                // misconfiguration doesn't read as the gateway vanishing.
+                static $logged = false;
+                if (!$logged && function_exists('wc_get_logger')) {
+                    $logged = true;
+                    wc_get_logger()->info(
+                        sprintf(
+                            'Brand availability gate removed %s from checkout (total=%s currency=%s country=%s; gate requires min %s %s in %s)',
+                            $this->id,
+                            WC()->cart->total,
+                            get_woocommerce_currency(),
+                            WC()->customer->get_billing_country(),
+                            $gate['min_order_amount'],
+                            $gate['currency'],
+                            implode(',', $gate['billing_countries'])
+                        ),
+                        ['source' => 'twoinc-payment-gateway']
+                    );
+                }
             }
 
             return $available_gateways;

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -1053,6 +1053,23 @@ if (!class_exists('WC_Twoinc')) {
 
             if ($body['status'] == 'REJECTED') {
                 $error_message = sprintf(__('Invoice purchase with %s is not available for this order.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name'));
+                // The backend decline reason is opaque, but when the basket
+                // sits near the brand's minimum the likely cause is the
+                // minimum-order rule — tell the buyer something actionable.
+                // Same-currency only: WooCommerce has no FX rate source.
+                $gate = WC_Twoinc_Brand::get('availability_gate');
+                if ($gate
+                    && isset($gate['min_order_amount'], $gate['currency'])
+                    && $order->get_currency() === $gate['currency']
+                    && ((float) $order->get_total() - (float) $order->get_total_tax()) < (float) $gate['min_order_amount'] * 1.05
+                ) {
+                    $error_message .= ' ' . sprintf(
+                        __('Note: %1\$s requires a minimum order value of %2\$s %3\$s excluding tax.', 'twoinc-payment-gateway'),
+                        WC_Twoinc_Brand::get('product_name'),
+                        $gate['min_order_amount'],
+                        $gate['currency']
+                    );
+                }
                 $order->add_order_note($error_message);
                 WC_Twoinc_Helper::display_ajax_error($error_message);
                 return;

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -1387,7 +1387,9 @@ if (!class_exists('WC_Twoinc')) {
                 'title' => [
                     'title'       => __('Title', 'twoinc-payment-gateway'),
                     'type'        => 'text',
-                    'default'     => __('Business invoice - %s days', 'twoinc-payment-gateway')
+                    // Brand-specific default: a fresh install must show the
+                    // brand's payment-method title, not the Two phrasing.
+                    'default'     => __(WC_Twoinc_Brand::get('title_default'), 'twoinc-payment-gateway')
                 ],
                 'test_checkout_host' => [
                     'type'        => 'text',

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -234,6 +234,74 @@ if (!class_exists('WC_Twoinc')) {
         }
 
         /**
+         * The platform's minimum order value for this merchant, resolved
+         * from the Two API (min_order_amount/min_order_currency/
+         * min_order_basis on GET /v1/merchant/{id} - the funding-partner
+         * default with merchant override, the same value checkout-api
+         * enforces at order create/intent), as
+         * ['amount', 'currency', 'basis'] or null when none is configured.
+         *
+         * Cached in options for 15 minutes following the
+         * get_days_on_invoice() pattern; the no-minimum outcome is cached
+         * too (the common case must not cost an API call per checkout
+         * render). A fetch failure resolves to no minimum: the server
+         * still enforces, and hiding the payment method on an API blip
+         * would be the worse failure.
+         *
+         * @return array|null
+         */
+        public function get_platform_minimum_order()
+        {
+            $checked_on = $this->get_option('platform_minimum_order_last_checked_on');
+
+            if (!$checked_on || ((int) $checked_on + 900) <= time()) {
+                $merchant_id = $this->get_merchant_id();
+                if (!$merchant_id || !$this->get_option('api_key')) {
+                    return null;
+                }
+
+                $minimum = null;
+                $response = $this->make_request("/v1/merchant/{$merchant_id}", [], 'GET');
+                if (
+                    !is_wp_error($response)
+                    && !WC_Twoinc_Helper::get_twoinc_error_msg($response)
+                    && $response
+                    && $response['body']
+                ) {
+                    $body = json_decode($response['body'], true);
+                    $amount = $body['min_order_amount'] ?? null;
+                    $currency = $body['min_order_currency'] ?? null;
+                    $basis = $body['min_order_basis'] ?? null;
+                    // The API omits all three fields when no minimum is
+                    // configured; a partial or malformed tuple is treated
+                    // the same way rather than gating on a guess.
+                    if (
+                        is_numeric($amount) && (float) $amount > 0
+                        && is_string($currency) && $currency !== ''
+                        && in_array($basis, ['net', 'gross'], true)
+                    ) {
+                        $minimum = [
+                            'amount' => (float) $amount,
+                            'currency' => strtoupper($currency),
+                            'basis' => $basis,
+                        ];
+                    }
+                }
+
+                $this->update_option('platform_minimum_order', $minimum ? wp_json_encode($minimum) : '');
+                $this->update_option('platform_minimum_order_last_checked_on', time());
+                return $minimum;
+            }
+
+            $cached = $this->get_option('platform_minimum_order');
+            if (!$cached) {
+                return null;
+            }
+            $minimum = json_decode((string) $cached, true);
+            return is_array($minimum) ? $minimum : null;
+        }
+
+        /**
          * Get about twoinc html
          */
         private function get_abt_twoinc_html()
@@ -835,9 +903,11 @@ if (!class_exists('WC_Twoinc')) {
          * @return array
          */
         /**
-         * Remove the gateway from checkout when the brand's availability
-         * gate (availability_gate in the brand config) is unmet. Mirrors
-         * the ABN fork's gate semantics: front-end only, minimum is
+         * Remove the gateway from checkout when the platform minimum
+         * (API-resolved, see get_platform_minimum_order()), the brand's
+         * billing-country restriction (availability_gate in the brand
+         * config), or the merchant's own minimum is unmet. Mirrors the
+         * ABN fork's gate semantics: front-end only, minimum is
          * inclusive (an exactly-minimum basket passes).
          *
          * @param array $available_gateways
@@ -846,44 +916,54 @@ if (!class_exists('WC_Twoinc')) {
          */
         public function apply_brand_availability_gate($available_gateways)
         {
+            if (is_admin() || !isset($available_gateways[$this->id])) {
+                return $available_gateways;
+            }
             $gate = WC_Twoinc_Brand::get('availability_gate');
-            if ($gate && !isset($gate['min_order_amount'], $gate['currency'], $gate['basis'], $gate['billing_countries'])) {
+            if ($gate && !isset($gate['billing_countries'])) {
                 // A truthy but malformed gate must not judge with missing
                 // criteria; leave the gateway available and let the log
                 // below stay quiet (config bug, not a basket decision).
                 $gate = null;
             }
+            $platform_minimum = $this->get_platform_minimum_order();
             $merchant_minimum = $this->get_merchant_minimum_order();
-            if ((!$gate && !$merchant_minimum) || is_admin() || !isset($available_gateways[$this->id])) {
+            if (!$gate && !$platform_minimum && !$merchant_minimum) {
                 return $available_gateways;
             }
             if (!function_exists('WC') || !WC()->cart || !WC()->customer) {
                 return $available_gateways;
             }
 
-            // Basket value on the configured basis: the platform minimum's
-            // basis is explicit (ABN's funding-partner rule is net; the
-            // platform's defaults are gross); the merchant minimum rides
-            // the same basis when a platform minimum exists.
-            $basis = $gate ? $gate['basis'] : ($merchant_minimum['basis'] ?? 'gross');
-            $basket_value = $basis === 'gross'
-                ? (float) WC()->cart->total
-                : (float) WC()->cart->total - (float) WC()->cart->get_total_tax();
+            // Basket value on each minimum's own basis - the platform
+            // minimum's basis is explicit (ABN's funding-partner rule is
+            // net; the platform's defaults are gross) and the merchant
+            // selects theirs independently.
+            $basket_value = static function (string $basis): float {
+                return $basis === 'gross'
+                    ? (float) WC()->cart->total
+                    : (float) WC()->cart->total - (float) WC()->cart->get_total_tax();
+            };
 
             $satisfied = true;
-            if ($gate) {
-                $satisfied = $basket_value >= (float) $gate['min_order_amount']
-                    && get_woocommerce_currency() === $gate['currency']
-                    && in_array(WC()->customer->get_billing_country(), $gate['billing_countries'], true);
+            if ($platform_minimum) {
+                // Fail closed on a basket in another currency: with no FX
+                // source in WooCommerce it cannot be proven to satisfy the
+                // funding partner's minimum.
+                $satisfied = get_woocommerce_currency() === $platform_minimum['currency']
+                    && $basket_value($platform_minimum['basis']) >= $platform_minimum['amount'];
+            }
+            if ($satisfied && $gate) {
+                $satisfied = in_array(WC()->customer->get_billing_country(), $gate['billing_countries'], true);
             }
             if ($satisfied && $merchant_minimum) {
                 $satisfied = get_woocommerce_currency() === $merchant_minimum['currency']
-                    ? $basket_value >= $merchant_minimum['amount']
+                    ? $basket_value($merchant_minimum['basis']) >= $merchant_minimum['amount']
                     // The merchant minimum is store-currency scoped; a
                     // basket in another currency cannot be judged against
                     // it (no FX source in WooCommerce) — fail open on the
-                    // merchant's own optional bar, the platform gate above
-                    // still applies.
+                    // merchant's own optional bar, the platform minimum
+                    // above still applies.
                     : $satisfied;
             }
             if (!$satisfied) {
@@ -896,14 +976,18 @@ if (!class_exists('WC_Twoinc')) {
                     $logged = true;
                     wc_get_logger()->info(
                         sprintf(
-                            'Brand availability gate removed %s from checkout (basket_value=%s basis=%s currency=%s country=%s; platform min %s, merchant min %s)',
+                            'Availability gate removed %s from checkout (gross=%s net=%s currency=%s country=%s; platform min %s, merchant min %s)',
                             $this->id,
-                            $basket_value,
-                            $basis,
+                            $basket_value('gross'),
+                            $basket_value('net'),
                             get_woocommerce_currency(),
                             WC()->customer->get_billing_country(),
-                            $gate ? $gate['min_order_amount'] . ' ' . $gate['currency'] : 'none',
-                            $merchant_minimum ? $merchant_minimum['amount'] . ' ' . $merchant_minimum['currency'] : 'none'
+                            $platform_minimum
+                                ? $platform_minimum['amount'] . ' ' . $platform_minimum['currency'] . ' ' . $platform_minimum['basis']
+                                : 'none',
+                            $merchant_minimum
+                                ? $merchant_minimum['amount'] . ' ' . $merchant_minimum['currency'] . ' ' . $merchant_minimum['basis']
+                                : 'none'
                         ),
                         ['source' => 'twoinc-payment-gateway']
                     );
@@ -925,35 +1009,36 @@ if (!class_exists('WC_Twoinc')) {
          */
         public function get_merchant_minimum_order_description()
         {
-            $gate = WC_Twoinc_Brand::get('availability_gate');
-            if ($gate && isset($gate['min_order_amount'], $gate['currency'])) {
-                $native_display = get_woocommerce_currency_symbol($gate['currency'])
-                    . number_format((float) $gate['min_order_amount'], 2);
-                $basis_label = ($gate['basis'] ?? 'net') === 'gross'
+            $platform_minimum = $this->get_platform_minimum_order();
+            if ($platform_minimum) {
+                $native_display = get_woocommerce_currency_symbol($platform_minimum['currency'])
+                    . number_format($platform_minimum['amount'], 2);
+                $basis_label = $platform_minimum['basis'] === 'gross'
                     ? __('including', 'twoinc-payment-gateway')
                     : __('excluding', 'twoinc-payment-gateway');
-                if (get_option('woocommerce_currency') === $gate['currency']) {
+                if (get_option('woocommerce_currency') === $platform_minimum['currency']) {
                     return sprintf(
-                        __('Platform minimum %1$s, %2$s tax. A value here is interpreted in the store currency on the same tax basis and must exceed it.', 'twoinc-payment-gateway'),
+                        __('Platform minimum %1$s, %2$s tax. A value here is interpreted in the store currency on the tax basis selected below and must exceed it.', 'twoinc-payment-gateway'),
                         $native_display,
                         $basis_label
                     );
                 }
                 return sprintf(
-                    __('Platform minimum %1$s, %2$s tax. A value here is interpreted in the store currency on the same tax basis; it cannot be checked against the platform minimum (different currency) — both minimums are enforced independently.', 'twoinc-payment-gateway'),
+                    __('Platform minimum %1$s, %2$s tax. A value here is interpreted in the store currency on the tax basis selected below; it cannot be checked against the platform minimum (different currency) — both minimums are enforced independently.', 'twoinc-payment-gateway'),
                     $native_display,
                     $basis_label
                 );
             }
-            return __('Hide the payment method below this order value (store currency, including tax). Leave empty for no minimum.', 'twoinc-payment-gateway');
+            return __('Hide the payment method below this order value (store currency, on the tax basis selected below). Leave empty for no minimum.', 'twoinc-payment-gateway');
         }
 
         /**
          * The merchant's own optional minimum order value, as
          * ['amount', 'currency', 'basis'] or null. Interpreted in the
          * STORE currency (the saved woocommerce_currency option, not the
-         * active multicurrency display currency) on the platform
-         * minimum's tax basis when the brand declares one, else gross.
+         * active multicurrency display currency) on the tax basis the
+         * merchant selects, falling back to the platform minimum's basis
+         * when unset, else gross.
          *
          * @return array|null
          */
@@ -963,11 +1048,15 @@ if (!class_exists('WC_Twoinc')) {
             if ($value <= 0) {
                 return null;
             }
-            $gate = WC_Twoinc_Brand::get('availability_gate');
+            $basis = (string) $this->get_option('merchant_minimum_order_basis');
+            if (!in_array($basis, ['net', 'gross'], true)) {
+                $platform_minimum = $this->get_platform_minimum_order();
+                $basis = $platform_minimum['basis'] ?? 'gross';
+            }
             return [
                 'amount' => $value,
                 'currency' => get_option('woocommerce_currency'),
-                'basis' => $gate['basis'] ?? 'gross',
+                'basis' => $basis,
             ];
         }
 
@@ -996,17 +1085,16 @@ if (!class_exists('WC_Twoinc')) {
             if (!is_numeric($value) || (float) $value < 0) {
                 throw new Exception(__('Minimum Order Value must be a non-negative number.', 'twoinc-payment-gateway'));
             }
-            $gate = WC_Twoinc_Brand::get('availability_gate');
+            $platform_minimum = $this->get_platform_minimum_order();
             if (
-                $gate
-                && isset($gate['min_order_amount'], $gate['currency'])
-                && get_option('woocommerce_currency') === $gate['currency']
-                && (float) $value <= (float) $gate['min_order_amount']
+                $platform_minimum
+                && get_option('woocommerce_currency') === $platform_minimum['currency']
+                && (float) $value <= $platform_minimum['amount']
             ) {
                 throw new Exception(sprintf(
                     __('Minimum Order Value must exceed the platform minimum of %1$s, %2$s tax.', 'twoinc-payment-gateway'),
-                    get_woocommerce_currency_symbol($gate['currency']) . number_format((float) $gate['min_order_amount'], 2),
-                    ($gate['basis'] ?? 'net') === 'gross' ? __('including', 'twoinc-payment-gateway') : __('excluding', 'twoinc-payment-gateway')
+                    get_woocommerce_currency_symbol($platform_minimum['currency']) . number_format($platform_minimum['amount'], 2),
+                    $platform_minimum['basis'] === 'gross' ? __('including', 'twoinc-payment-gateway') : __('excluding', 'twoinc-payment-gateway')
                 ));
             }
             return $value;
@@ -1176,20 +1264,20 @@ if (!class_exists('WC_Twoinc')) {
                 // reason, with a strictly-below-minimum check as fallback
                 // while older backends carry only a generic reason. Same
                 // currency only: WooCommerce has no FX rate source.
-                $gate = WC_Twoinc_Brand::get('availability_gate');
-                if ($gate && isset($gate['min_order_amount'], $gate['currency'], $gate['basis'])) {
-                    $order_value = $gate['basis'] === 'gross'
+                $platform_minimum = $this->get_platform_minimum_order();
+                if ($platform_minimum) {
+                    $order_value = $platform_minimum['basis'] === 'gross'
                         ? (float) $order->get_total()
                         : (float) $order->get_total() - (float) $order->get_total_tax();
                     $declined_on_minimum = ($body['decline_reason'] ?? null) === 'ORDER_BELOW_MIN_INVOICE_AMOUNT'
-                        || ($order->get_currency() === $gate['currency']
-                            && $order_value < (float) $gate['min_order_amount']);
-                    if ($declined_on_minimum && $order->get_currency() === $gate['currency']) {
+                        || ($order->get_currency() === $platform_minimum['currency']
+                            && $order_value < $platform_minimum['amount']);
+                    if ($declined_on_minimum && $order->get_currency() === $platform_minimum['currency']) {
                         $error_message .= ' ' . sprintf(
                             __('Minimum order value is %1$s%2$s %3$s tax.', 'twoinc-payment-gateway'),
-                            get_woocommerce_currency_symbol($gate['currency']),
-                            number_format((float) $gate['min_order_amount'], 2),
-                            $gate['basis'] === 'gross' ? __('including', 'twoinc-payment-gateway') : __('excluding', 'twoinc-payment-gateway')
+                            get_woocommerce_currency_symbol($platform_minimum['currency']),
+                            number_format($platform_minimum['amount'], 2),
+                            $platform_minimum['basis'] === 'gross' ? __('including', 'twoinc-payment-gateway') : __('excluding', 'twoinc-payment-gateway')
                         );
                     }
                 }
@@ -1536,10 +1624,25 @@ if (!class_exists('WC_Twoinc')) {
                     'default'     => __(WC_Twoinc_Brand::get('title_default'), 'twoinc-payment-gateway')
                 ],
                 'merchant_minimum_order' => [
-                    'title'       => __('Minimum Order Value', 'twoinc-payment-gateway'),
+                    // The value is interpreted in the store currency, so
+                    // the label says which one applies.
+                    'title'       => sprintf(
+                        __('Minimum Order Value, %s', 'twoinc-payment-gateway'),
+                        get_option('woocommerce_currency')
+                    ),
                     'type'        => 'text',
                     'default'     => '',
                     'description' => $this->get_merchant_minimum_order_description(),
+                ],
+                'merchant_minimum_order_basis' => [
+                    'title'       => __('Minimum Order Value Tax Basis', 'twoinc-payment-gateway'),
+                    'type'        => 'select',
+                    'default'     => 'gross',
+                    'options'     => [
+                        'gross' => __('Including tax (gross)', 'twoinc-payment-gateway'),
+                        'net'   => __('Excluding tax (net)', 'twoinc-payment-gateway'),
+                    ],
+                    'description' => __('Whether the basket is compared against the minimum including or excluding tax.', 'twoinc-payment-gateway'),
                 ],
                 'test_checkout_host' => [
                     'type'        => 'text',
@@ -2178,6 +2281,23 @@ if (!class_exists('WC_Twoinc')) {
             if ($this->get_option('clear_options_on_deactivation') === 'yes') {
                 delete_option('woocommerce_' . $this->id . '_settings');
             }
+        }
+
+        /**
+         * Append plugin/platform version info below the settings form,
+         * mirroring the version panels in the Magento and PrestaShop
+         * plugins - the support team's first question is always
+         * "what version are you on".
+         */
+        public function admin_options()
+        {
+            parent::admin_options();
+            echo '<p><small class="description">' . esc_html(sprintf(
+                __('Plugin version: %1$s | WooCommerce: %2$s | WordPress: %3$s', 'twoinc-payment-gateway'),
+                get_twoinc_plugin_version(),
+                defined('WC_VERSION') ? WC_VERSION : '?',
+                get_bloginfo('version')
+            )) . '</small></p>';
         }
 
         /**

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -914,18 +914,12 @@ if (!class_exists('WC_Twoinc')) {
         }
 
         /**
-         * The merchant's own optional minimum order value, as
-         * ['amount', 'currency', 'basis'] or null. Interpreted in the
-         * platform minimum's currency/basis when the brand declares one,
-         * otherwise store currency, gross. The admin field is validated
-         * on save to exceed the platform minimum — merchants may only
-         * raise the bar.
-         *
-         * @return array|null
-         */
-        /**
          * Dynamic description for the Minimum Order Value setting: shows
-         * the platform minimum the merchant's value must exceed.
+         * the platform minimum the merchant's value must exceed. The
+         * field is interpreted in the STORE currency; when that differs
+         * from the platform minimum's currency the floor is shown in its
+         * native currency only — WooCommerce has no FX rate source until
+         * TWO-24776, so no converted figure can honestly be displayed.
          *
          * @return string
          */
@@ -933,16 +927,36 @@ if (!class_exists('WC_Twoinc')) {
         {
             $gate = WC_Twoinc_Brand::get('availability_gate');
             if ($gate && isset($gate['min_order_amount'], $gate['currency'])) {
+                $native_display = get_woocommerce_currency_symbol($gate['currency'])
+                    . number_format((float) $gate['min_order_amount'], 2);
+                $basis_label = ($gate['basis'] ?? 'net') === 'gross'
+                    ? __('including', 'twoinc-payment-gateway')
+                    : __('excluding', 'twoinc-payment-gateway');
+                if (get_option('woocommerce_currency') === $gate['currency']) {
+                    return sprintf(
+                        __('Platform minimum %1$s, %2$s tax. A value here is interpreted in the store currency on the same tax basis and must exceed it.', 'twoinc-payment-gateway'),
+                        $native_display,
+                        $basis_label
+                    );
+                }
                 return sprintf(
-                    __('Platform minimum: %1$s %2$s (%3$s tax). A value here must exceed it and is interpreted in the same currency and tax basis.', 'twoinc-payment-gateway'),
-                    $gate['min_order_amount'],
-                    $gate['currency'],
-                    ($gate['basis'] ?? 'net') === 'gross' ? __('including', 'twoinc-payment-gateway') : __('excluding', 'twoinc-payment-gateway')
+                    __('Platform minimum %1$s, %2$s tax. A value here is interpreted in the store currency on the same tax basis; it cannot be checked against the platform minimum (different currency) — both minimums are enforced independently.', 'twoinc-payment-gateway'),
+                    $native_display,
+                    $basis_label
                 );
             }
             return __('Hide the payment method below this order value (store currency, including tax). Leave empty for no minimum.', 'twoinc-payment-gateway');
         }
 
+        /**
+         * The merchant's own optional minimum order value, as
+         * ['amount', 'currency', 'basis'] or null. Interpreted in the
+         * STORE currency (the saved woocommerce_currency option, not the
+         * active multicurrency display currency) on the platform
+         * minimum's tax basis when the brand declares one, else gross.
+         *
+         * @return array|null
+         */
         public function get_merchant_minimum_order()
         {
             $value = (float) $this->get_option('merchant_minimum_order');
@@ -952,15 +966,19 @@ if (!class_exists('WC_Twoinc')) {
             $gate = WC_Twoinc_Brand::get('availability_gate');
             return [
                 'amount' => $value,
-                'currency' => $gate['currency'] ?? get_woocommerce_currency(),
+                'currency' => get_option('woocommerce_currency'),
                 'basis' => $gate['basis'] ?? 'gross',
             ];
         }
 
         /**
-         * Validate the merchant minimum on settings save: numeric,
-         * non-negative, and strictly above the platform minimum when the
-         * brand declares one.
+         * Validate the merchant minimum on settings save: numeric and
+         * non-negative always; strictly above the platform minimum when
+         * the brand declares one IN THE STORE CURRENCY. A platform
+         * minimum in another currency cannot be compared (no FX source
+         * in WooCommerce until TWO-24776) — the numeric floor check is
+         * skipped and both minimums are enforced independently at
+         * checkout.
          *
          * @param string $key
          * @param string $value
@@ -979,11 +997,15 @@ if (!class_exists('WC_Twoinc')) {
                 throw new Exception(__('Minimum Order Value must be a non-negative number.', 'twoinc-payment-gateway'));
             }
             $gate = WC_Twoinc_Brand::get('availability_gate');
-            if ($gate && isset($gate['min_order_amount']) && (float) $value <= (float) $gate['min_order_amount']) {
+            if (
+                $gate
+                && isset($gate['min_order_amount'], $gate['currency'])
+                && get_option('woocommerce_currency') === $gate['currency']
+                && (float) $value <= (float) $gate['min_order_amount']
+            ) {
                 throw new Exception(sprintf(
-                    __('Minimum Order Value must exceed the platform minimum of %1$s %2$s (%3$s tax).', 'twoinc-payment-gateway'),
-                    $gate['min_order_amount'],
-                    $gate['currency'],
+                    __('Minimum Order Value must exceed the platform minimum of %1$s, %2$s tax.', 'twoinc-payment-gateway'),
+                    get_woocommerce_currency_symbol($gate['currency']) . number_format((float) $gate['min_order_amount'], 2),
                     ($gate['basis'] ?? 'net') === 'gross' ? __('including', 'twoinc-payment-gateway') : __('excluding', 'twoinc-payment-gateway')
                 ));
             }

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -847,26 +847,45 @@ if (!class_exists('WC_Twoinc')) {
         public function apply_brand_availability_gate($available_gateways)
         {
             $gate = WC_Twoinc_Brand::get('availability_gate');
-            if (!$gate || is_admin() || !isset($available_gateways[$this->id])) {
-                return $available_gateways;
-            }
-            if (!isset($gate['min_order_amount'], $gate['currency'], $gate['billing_countries'])) {
+            if ($gate && !isset($gate['min_order_amount'], $gate['currency'], $gate['basis'], $gate['billing_countries'])) {
                 // A truthy but malformed gate must not judge with missing
                 // criteria; leave the gateway available and let the log
                 // below stay quiet (config bug, not a basket decision).
+                $gate = null;
+            }
+            $merchant_minimum = $this->get_merchant_minimum_order();
+            if ((!$gate && !$merchant_minimum) || is_admin() || !isset($available_gateways[$this->id])) {
                 return $available_gateways;
             }
             if (!function_exists('WC') || !WC()->cart || !WC()->customer) {
                 return $available_gateways;
             }
 
-            // Net basket value (total minus tax): the funding partner's
-            // server-side risk rule compares net, so a gross-compared gate
-            // would show the method on baskets the credit check declines.
-            $net_total = (float) WC()->cart->total - (float) WC()->cart->get_total_tax();
-            $satisfied = $net_total >= (float) $gate['min_order_amount']
-                && get_woocommerce_currency() === $gate['currency']
-                && in_array(WC()->customer->get_billing_country(), $gate['billing_countries'], true);
+            // Basket value on the configured basis: the platform minimum's
+            // basis is explicit (ABN's funding-partner rule is net; the
+            // platform's defaults are gross); the merchant minimum rides
+            // the same basis when a platform minimum exists.
+            $basis = $gate ? $gate['basis'] : ($merchant_minimum['basis'] ?? 'gross');
+            $basket_value = $basis === 'gross'
+                ? (float) WC()->cart->total
+                : (float) WC()->cart->total - (float) WC()->cart->get_total_tax();
+
+            $satisfied = true;
+            if ($gate) {
+                $satisfied = $basket_value >= (float) $gate['min_order_amount']
+                    && get_woocommerce_currency() === $gate['currency']
+                    && in_array(WC()->customer->get_billing_country(), $gate['billing_countries'], true);
+            }
+            if ($satisfied && $merchant_minimum) {
+                $satisfied = get_woocommerce_currency() === $merchant_minimum['currency']
+                    ? $basket_value >= $merchant_minimum['amount']
+                    // The merchant minimum is store-currency scoped; a
+                    // basket in another currency cannot be judged against
+                    // it (no FX source in WooCommerce) — fail open on the
+                    // merchant's own optional bar, the platform gate above
+                    // still applies.
+                    : $satisfied;
+            }
             if (!$satisfied) {
                 unset($available_gateways[$this->id]);
                 // Removing a payment method is invisible to the merchant —
@@ -877,14 +896,14 @@ if (!class_exists('WC_Twoinc')) {
                     $logged = true;
                     wc_get_logger()->info(
                         sprintf(
-                            'Brand availability gate removed %s from checkout (net_total=%s currency=%s country=%s; gate requires net min %s %s in %s)',
+                            'Brand availability gate removed %s from checkout (basket_value=%s basis=%s currency=%s country=%s; platform min %s, merchant min %s)',
                             $this->id,
-                            $net_total,
+                            $basket_value,
+                            $basis,
                             get_woocommerce_currency(),
                             WC()->customer->get_billing_country(),
-                            $gate['min_order_amount'],
-                            $gate['currency'],
-                            implode(',', $gate['billing_countries'])
+                            $gate ? $gate['min_order_amount'] . ' ' . $gate['currency'] : 'none',
+                            $merchant_minimum ? $merchant_minimum['amount'] . ' ' . $merchant_minimum['currency'] : 'none'
                         ),
                         ['source' => 'twoinc-payment-gateway']
                     );
@@ -892,6 +911,83 @@ if (!class_exists('WC_Twoinc')) {
             }
 
             return $available_gateways;
+        }
+
+        /**
+         * The merchant's own optional minimum order value, as
+         * ['amount', 'currency', 'basis'] or null. Interpreted in the
+         * platform minimum's currency/basis when the brand declares one,
+         * otherwise store currency, gross. The admin field is validated
+         * on save to exceed the platform minimum — merchants may only
+         * raise the bar.
+         *
+         * @return array|null
+         */
+        /**
+         * Dynamic description for the Minimum Order Value setting: shows
+         * the platform minimum the merchant's value must exceed.
+         *
+         * @return string
+         */
+        public function get_merchant_minimum_order_description()
+        {
+            $gate = WC_Twoinc_Brand::get('availability_gate');
+            if ($gate && isset($gate['min_order_amount'], $gate['currency'])) {
+                return sprintf(
+                    __('Platform minimum: %1$s %2$s (%3$s tax). A value here must exceed it and is interpreted in the same currency and tax basis.', 'twoinc-payment-gateway'),
+                    $gate['min_order_amount'],
+                    $gate['currency'],
+                    ($gate['basis'] ?? 'net') === 'gross' ? __('including', 'twoinc-payment-gateway') : __('excluding', 'twoinc-payment-gateway')
+                );
+            }
+            return __('Hide the payment method below this order value (store currency, including tax). Leave empty for no minimum.', 'twoinc-payment-gateway');
+        }
+
+        public function get_merchant_minimum_order()
+        {
+            $value = (float) $this->get_option('merchant_minimum_order');
+            if ($value <= 0) {
+                return null;
+            }
+            $gate = WC_Twoinc_Brand::get('availability_gate');
+            return [
+                'amount' => $value,
+                'currency' => $gate['currency'] ?? get_woocommerce_currency(),
+                'basis' => $gate['basis'] ?? 'gross',
+            ];
+        }
+
+        /**
+         * Validate the merchant minimum on settings save: numeric,
+         * non-negative, and strictly above the platform minimum when the
+         * brand declares one.
+         *
+         * @param string $key
+         * @param string $value
+         *
+         * @return string
+         * @throws Exception
+         */
+        public function validate_merchant_minimum_order_field($key, $value)
+        {
+            $value = trim((string) $value);
+            if ($value === '') {
+                return '';
+            }
+            $value = str_replace(',', '.', $value);
+            if (!is_numeric($value) || (float) $value < 0) {
+                throw new Exception(__('Minimum Order Value must be a non-negative number.', 'twoinc-payment-gateway'));
+            }
+            $gate = WC_Twoinc_Brand::get('availability_gate');
+            if ($gate && isset($gate['min_order_amount']) && (float) $value <= (float) $gate['min_order_amount']) {
+                throw new Exception(sprintf(
+                    __('Minimum Order Value must exceed the platform minimum of %1$s %2$s (%3$s tax).', 'twoinc-payment-gateway'),
+                    $gate['min_order_amount'],
+                    $gate['currency'],
+                    ($gate['basis'] ?? 'net') === 'gross' ? __('including', 'twoinc-payment-gateway') : __('excluding', 'twoinc-payment-gateway')
+                ));
+            }
+            return $value;
         }
 
         /**
@@ -1053,22 +1149,27 @@ if (!class_exists('WC_Twoinc')) {
 
             if ($body['status'] == 'REJECTED') {
                 $error_message = sprintf(__('Invoice purchase with %s is not available for this order.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name'));
-                // The backend decline reason is opaque, but when the basket
-                // sits near the brand's minimum the likely cause is the
-                // minimum-order rule — tell the buyer something actionable.
-                // Same-currency only: WooCommerce has no FX rate source.
+                // Surface the minimum when the decline is attributable to
+                // it: primarily by the API's machine-readable decline
+                // reason, with a strictly-below-minimum check as fallback
+                // while older backends carry only a generic reason. Same
+                // currency only: WooCommerce has no FX rate source.
                 $gate = WC_Twoinc_Brand::get('availability_gate');
-                if ($gate
-                    && isset($gate['min_order_amount'], $gate['currency'])
-                    && $order->get_currency() === $gate['currency']
-                    && ((float) $order->get_total() - (float) $order->get_total_tax()) < (float) $gate['min_order_amount'] * 1.05
-                ) {
-                    $error_message .= ' ' . sprintf(
-                        __('Note: %1\$s requires a minimum order value of %2\$s %3\$s excluding tax.', 'twoinc-payment-gateway'),
-                        WC_Twoinc_Brand::get('product_name'),
-                        $gate['min_order_amount'],
-                        $gate['currency']
-                    );
+                if ($gate && isset($gate['min_order_amount'], $gate['currency'], $gate['basis'])) {
+                    $order_value = $gate['basis'] === 'gross'
+                        ? (float) $order->get_total()
+                        : (float) $order->get_total() - (float) $order->get_total_tax();
+                    $declined_on_minimum = ($body['decline_reason'] ?? null) === 'ORDER_BELOW_MIN_INVOICE_AMOUNT'
+                        || ($order->get_currency() === $gate['currency']
+                            && $order_value < (float) $gate['min_order_amount']);
+                    if ($declined_on_minimum && $order->get_currency() === $gate['currency']) {
+                        $error_message .= ' ' . sprintf(
+                            __('Minimum order value is %1$s%2$s %3$s tax.', 'twoinc-payment-gateway'),
+                            get_woocommerce_currency_symbol($gate['currency']),
+                            number_format((float) $gate['min_order_amount'], 2),
+                            $gate['basis'] === 'gross' ? __('including', 'twoinc-payment-gateway') : __('excluding', 'twoinc-payment-gateway')
+                        );
+                    }
                 }
                 $order->add_order_note($error_message);
                 WC_Twoinc_Helper::display_ajax_error($error_message);
@@ -1411,6 +1512,12 @@ if (!class_exists('WC_Twoinc')) {
                     // Brand-specific default: a fresh install must show the
                     // brand's payment-method title, not the Two phrasing.
                     'default'     => __(WC_Twoinc_Brand::get('title_default'), 'twoinc-payment-gateway')
+                ],
+                'merchant_minimum_order' => [
+                    'title'       => __('Minimum Order Value', 'twoinc-payment-gateway'),
+                    'type'        => 'text',
+                    'default'     => '',
+                    'description' => $this->get_merchant_minimum_order_description(),
                 ],
                 'test_checkout_host' => [
                     'type'        => 'text',

--- a/class/WC_Twoinc_Brand.php
+++ b/class/WC_Twoinc_Brand.php
@@ -78,6 +78,36 @@ if (!class_exists('WC_Twoinc_Brand')) {
         }
 
         /**
+         * Brand-prefixed name, e.g. meta_prefix 'twoinc' + 'order_id'
+         * -> 'twoinc_order_id'. Used for the unprefixed-underscore meta
+         * keys, user meta keys, confirmation request params and the
+         * confirmation nonce action.
+         *
+         * @param string $name
+         *
+         * @return string
+         */
+        public static function prefixed_name($name)
+        {
+            return self::get('meta_prefix') . '_' . $name;
+        }
+
+        /**
+         * Brand-prefixed hidden order meta key, e.g. 'order_reference'
+         * -> '_twoinc_order_reference'. Live stores hold data under the
+         * brand's prefix (ABN stores hold _abn_*), so the prefix is
+         * load-bearing for existing orders — never hardcode the literal.
+         *
+         * @param string $name
+         *
+         * @return string
+         */
+        public static function meta_key($name)
+        {
+            return '_' . self::prefixed_name($name);
+        }
+
+        /**
          * Drop the cached config so the next read reloads it.
          *
          * @internal Test-only. Clearing the cache mid-request would re-run

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -232,7 +232,7 @@ if (!class_exists('WC_Twoinc_Checkout')) {
             $currency = get_woocommerce_currency();
 
             // TODO: Make this dynamic based on active merchant payee accounts
-            $supported_buyer_countries = ["NO", "GB", "SE", "NL", "FI", "DK"];
+            $supported_buyer_countries = WC_Twoinc_Brand::get('supported_buyer_countries');
 
             $properties = [
                 'text' => [
@@ -259,10 +259,10 @@ if (!class_exists('WC_Twoinc_Checkout')) {
 
             $user_id = wp_get_current_user()->ID;
             if ($user_id) {
-                $properties['company_id'] = get_user_meta($user_id, 'twoinc_company_id', true);
-                $properties['billing_company'] = get_user_meta($user_id, 'twoinc_billing_company', true);
-                $properties['department'] = get_user_meta($user_id, 'twoinc_department', true);
-                $properties['project'] = get_user_meta($user_id, 'twoinc_project', true);
+                $properties['company_id'] = get_user_meta($user_id, WC_Twoinc_Brand::prefixed_name('company_id'), true);
+                $properties['billing_company'] = get_user_meta($user_id, WC_Twoinc_Brand::prefixed_name('billing_company'), true);
+                $properties['department'] = get_user_meta($user_id, WC_Twoinc_Brand::prefixed_name('department'), true);
+                $properties['project'] = get_user_meta($user_id, WC_Twoinc_Brand::prefixed_name('project'), true);
             }
 
             return $properties;

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -246,6 +246,7 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                 'enable_order_intent' => $this->wc_twoinc->get_option('enable_order_intent'),
                 'display_tooltips' => $this->wc_twoinc->get_option('display_tooltips'),
                 'supported_buyer_countries' => $supported_buyer_countries,
+                'gateway_id' => WC_Twoinc_Brand::get('gateway_id'),
                 'merchant' => $merchant,
                 'days_on_invoice' => $this->wc_twoinc->get_merchant_default_days_on_invoice(),
                 'shop_base_country' => strtolower(WC()->countries->get_base_country()),

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -575,12 +575,19 @@ if (!class_exists('WC_Twoinc_Helper')) {
             }
 
             if (!$skip_nonce) {
+                // Param names and nonce action derive from the brand's
+                // meta_prefix so the read side (process_confirmation)
+                // matches what live branded stores already expect. The
+                // path segment is cosmetic: confirmation detection is by
+                // param presence, not path.
                 $confirmation_url = sprintf(
-                    '%s/twoinc-payment-gateway/confirm?order_id=%s&twoinc_order_reference=%s&twoinc_nonce=%s',
+                    '%s/twoinc-payment-gateway/confirm?order_id=%s&%s=%s&%s=%s',
                     get_home_url(),
                     $order->get_id(),
+                    WC_Twoinc_Brand::prefixed_name('order_reference'),
                     $order_reference,
-                    wp_create_nonce('twoinc_confirm_' . $order->get_id())
+                    WC_Twoinc_Brand::prefixed_name('nonce'),
+                    wp_create_nonce(WC_Twoinc_Brand::prefixed_name('confirm_' . $order->get_id()))
                 );
                 /**
                  * Filter the confirmation URL sent to the Two API.

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -80,12 +80,24 @@ function get_user_locale()
     return 'en_US';
 }
 
+function is_admin()
+{
+    return false;
+}
+
+function get_woocommerce_currency()
+{
+    return $GLOBALS['__twoinc_test_currency'] ?? 'EUR';
+}
+
 function WC()
 {
     static $wc = null;
     if ($wc === null) {
         $wc = new class () {
             public $countries;
+            public $cart;
+            public $customer;
 
             public function __construct()
             {
@@ -101,8 +113,24 @@ function WC()
     return $wc;
 }
 
+class StubCustomer
+{
+    private $country;
+
+    public function __construct($country)
+    {
+        $this->country = $country;
+    }
+
+    public function get_billing_country()
+    {
+        return $this->country;
+    }
+}
+
 class WC_Payment_Gateway
 {
+    public $id;
 }
 
 class WC_HTTPS

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -90,6 +90,19 @@ function get_woocommerce_currency()
     return $GLOBALS['__twoinc_test_currency'] ?? 'EUR';
 }
 
+function get_woocommerce_currency_symbol($currency = '')
+{
+    return $currency !== '' ? $currency . ' ' : '';
+}
+
+function get_option($key, $default = false)
+{
+    if ($key === 'woocommerce_currency') {
+        return $GLOBALS['__twoinc_test_store_currency'] ?? 'EUR';
+    }
+    return $GLOBALS['__twoinc_test_options'][$key] ?? $default;
+}
+
 function WC()
 {
     static $wc = null;

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -113,6 +113,23 @@ function WC()
     return $wc;
 }
 
+class StubCart
+{
+    public $total;
+    private $total_tax;
+
+    public function __construct($total, $total_tax = 0.0)
+    {
+        $this->total = $total;
+        $this->total_tax = $total_tax;
+    }
+
+    public function get_total_tax()
+    {
+        return $this->total_tax;
+    }
+}
+
 class StubCustomer
 {
     private $country;

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -85,6 +85,11 @@ function is_admin()
     return false;
 }
 
+function is_wc_endpoint_url($endpoint = false)
+{
+    return $endpoint === 'order-pay' && !empty($GLOBALS['__twoinc_test_is_order_pay']);
+}
+
 function get_woocommerce_currency()
 {
     return $GLOBALS['__twoinc_test_currency'] ?? 'EUR';
@@ -130,16 +135,23 @@ class StubCart
 {
     public $total;
     private $total_tax;
+    private $is_empty;
 
-    public function __construct($total, $total_tax = 0.0)
+    public function __construct($total, $total_tax = 0.0, $is_empty = false)
     {
         $this->total = $total;
         $this->total_tax = $total_tax;
+        $this->is_empty = $is_empty;
     }
 
     public function get_total_tax()
     {
         return $this->total_tax;
+    }
+
+    public function is_empty()
+    {
+        return $this->is_empty;
     }
 }
 

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -148,6 +148,11 @@ class StubCustomer
 class WC_Payment_Gateway
 {
     public $id;
+
+    public function get_option($key, $empty_value = null)
+    {
+        return $empty_value ?? '';
+    }
 }
 
 class WC_HTTPS

--- a/tests/unit/fixtures/testbrand.php
+++ b/tests/unit/fixtures/testbrand.php
@@ -10,10 +10,9 @@ return [
     'product_name' => 'Testbrand',
     'gateway_id' => 'woocommerce-gateway-testbrand',
     'meta_prefix' => 'testbrand',
+    // The minimum order value is API-resolved (get_platform_minimum_order);
+    // the brand gate only restricts billing countries.
     'availability_gate' => [
-        'min_order_amount' => 250.0,
-        'currency' => 'EUR',
-        'basis' => 'net',
         'billing_countries' => ['NL'],
     ],
 ];

--- a/tests/unit/fixtures/testbrand.php
+++ b/tests/unit/fixtures/testbrand.php
@@ -9,4 +9,10 @@ return [
     'code' => 'testbrand',
     'product_name' => 'Testbrand',
     'gateway_id' => 'woocommerce-gateway-testbrand',
+    'meta_prefix' => 'testbrand',
+    'availability_gate' => [
+        'min_order_amount' => 250.0,
+        'currency' => 'EUR',
+        'billing_countries' => ['NL'],
+    ],
 ];

--- a/tests/unit/fixtures/testbrand.php
+++ b/tests/unit/fixtures/testbrand.php
@@ -13,6 +13,7 @@ return [
     'availability_gate' => [
         'min_order_amount' => 250.0,
         'currency' => 'EUR',
+        'basis' => 'net',
         'billing_countries' => ['NL'],
     ],
 ];

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -44,6 +44,7 @@ final class BrandConfigSpec
             'testAvailabilityGateRemovesGatewayWhenUnmet',
             'testAvailabilityGateKeepsGatewayAtExactMinimum',
             'testPaymentValidationErrorFilterVetoes',
+            'testConfirmationPageDetectionFollowsBrandPrefix',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -324,6 +325,36 @@ final class BrandConfigSpec
             'You must first accept the payment terms (order 42)',
             self::gateway()->get_brand_payment_validation_error(42)
         );
+    }
+
+    private static function testConfirmationPageDetectionFollowsBrandPrefix(): void
+    {
+        // The read side is the half that strands in-flight orders if it
+        // drifts from the write side: both must derive from meta_prefix.
+        self::useTestbrand();
+        $gateway = new class () extends WC_Twoinc {
+            public function __construct()
+            {
+            }
+        };
+        $is_confirmation_page = new ReflectionMethod(WC_Twoinc::class, 'is_confirmation_page');
+        $is_confirmation_page->setAccessible(true);
+
+        $_REQUEST = [
+            'order_id' => '42',
+            'testbrand_order_reference' => 'ref',
+            'testbrand_nonce' => 'nonce',
+        ];
+        TinyAssert::true($is_confirmation_page->invoke($gateway));
+
+        // Params under another brand's prefix must NOT be detected
+        $_REQUEST = [
+            'order_id' => '42',
+            'twoinc_order_reference' => 'ref',
+            'twoinc_nonce' => 'nonce',
+        ];
+        TinyAssert::same(false, $is_confirmation_page->invoke($gateway));
+        $_REQUEST = [];
     }
 
     private static function testBrandFileReturningNonArrayFallsBackToDefaults(): void

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -106,6 +106,7 @@ final class BrandConfigSpec
         TinyAssert::same('Two', WC_Twoinc_Brand::get('provider'));
         TinyAssert::same('https://portal.two.inc/auth/merchant/signup', WC_Twoinc_Brand::get('merchant_signup_url'));
         TinyAssert::same(WC_TWOINC_PLUGIN_URL . 'assets/images/two-logo.svg', WC_Twoinc_Brand::get('logo_url'));
+        TinyAssert::same('Business invoice - %s days', WC_Twoinc_Brand::get('title_default'));
         TinyAssert::same(null, WC_Twoinc_Brand::get('not_a_key'));
     }
 

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -45,6 +45,8 @@ final class BrandConfigSpec
             'testAvailabilityGateKeepsGatewayAtExactMinimum',
             'testAvailabilityGateComparesNetNotGross',
             'testAvailabilityGateRestrictsBillingCountry',
+            'testAvailabilityGateSkipsMinimumsOnEmptyCart',
+            'testAvailabilityGateSkipsMinimumsOnOrderPayPage',
             'testMerchantMinimumRaisesTheBar',
             'testMerchantMinimumValidationRejectsValuesAtOrBelowPlatformMinimum',
             'testMerchantMinimumValidationSkipsFloorCheckAcrossCurrencies',
@@ -377,6 +379,46 @@ final class BrandConfigSpec
         $result = self::gateway(self::EUR_250_NET)->apply_brand_availability_gate($gateways);
 
         TinyAssert::true(!isset($result['woocommerce-gateway-testbrand']));
+    }
+
+    private static function testAvailabilityGateSkipsMinimumsOnEmptyCart(): void
+    {
+        // No live basket to judge (e.g. a cartless REST context): the
+        // minimums must not hide the gateway on a zero-value cart — the
+        // API still enforces them at order creation.
+        self::useTestbrand();
+        WC()->cart = new StubCart(0.0, 0.0, true);
+        WC()->customer = new StubCustomer('NL');
+        $GLOBALS['__twoinc_test_currency'] = 'EUR';
+
+        $gateways = ['woocommerce-gateway-testbrand' => 'gw'];
+        $result = self::gateway(self::EUR_250_NET)->apply_brand_availability_gate($gateways);
+
+        TinyAssert::same('gw', $result['woocommerce-gateway-testbrand']);
+    }
+
+    private static function testAvailabilityGateSkipsMinimumsOnOrderPayPage(): void
+    {
+        // Pay-for-order page: the session cart is not the basket being
+        // paid, so an under-minimum (or stale) cart must not hide the
+        // gateway. The billing-country gate still applies there.
+        self::useTestbrand();
+        WC()->cart = new StubCart(100.0);
+        WC()->customer = new StubCustomer('NL');
+        $GLOBALS['__twoinc_test_currency'] = 'EUR';
+        $GLOBALS['__twoinc_test_is_order_pay'] = true;
+
+        try {
+            $gateways = ['woocommerce-gateway-testbrand' => 'gw'];
+            $result = self::gateway(self::EUR_250_NET)->apply_brand_availability_gate($gateways);
+            TinyAssert::same('gw', $result['woocommerce-gateway-testbrand']);
+
+            WC()->customer = new StubCustomer('DE');
+            $result = self::gateway(self::EUR_250_NET)->apply_brand_availability_gate($gateways);
+            TinyAssert::true(!isset($result['woocommerce-gateway-testbrand']));
+        } finally {
+            unset($GLOBALS['__twoinc_test_is_order_pay']);
+        }
     }
 
     private static function testMerchantMinimumRaisesTheBar(): void

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -46,6 +46,7 @@ final class BrandConfigSpec
             'testAvailabilityGateComparesNetNotGross',
             'testMerchantMinimumRaisesTheBar',
             'testMerchantMinimumValidationRejectsValuesAtOrBelowPlatformMinimum',
+            'testMerchantMinimumValidationSkipsFloorCheckAcrossCurrencies',
             'testPaymentValidationErrorFilterVetoes',
             'testConfirmationPageDetectionFollowsBrandPrefix',
         ];
@@ -393,6 +394,23 @@ final class BrandConfigSpec
 
         TinyAssert::same('251', $gateway->validate_merchant_minimum_order_field('merchant_minimum_order', '251'));
         TinyAssert::same('', $gateway->validate_merchant_minimum_order_field('merchant_minimum_order', ''));
+    }
+
+    private static function testMerchantMinimumValidationSkipsFloorCheckAcrossCurrencies(): void
+    {
+        // Store currency GBP vs platform minimum in EUR: WooCommerce has
+        // no FX source (until TWO-24776), so the floor comparison is
+        // skipped on save — the gate enforces both minima independently.
+        self::useTestbrand();
+        $GLOBALS['__twoinc_test_store_currency'] = 'GBP';
+        try {
+            TinyAssert::same(
+                '10',
+                self::gateway()->validate_merchant_minimum_order_field('merchant_minimum_order', '10')
+            );
+        } finally {
+            unset($GLOBALS['__twoinc_test_store_currency']);
+        }
     }
 
     private static function testConfirmationPageDetectionFollowsBrandPrefix(): void

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -38,6 +38,12 @@ final class BrandConfigSpec
             'testEditOrderAppliesSameBrandHooks',
             'testLegacyOrderCreateFilterRunsBeforeOrderPayload',
             'testBrandFileReturningNonArrayFallsBackToDefaults',
+            'testMetaKeysDeriveFromBrandPrefix',
+            'testConfirmationUrlParamsDeriveFromBrandPrefix',
+            'testAvailabilityGateAbsentForTwoBrand',
+            'testAvailabilityGateRemovesGatewayWhenUnmet',
+            'testAvailabilityGateKeepsGatewayAtExactMinimum',
+            'testPaymentValidationErrorFilterVetoes',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -50,9 +56,33 @@ final class BrandConfigSpec
     {
         WC_Twoinc_Brand::reset();
         putenv('TWO_BRAND_CODE');
-        foreach (['twoinc_brand_file', 'twoinc_checkout_fields', 'twoinc_confirmation_url', 'twoinc_order_payload', 'twoinc_payment_terms_line', 'two_order_create'] as $tag) {
+        unset($GLOBALS['__twoinc_test_currency']);
+        WC()->cart = null;
+        WC()->customer = null;
+        foreach (['twoinc_brand_file', 'twoinc_checkout_fields', 'twoinc_confirmation_url', 'twoinc_order_payload', 'twoinc_payment_terms_line', 'two_order_create', 'twoinc_payment_validation_error'] as $tag) {
             remove_all_filters($tag);
         }
+    }
+
+    /**
+     * Gateway instance with only the brand-derived id set — the full
+     * constructor needs a WooCommerce install.
+     */
+    private static function gateway(): WC_Twoinc
+    {
+        return new class () extends WC_Twoinc {
+            public function __construct()
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+            }
+        };
+    }
+
+    private static function useTestbrand(): void
+    {
+        add_filter('twoinc_brand_file', static function ($file) {
+            return __DIR__ . '/fixtures/testbrand.php';
+        });
     }
 
     private static function composeOrder(): array
@@ -218,6 +248,82 @@ final class BrandConfigSpec
         TinyAssert::same(true, $payload_saw_legacy, 'twoinc_order_payload must see two_order_create result');
         TinyAssert::same('yes', $body['legacy_marker']);
         TinyAssert::same('yes', $body['new_marker']);
+    }
+
+    private static function testMetaKeysDeriveFromBrandPrefix(): void
+    {
+        TinyAssert::same('_twoinc_order_reference', WC_Twoinc_Brand::meta_key('order_reference'));
+        TinyAssert::same('twoinc_order_id', WC_Twoinc_Brand::prefixed_name('order_id'));
+
+        WC_Twoinc_Brand::reset();
+        self::useTestbrand();
+
+        // Live stores hold data under the overlay's prefix — the keys
+        // must follow the brand, not the literal
+        TinyAssert::same('_testbrand_order_reference', WC_Twoinc_Brand::meta_key('order_reference'));
+        TinyAssert::same('testbrand_company_id', WC_Twoinc_Brand::prefixed_name('company_id'));
+    }
+
+    private static function testConfirmationUrlParamsDeriveFromBrandPrefix(): void
+    {
+        self::useTestbrand();
+
+        $body = self::composeOrder();
+        $url = $body['merchant_urls']['merchant_confirmation_url'];
+
+        TinyAssert::true(strpos($url, 'testbrand_order_reference=test-order-reference') !== false, $url);
+        TinyAssert::true(strpos($url, 'testbrand_nonce=') !== false, $url);
+    }
+
+    private static function testAvailabilityGateAbsentForTwoBrand(): void
+    {
+        // No WC() cart/customer set up: with no gate configured the
+        // filter must not even look at them
+        $gateways = ['woocommerce-gateway-tillit' => 'gw'];
+
+        TinyAssert::same($gateways, self::gateway()->apply_brand_availability_gate($gateways));
+    }
+
+    private static function testAvailabilityGateRemovesGatewayWhenUnmet(): void
+    {
+        self::useTestbrand();
+        WC()->cart = (object) ['total' => 249.99];
+        WC()->customer = new StubCustomer('NL');
+        $GLOBALS['__twoinc_test_currency'] = 'EUR';
+
+        $gateways = ['woocommerce-gateway-testbrand' => 'gw', 'other' => 'x'];
+        $result = self::gateway()->apply_brand_availability_gate($gateways);
+
+        TinyAssert::true(!isset($result['woocommerce-gateway-testbrand']));
+        TinyAssert::same('x', $result['other']);
+    }
+
+    private static function testAvailabilityGateKeepsGatewayAtExactMinimum(): void
+    {
+        self::useTestbrand();
+        WC()->cart = (object) ['total' => 250.0];
+        WC()->customer = new StubCustomer('NL');
+        $GLOBALS['__twoinc_test_currency'] = 'EUR';
+
+        $gateways = ['woocommerce-gateway-testbrand' => 'gw'];
+        $result = self::gateway()->apply_brand_availability_gate($gateways);
+
+        // The minimum is inclusive: an exactly-minimum basket passes
+        TinyAssert::same('gw', $result['woocommerce-gateway-testbrand']);
+    }
+
+    private static function testPaymentValidationErrorFilterVetoes(): void
+    {
+        TinyAssert::same(null, self::gateway()->get_brand_payment_validation_error(42));
+
+        add_filter('twoinc_payment_validation_error', static function ($error, $order_id) {
+            return 'You must first accept the payment terms (order ' . $order_id . ')';
+        }, 10, 2);
+
+        TinyAssert::same(
+            'You must first accept the payment terms (order 42)',
+            self::gateway()->get_brand_payment_validation_error(42)
+        );
     }
 
     private static function testBrandFileReturningNonArrayFallsBackToDefaults(): void

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -44,6 +44,8 @@ final class BrandConfigSpec
             'testAvailabilityGateRemovesGatewayWhenUnmet',
             'testAvailabilityGateKeepsGatewayAtExactMinimum',
             'testAvailabilityGateComparesNetNotGross',
+            'testMerchantMinimumRaisesTheBar',
+            'testMerchantMinimumValidationRejectsValuesAtOrBelowPlatformMinimum',
             'testPaymentValidationErrorFilterVetoes',
             'testConfirmationPageDetectionFollowsBrandPrefix',
         ];
@@ -346,6 +348,51 @@ final class BrandConfigSpec
             'You must first accept the payment terms (order 42)',
             self::gateway()->get_brand_payment_validation_error(42)
         );
+    }
+
+    private static function testMerchantMinimumRaisesTheBar(): void
+    {
+        // No platform gate (Two brand): the merchant minimum gates alone
+        WC()->customer = new StubCustomer('NO');
+        $GLOBALS['__twoinc_test_currency'] = 'EUR';
+        $gateway = new class () extends WC_Twoinc {
+            public function __construct()
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $key === 'merchant_minimum_order' ? '500' : '';
+            }
+        };
+
+        $gateways = ['woocommerce-gateway-tillit' => 'gw'];
+        WC()->cart = new StubCart(499.0);
+        $result = $gateway->apply_brand_availability_gate($gateways);
+        TinyAssert::true(!isset($result['woocommerce-gateway-tillit']));
+
+        // Gross basis by default for a standalone merchant minimum
+        WC()->cart = new StubCart(500.0, 100.0);
+        $result = $gateway->apply_brand_availability_gate($gateways);
+        TinyAssert::same('gw', $result['woocommerce-gateway-tillit']);
+    }
+
+    private static function testMerchantMinimumValidationRejectsValuesAtOrBelowPlatformMinimum(): void
+    {
+        self::useTestbrand();
+        $gateway = self::gateway();
+
+        $threw = false;
+        try {
+            $gateway->validate_merchant_minimum_order_field('merchant_minimum_order', '250');
+        } catch (Exception $e) {
+            $threw = true;
+        }
+        TinyAssert::true($threw, 'A value equal to the platform minimum must be rejected');
+
+        TinyAssert::same('251', $gateway->validate_merchant_minimum_order_field('merchant_minimum_order', '251'));
+        TinyAssert::same('', $gateway->validate_merchant_minimum_order_field('merchant_minimum_order', ''));
     }
 
     private static function testConfirmationPageDetectionFollowsBrandPrefix(): void

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -44,6 +44,7 @@ final class BrandConfigSpec
             'testAvailabilityGateRemovesGatewayWhenUnmet',
             'testAvailabilityGateKeepsGatewayAtExactMinimum',
             'testAvailabilityGateComparesNetNotGross',
+            'testAvailabilityGateRestrictsBillingCountry',
             'testMerchantMinimumRaisesTheBar',
             'testMerchantMinimumValidationRejectsValuesAtOrBelowPlatformMinimum',
             'testMerchantMinimumValidationSkipsFloorCheckAcrossCurrencies',
@@ -71,17 +72,28 @@ final class BrandConfigSpec
 
     /**
      * Gateway instance with only the brand-derived id set — the full
-     * constructor needs a WooCommerce install.
+     * constructor needs a WooCommerce install. The API-resolved platform
+     * minimum is injected per test; null = none configured.
      */
-    private static function gateway(): WC_Twoinc
+    private static function gateway(?array $platform_minimum = null): WC_Twoinc
     {
-        return new class () extends WC_Twoinc {
-            public function __construct()
+        return new class ($platform_minimum) extends WC_Twoinc {
+            private $test_platform_minimum;
+
+            public function __construct($platform_minimum = null)
             {
                 $this->id = WC_Twoinc_Brand::get('gateway_id');
+                $this->test_platform_minimum = $platform_minimum;
+            }
+
+            public function get_platform_minimum_order()
+            {
+                return $this->test_platform_minimum;
             }
         };
     }
+
+    private const EUR_250_NET = ['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net'];
 
     private static function useTestbrand(): void
     {
@@ -298,7 +310,7 @@ final class BrandConfigSpec
         $GLOBALS['__twoinc_test_currency'] = 'EUR';
 
         $gateways = ['woocommerce-gateway-testbrand' => 'gw', 'other' => 'x'];
-        $result = self::gateway()->apply_brand_availability_gate($gateways);
+        $result = self::gateway(self::EUR_250_NET)->apply_brand_availability_gate($gateways);
 
         TinyAssert::true(!isset($result['woocommerce-gateway-testbrand']));
         TinyAssert::same('x', $result['other']);
@@ -312,7 +324,7 @@ final class BrandConfigSpec
         $GLOBALS['__twoinc_test_currency'] = 'EUR';
 
         $gateways = ['woocommerce-gateway-testbrand' => 'gw'];
-        $result = self::gateway()->apply_brand_availability_gate($gateways);
+        $result = self::gateway(self::EUR_250_NET)->apply_brand_availability_gate($gateways);
 
         // The minimum is inclusive: an exactly-minimum basket passes
         TinyAssert::same('gw', $result['woocommerce-gateway-testbrand']);
@@ -327,13 +339,13 @@ final class BrandConfigSpec
 
         // EUR 302.50 gross with EUR 52.50 tax is exactly EUR 250 net: passes
         WC()->cart = new StubCart(302.50, 52.50);
-        $result = self::gateway()->apply_brand_availability_gate($gateways);
+        $result = self::gateway(self::EUR_250_NET)->apply_brand_availability_gate($gateways);
         TinyAssert::same('gw', $result['woocommerce-gateway-testbrand']);
 
         // EUR 250 gross with tax is below EUR 250 net: the credit check
         // would decline it, so the gate must hide the method
         WC()->cart = new StubCart(250.0, 43.39);
-        $result = self::gateway()->apply_brand_availability_gate($gateways);
+        $result = self::gateway(self::EUR_250_NET)->apply_brand_availability_gate($gateways);
         TinyAssert::true(!isset($result['woocommerce-gateway-testbrand']));
     }
 
@@ -349,6 +361,22 @@ final class BrandConfigSpec
             'You must first accept the payment terms (order 42)',
             self::gateway()->get_brand_payment_validation_error(42)
         );
+    }
+
+    private static function testAvailabilityGateRestrictsBillingCountry(): void
+    {
+        // The brand gate's billing-country restriction stands alone now
+        // that the minimum is API-resolved: an over-minimum basket from
+        // an unsupported country is still gated.
+        self::useTestbrand();
+        WC()->cart = new StubCart(1000.0);
+        WC()->customer = new StubCustomer('DE');
+        $GLOBALS['__twoinc_test_currency'] = 'EUR';
+
+        $gateways = ['woocommerce-gateway-testbrand' => 'gw'];
+        $result = self::gateway(self::EUR_250_NET)->apply_brand_availability_gate($gateways);
+
+        TinyAssert::true(!isset($result['woocommerce-gateway-testbrand']));
     }
 
     private static function testMerchantMinimumRaisesTheBar(): void
@@ -382,7 +410,7 @@ final class BrandConfigSpec
     private static function testMerchantMinimumValidationRejectsValuesAtOrBelowPlatformMinimum(): void
     {
         self::useTestbrand();
-        $gateway = self::gateway();
+        $gateway = self::gateway(self::EUR_250_NET);
 
         $threw = false;
         try {
@@ -406,7 +434,7 @@ final class BrandConfigSpec
         try {
             TinyAssert::same(
                 '10',
-                self::gateway()->validate_merchant_minimum_order_field('merchant_minimum_order', '10')
+                self::gateway(self::EUR_250_NET)->validate_merchant_minimum_order_field('merchant_minimum_order', '10')
             );
         } finally {
             unset($GLOBALS['__twoinc_test_store_currency']);

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -43,6 +43,7 @@ final class BrandConfigSpec
             'testAvailabilityGateAbsentForTwoBrand',
             'testAvailabilityGateRemovesGatewayWhenUnmet',
             'testAvailabilityGateKeepsGatewayAtExactMinimum',
+            'testAvailabilityGateComparesNetNotGross',
             'testPaymentValidationErrorFilterVetoes',
             'testConfirmationPageDetectionFollowsBrandPrefix',
         ];
@@ -289,7 +290,7 @@ final class BrandConfigSpec
     private static function testAvailabilityGateRemovesGatewayWhenUnmet(): void
     {
         self::useTestbrand();
-        WC()->cart = (object) ['total' => 249.99];
+        WC()->cart = new StubCart(249.99);
         WC()->customer = new StubCustomer('NL');
         $GLOBALS['__twoinc_test_currency'] = 'EUR';
 
@@ -303,7 +304,7 @@ final class BrandConfigSpec
     private static function testAvailabilityGateKeepsGatewayAtExactMinimum(): void
     {
         self::useTestbrand();
-        WC()->cart = (object) ['total' => 250.0];
+        WC()->cart = new StubCart(250.0);
         WC()->customer = new StubCustomer('NL');
         $GLOBALS['__twoinc_test_currency'] = 'EUR';
 
@@ -312,6 +313,25 @@ final class BrandConfigSpec
 
         // The minimum is inclusive: an exactly-minimum basket passes
         TinyAssert::same('gw', $result['woocommerce-gateway-testbrand']);
+    }
+
+    private static function testAvailabilityGateComparesNetNotGross(): void
+    {
+        self::useTestbrand();
+        WC()->customer = new StubCustomer('NL');
+        $GLOBALS['__twoinc_test_currency'] = 'EUR';
+        $gateways = ['woocommerce-gateway-testbrand' => 'gw'];
+
+        // EUR 302.50 gross with EUR 52.50 tax is exactly EUR 250 net: passes
+        WC()->cart = new StubCart(302.50, 52.50);
+        $result = self::gateway()->apply_brand_availability_gate($gateways);
+        TinyAssert::same('gw', $result['woocommerce-gateway-testbrand']);
+
+        // EUR 250 gross with tax is below EUR 250 net: the credit check
+        // would decline it, so the gate must hide the method
+        WC()->cart = new StubCart(250.0, 43.39);
+        $result = self::gateway()->apply_brand_availability_gate($gateways);
+        TinyAssert::true(!isset($result['woocommerce-gateway-testbrand']));
     }
 
     private static function testPaymentValidationErrorFilterVetoes(): void


### PR DESCRIPTION
## What

C1.5 of the plugin parity plan: the base-plugin seams the ABN overlay (TWO-24745 / C2) needs but the C1 brand layer could not express. Driven by an exhaustive fork-vs-base divergence inventory of `woocommerce-abn-plugin`.

**Stacked on #320** — merge that first; base retargets when it lands.

## Why these seams

The inventory found the four C1 hooks + brand keys cover identity and payload shape, but five divergences are hardcoded in base code paths:

| Seam | Why the overlay needs it |
|---|---|
| `meta_prefix` brand key routed through `WC_Twoinc_Brand::meta_key()` / `prefixed_name()` (order meta, user meta, confirmation params, nonce action) | **Live ABN stores hold `_abn_*` order meta.** Without the prefix following the brand, every existing ABN order's reference/state/hash becomes unreadable after migration. The confirmation return-side (`abn_order_reference`/`abn_nonce` params, `abn_confirm_` nonce) is the same prefix family — the outbound `twoinc_confirmation_url` filter alone could not cover the read side. |
| `availability_gate` brand config + `woocommerce_available_payment_gateways` filter | The fork's €250/EUR/NL gate (front-end only, inclusive minimum). Config, not code, so the overlay declares `['min_order_amount' => 250, 'currency' => 'EUR', 'billing_countries' => ['NL']]`. |
| `twoinc_payment_validation_error` filter in `process_payment` | The fork's required terms-acceptance checkbox validation — without a veto seam the overlay must duplicate `process_payment()`. |
| `twoinc_payment_description` filter | The fork ships wholly different payment-box copy (bullet list, "Enabled by ABN AMRO"). |
| `supported_buyer_countries` brand key | Fork pins the checkout JS to `["NL"]`. |

Two brand values reproduce today's behaviour exactly (`meta_prefix=twoinc`, no gate, default countries); `_tillit_*` legacy fallbacks and HTML form input names stay literal (not data-bearing).

## Test plan

- [x] 18/18 unit tests green on PHP 7.4 + 8.2 (new: prefix derivation under overlay brand, confirmation-URL params follow prefix, gate absent/unmet/exact-minimum boundary, validation veto)
- [x] `php -l` all changed files
- [ ] e2e suite on this PR (Two brand, full checkout) — verifies the zero-behaviour-change claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)