### PR TITLE
TWO-24747/feat: Local dev harness targets and env plumbing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ TWO_API_BASE_URL=http://portal.localhost/api
 # Merchant API key for the environment above. For staging:
 # gcloud secrets versions access latest \
 #   --secret=STAGING_SHOP_MERCHANT_API_KEY_TILLITTESTUK --project=two-beta
-TWO_API_KEY=secret_test_ePLc4yzRw2w-sUzJTtUABPMvTfnI0WrazJ1aotjX2Bw
+TWO_API_KEY=secret_test_REPLACE_ME
 
 # Brand to run the plugin as (brands/{code}.php inside the plugin).
 # 'two' is the shipped default; overlay brands need their overlay

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Local dev environment — copy to .env and adjust (docker compose reads
+# .env natively; .env is gitignored).
+
+# Two API the local shop talks to. The default targets a locally running
+# checkout-api behind portal.localhost; use https://api.staging.two.inc
+# for staging.
+TWO_API_BASE_URL=http://portal.localhost/api
+
+# Merchant API key for the environment above. For staging:
+# gcloud secrets versions access latest \
+#   --secret=STAGING_SHOP_MERCHANT_API_KEY_TILLITTESTUK --project=two-beta
+TWO_API_KEY=secret_test_ePLc4yzRw2w-sUzJTtUABPMvTfnI0WrazJ1aotjX2Bw
+
+# Brand to run the plugin as (brands/{code}.php inside the plugin).
+# 'two' is the shipped default; overlay brands need their overlay
+# plugin installed in the container.
+TWO_BRAND_CODE=two
+
+# WooCommerce flavour
+WOOCOM_VERSION=9.9.5
+WOOCOM_CURRENCY=GBP
+WOOCOM_DEFAULT_COUNTRY=GB
+
+# Full gateway-settings JSON applied at first provision (env values
+# above override api_key/test_checkout_host afterwards via
+# `make configure`).
+WOOCOM_PLUGIN_CONFIG_JSON=docker/config/local.json

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -50,7 +50,12 @@ jobs:
           MERCHANT_API_KEY: ${{ steps.secrets.outputs.MERCHANT_API_KEY }}
 
       - name: Start WordPress
-        run: docker compose up -d
+        run: |
+          # Compose defaults WOOCOM_PLUGIN_CONFIG_JSON to the local-dev
+          # config; CI must seed the gateway with the staging config the
+          # previous step rendered.
+          echo "WOOCOM_PLUGIN_CONFIG_JSON=docker/config/staging-tillittestuk.json" > .env
+          docker compose up -d
 
       - name: Wait for bootstrap to complete
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,37 @@
+# Local dev — see README "Set up Wordpress for local development".
+# Copy .env.example to .env first; docker compose reads it natively.
+
+run:
+	docker compose up -d
+
+install: run
+	@echo "First provision runs in the wpcli container (~90s):"
+	@echo "  make logs-wpcli   # watch progress"
+
+configure:
+	docker compose exec -T wpcli bash /opt/tillit-payment-gateway/dev/configure
+
+logs:
+	docker compose logs -f wordpress
+
+logs-wpcli:
+	docker compose logs -f wpcli
+
+stop:
+	docker compose down
+
+clean:
+	docker compose down -v
+	rm -rf volumes/
+
+test-unit:
+	docker run --rm -v "$(CURDIR)":/app -w /app php:8.2-cli php tests/unit/run.php
+
+test: test-unit
+
+format:
+	pre-commit run --all-files
+
 archive:
 	git archive --format zip HEAD > tillit-payment-gateway.zip
 bumpver-%:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ make install           # docker compose up; first provision takes ~90s (make log
 ```
 
 Navigate to <http://localhost:8888/>. `make configure` re-applies the
-TWO_* env values to the gateway settings after you edit `.env` (run
+TWO\_\* env values to the gateway settings after you edit `.env` (run
 `make run` first so the container env is recreated). Other targets:
 `make logs`, `make stop`, `make clean` (full reset), `make test-unit`,
 `make format`.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ EOF
 Now you can bring up your Wordpress instance:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 Navigate to <http://localhost:8888/> on your browser to access the Wordpress site.
@@ -100,6 +100,9 @@ Playwright e2e tests live in `tests/e2e/`. They run against the local Docker env
 ### Setup
 
 ```bash
+# The compose default seeds the LOCAL dev config; e2e runs against the
+# staging shop, so pin the staging config first (CI does the same):
+echo WOOCOM_PLUGIN_CONFIG_JSON=docker/config/staging-tillittestuk.json > .env
 docker compose up -d
 # wait ~90s for wpcli bootstrap to finish (installs WooCommerce, creates products, activates plugin)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,19 @@ Now, go to Github to create a new release which triggers publication of the new 
 
 ## Set up Wordpress for local development
 
-Also, if you wish to use a locally running Checkout API backend, no additional setup is required.
+```bash
+cp .env.example .env   # adjust TWO_API_KEY / TWO_API_BASE_URL / TWO_BRAND_CODE
+make install           # docker compose up; first provision takes ~90s (make logs-wpcli)
+```
+
+Navigate to <http://localhost:8888/>. `make configure` re-applies the
+TWO_* env values to the gateway settings after you edit `.env` (run
+`make run` first so the container env is recreated). Other targets:
+`make logs`, `make stop`, `make clean` (full reset), `make test-unit`,
+`make format`.
+
+The default `.env` targets a locally running Checkout API backend
+(`portal.localhost`) — no additional setup required.
 
 If you wish to use the staging site,
 

--- a/brands/two.php
+++ b/brands/two.php
@@ -8,9 +8,10 @@
  * values are merged over these defaults, so an overlay declares only
  * what differs.
  *
- * Every key here either has a runtime consumer or mirrors one of the
- * BC-frozen WC_Twoinc constants (pinned by tests/unit). Do not declare
- * speculative config — new keys land with the code that reads them.
+ * Every key here has a runtime consumer, mirrors one of the BC-frozen
+ * WC_Twoinc constants, or is asserted by tests/unit (`code`). Do not
+ * declare speculative config — new keys land with the code that reads
+ * them.
  */
 
 return [
@@ -18,7 +19,7 @@ return [
     'provider' => 'Two',
     'provider_full_name' => 'Two',
     'product_name' => 'Two',
-    'merchant_signup_url' => 'https://portal.two.inc/auth/merchant/signup',
+    'sign_up_url' => 'https://portal.two.inc/auth/merchant/signup',
     'alert_email_address' => 'woocom-alerts@two.inc',
     'gateway_id' => 'woocommerce-gateway-tillit',
     'logo_url' => WC_TWOINC_PLUGIN_URL . 'assets/images/two-logo.svg',

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -1589,7 +1589,7 @@ if (!class_exists('WC_Twoinc')) {
                             </div>
                         <?php else: ?>
                             <div style="margin-top: 8px; color: #666; font-size: 13px;">
-                                <strong><?php printf(__('Don\'t have an API key? Get one by signing up <a href=\'%s\'>here</a>.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('merchant_signup_url')); ?></strong>
+                                <strong><?php printf(__('Don\'t have an API key? Get one by signing up <a href=\'%s\'>here</a>.', 'twoinc-payment-gateway'), esc_url(WC_Twoinc_Brand::get('sign_up_url'))); ?></strong>
                             </div>
                         <?php endif; ?>
                         <?php echo $this->get_description_html($data); // WPCS: XSS ok.

--- a/class/WC_Twoinc_Brand.php
+++ b/class/WC_Twoinc_Brand.php
@@ -69,8 +69,20 @@ if (!class_exists('WC_Twoinc_Brand')) {
             }
 
             $config = $defaults;
-            if ($brand_file && is_file($brand_file)) {
-                $config = array_merge($defaults, (array) require $brand_file);
+            // Defence in depth: a filter-supplied path must be a real .php
+            // file inside the plugins (or mu-plugins) tree. Co-resident
+            // plugins are trusted code, but this keeps the loader from ever
+            // require-ing uploads or other writable paths.
+            if ($brand_file && is_file($brand_file) && substr($brand_file, -4) === '.php') {
+                $real = realpath($brand_file);
+                $plugin_root = defined('WP_PLUGIN_DIR') ? realpath(WP_PLUGIN_DIR) : false;
+                $mu_root = defined('WPMU_PLUGIN_DIR') ? realpath(WPMU_PLUGIN_DIR) : false;
+                $inside = static function ($root) use ($real) {
+                    return $root && $real && strpos($real, $root . DIRECTORY_SEPARATOR) === 0;
+                };
+                if ($real && (!$plugin_root && !$mu_root || $inside($plugin_root) || $inside($mu_root))) {
+                    $config = array_merge($defaults, (array) require $real);
+                }
             }
 
             self::$config = $config;

--- a/dev/configure
+++ b/dev/configure
@@ -22,5 +22,4 @@ if [ -n "$TWO_API_BASE_URL" ]; then
     wp option patch update "$OPTION_KEY" test_checkout_host "$TWO_API_BASE_URL"
 fi
 
-echo "Configured $OPTION_KEY:"
-wp option patch get "$OPTION_KEY" test_checkout_host
+echo "Configured $OPTION_KEY (test_checkout_host: $(wp option pluck "$OPTION_KEY" test_checkout_host || echo unset))"

--- a/dev/configure
+++ b/dev/configure
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Write the gateway options from the TWO_* env vars into the running
+# WordPress. Runs inside the wpcli container:
+#   make configure
+# Idempotent — safe to re-run after editing .env (compose must be
+# recreated first so the container env updates: make run).
+set -e
+
+GATEWAY_ID="${TWO_GATEWAY_ID:-woocommerce-gateway-tillit}"
+OPTION_KEY="woocommerce_${GATEWAY_ID}_settings"
+
+if ! wp option get "$OPTION_KEY" >/dev/null 2>&1; then
+    echo "Option $OPTION_KEY not found — seeding from ${WOOCOM_PLUGIN_CONFIG_JSON:-docker/config/local.json}"
+    wp option update "$OPTION_KEY" --format=json \
+        <"/opt/tillit-payment-gateway/${WOOCOM_PLUGIN_CONFIG_JSON:-docker/config/local.json}"
+fi
+
+if [ -n "$TWO_API_KEY" ]; then
+    wp option patch update "$OPTION_KEY" api_key "$TWO_API_KEY"
+fi
+if [ -n "$TWO_API_BASE_URL" ]; then
+    wp option patch update "$OPTION_KEY" test_checkout_host "$TWO_API_BASE_URL"
+fi
+
+echo "Configured $OPTION_KEY:"
+wp option patch get "$OPTION_KEY" test_checkout_host

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,8 @@ services:
       WORDPRESS_HOME: "http://localhost:8888"
       WORDPRESS_SITEURL: "http://localhost:8888"
       WORDPRESS_DEBUG: "true"
+      # Brand override for the plugin's WC_Twoinc_Brand loader (dev only)
+      TWO_BRAND_CODE: "${TWO_BRAND_CODE:-}"
     volumes:
       - ./volumes/wordpress:/var/www/html
       - .:/var/www/html/wp-content/plugins/tillit-payment-gateway
@@ -45,12 +47,13 @@ services:
       WORDPRESS_ADMIN_USER: admin
       WORDPRESS_ADMIN_PASSWORD: twoinb2b
       WORDPRESS_ADMIN_EMAIL: admin@two.inc
-      WOOCOM_PLUGIN_CONFIG_JSON: docker/config/staging-tillittestuk.json
-      WOOCOM_CURRENCY: GBP
-      WOOCOM_DEFAULT_COUNTRY: GB
-      WOOCOM_VERSION: 9.9.5
-      # WOOCOM_VERSION: 8.9.5
-      # WOOCOM_VERSION: 7.9.1
+      WOOCOM_PLUGIN_CONFIG_JSON: "${WOOCOM_PLUGIN_CONFIG_JSON:-docker/config/local.json}"
+      WOOCOM_CURRENCY: "${WOOCOM_CURRENCY:-GBP}"
+      WOOCOM_DEFAULT_COUNTRY: "${WOOCOM_DEFAULT_COUNTRY:-GB}"
+      WOOCOM_VERSION: "${WOOCOM_VERSION:-9.9.5}"
+      TWO_BRAND_CODE: "${TWO_BRAND_CODE:-}"
+      TWO_API_KEY: "${TWO_API_KEY:-}"
+      TWO_API_BASE_URL: "${TWO_API_BASE_URL:-}"
     volumes:
       - ./volumes/wordpress:/var/www/html
       - .:/opt/tillit-payment-gateway

--- a/docker/wpcli.sh
+++ b/docker/wpcli.sh
@@ -26,11 +26,15 @@ until wp plugin activate tillit-payment-gateway; do
 done
 set -e
 PLUGIN_CONFIG="/opt/tillit-payment-gateway/${WOOCOM_PLUGIN_CONFIG_JSON:-docker/config/local.json}"
+# Settings option key follows the gateway id, which follows the brand
+OPTION_KEY="woocommerce_${TWO_GATEWAY_ID:-woocommerce-gateway-tillit}_settings"
 if [ -f "$PLUGIN_CONFIG" ]; then
-  wp option update woocommerce_woocommerce-gateway-tillit_settings --format=json <"$PLUGIN_CONFIG"
+  wp option update "$OPTION_KEY" --format=json <"$PLUGIN_CONFIG"
 else
   echo "Warning: Plugin config not found at $PLUGIN_CONFIG, skipping settings load"
 fi
+# Env values (TWO_API_KEY / TWO_API_BASE_URL) override the JSON
+bash /opt/tillit-payment-gateway/dev/configure
 wp post update $(wp option get woocommerce_checkout_page_id) --post_content='[woocommerce_checkout]'
 wp post update $(wp option get woocommerce_cart_page_id) --post_content='[woocommerce_cart]'
 wp option update woocommerce_coming_soon no

--- a/docker/wpcli.sh
+++ b/docker/wpcli.sh
@@ -26,7 +26,9 @@ until wp plugin activate tillit-payment-gateway; do
 done
 set -e
 PLUGIN_CONFIG="/opt/tillit-payment-gateway/${WOOCOM_PLUGIN_CONFIG_JSON:-docker/config/local.json}"
-# Settings option key follows the gateway id, which follows the brand
+# Static fallback matching the two brand's gateway id; running the
+# harness as an overlay brand requires TWO_GATEWAY_ID to be set to the
+# overlay's id (and its plugin to be installed in the container)
 OPTION_KEY="woocommerce_${TWO_GATEWAY_ID:-woocommerce-gateway-tillit}_settings"
 if [ -f "$PLUGIN_CONFIG" ]; then
   wp option update "$OPTION_KEY" --format=json <"$PLUGIN_CONFIG"

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -104,7 +104,7 @@ final class BrandConfigSpec
         TinyAssert::same('two', WC_Twoinc_Brand::get('code'));
         TinyAssert::same('Two', WC_Twoinc_Brand::get('product_name'));
         TinyAssert::same('Two', WC_Twoinc_Brand::get('provider'));
-        TinyAssert::same('https://portal.two.inc/auth/merchant/signup', WC_Twoinc_Brand::get('merchant_signup_url'));
+        TinyAssert::same('https://portal.two.inc/auth/merchant/signup', WC_Twoinc_Brand::get('sign_up_url'));
         TinyAssert::same(WC_TWOINC_PLUGIN_URL . 'assets/images/two-logo.svg', WC_Twoinc_Brand::get('logo_url'));
         TinyAssert::same('Business invoice - %s days', WC_Twoinc_Brand::get('title_default'));
         TinyAssert::same(null, WC_Twoinc_Brand::get('not_a_key'));
@@ -123,7 +123,9 @@ final class BrandConfigSpec
         TinyAssert::same(WC_Twoinc::PROVIDER, WC_Twoinc_Brand::get('provider'));
         TinyAssert::same(WC_Twoinc::PROVIDER_FULL_NAME, WC_Twoinc_Brand::get('provider_full_name'));
         TinyAssert::same(WC_Twoinc::PRODUCT_NAME, WC_Twoinc_Brand::get('product_name'));
-        TinyAssert::same(WC_Twoinc::MERCHANT_SIGNUP_URL, WC_Twoinc_Brand::get('merchant_signup_url'));
+        // Constant name keeps its BC spelling; the brand key uses the
+        // cross-plugin canonical sign_up_url (Magento's spelling)
+        TinyAssert::same(WC_Twoinc::MERCHANT_SIGNUP_URL, WC_Twoinc_Brand::get('sign_up_url'));
         TinyAssert::same(WC_Twoinc::ALERT_EMAIL_ADDRESS, WC_Twoinc_Brand::get('alert_email_address'));
     }
 


### PR DESCRIPTION
## What

D1 of the plugin parity plan (TWO-24739 → TWO-24747). **Ticket premise correction**: the compose stack (wordpress + wpcli provisioner + mariadb, product seeding, plugin activation, config JSON) already existed — this PR adds the missing ergonomics, not the environment.

**Stacked on #321** (needs the brand layer's `TWO_BRAND_CODE` handling).

## How

- `.env.example` → copy to `.env` (compose's native env file — the ticket's `.env.local` spelling diverged from the repo's existing `.env` convention; code wins): `TWO_API_BASE_URL`, `TWO_API_KEY`, `TWO_BRAND_CODE`, WooCommerce knobs.
- Compose passes `TWO_BRAND_CODE` into the WordPress container (PHP `getenv` → `WC_Twoinc_Brand`) and parameterises the provisioning vars with the previous hardcoded values as defaults.
- `dev/configure`: idempotent wp-cli script writing `TWO_API_KEY`/`TWO_API_BASE_URL` onto the gateway settings; runs at first provision and via `make configure`.
- `docker/wpcli.sh` now derives the settings option key from the gateway id (was hardcoded — a brand-override run would have seeded the wrong option row).
- Makefile: `install` / `run` / `configure` / `logs` / `logs-wpcli` / `stop` / `clean` / `test-unit` / `test` / `format`. `make test-unit` runs the TWO-24744 unit harness in a `php:8.2` container — the ticket's "establish PHPUnit baseline" is superseded by that suite (deliberately dependency-free; CI already runs it on 7.4+8.2).

## Test plan

- [x] `docker compose config` valid; `bash -n` on both scripts
- [x] `make test-unit` green (19/19)
- [ ] Fresh `make clean && make install` provision on a dev box, checkout loads, `make configure` round-trips an api-key change

🤖 Generated with [Claude Code](https://claude.com/claude-code)