### PR TITLE
TWO-24751/feat: Payment terms chip selector and offset pricing fee

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -178,3 +178,36 @@
   position: absolute;
   right: 4px;
 }
+
+/* Payment terms chip selector (TWO-24751) */
+.twoinc-term-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 8px 0;
+}
+.twoinc-term-chips.hidden {
+  display: none;
+}
+.twoinc-term-chip {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 6px 14px;
+  border: 1px solid #c4c9e8;
+  border-radius: 16px;
+  background: #fff;
+  cursor: pointer;
+  line-height: 1.3;
+}
+.twoinc-term-chip--selected {
+  border-color: #3043d1;
+  background: #eef0fb;
+}
+.twoinc-term-chip--single {
+  cursor: default;
+}
+.twoinc-term-chip__fee {
+  font-size: 0.85em;
+  color: #3043d1;
+}

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -876,6 +876,116 @@ let twoincDomHelper = {
   }
 };
 
+/**
+ * Payment terms chip selector — presentation only (TWO-24751).
+ *
+ * All business logic (term availability, fee quoting, selection
+ * validation) lives in WC_Twoinc_Payment_Terms; this module renders the
+ * data the wc-ajax endpoints return and posts the buyer's selection back.
+ */
+let twoincTermChips = {
+  fees: {},
+
+  config: function () {
+    return (window.twoinc && window.twoinc.payment_terms) || { enabled: false };
+  },
+
+  /**
+   * Re-render the chips after every checkout update (cart changes move
+   * the fee quotes, so re-fetch then re-render).
+   */
+  refresh: function () {
+    const cfg = twoincTermChips.config();
+    const $container = jQuery(".twoinc-term-chips");
+    if (!cfg.enabled || !cfg.terms || cfg.terms.length === 0 || $container.length === 0) {
+      return;
+    }
+    $container.removeClass("hidden");
+    twoincTermChips.render(cfg.terms, cfg.selected);
+
+    if (cfg.offset_pricing_enabled && cfg.fees_url) {
+      jQuery
+        .post(cfg.fees_url)
+        .done(function (response) {
+          if (response && response.success && response.data) {
+            twoincTermChips.fees = response.data.fees || {};
+            twoincTermChips.render(response.data.terms, response.data.selected);
+          }
+        })
+        .fail(function () {
+          // Fee labels are decorative: chips stay usable without them.
+        });
+    }
+  },
+
+  render: function (terms, selected) {
+    const $container = jQuery(".twoinc-term-chips");
+    if ($container.length === 0) return;
+    $container.empty();
+
+    const single = terms.length === 1;
+    terms.forEach(function (days) {
+      const isSelected = days === selected;
+      const $chip = jQuery("<button>", {
+        type: "button",
+        class:
+          "twoinc-term-chip" +
+          (isSelected ? " twoinc-term-chip--selected" : "") +
+          (single ? " twoinc-term-chip--single" : ""),
+        role: "radio",
+        "aria-checked": isSelected ? "true" : "false",
+        "data-days": days,
+        disabled: single
+      });
+      const daysLabel = (twoincTermChips.config().days_label || "%s days").replace("%s", days);
+      $chip.append(jQuery("<span>", { class: "twoinc-term-chip__days", text: daysLabel }));
+
+      const fee = twoincTermChips.fees[days];
+      if (fee && parseFloat(fee.buyer_fee_share) > 0) {
+        $chip.append(
+          jQuery("<span>", {
+            class: "twoinc-term-chip__fee",
+            text: "+" + fee.buyer_fee_share + " " + fee.currency
+          })
+        );
+      }
+      if (!single) {
+        $chip.on("click", function () {
+          twoincTermChips.select(days);
+        });
+      }
+      $container.append($chip);
+    });
+
+    // The selection rides the checkout form post so process_payment can
+    // validate it without depending on the session.
+    let $hidden = $container.find("input[name='two_selected_term']");
+    if ($hidden.length === 0) {
+      $hidden = jQuery("<input>", { type: "hidden", name: "two_selected_term" });
+      $container.append($hidden);
+    }
+    $hidden.val(selected);
+  },
+
+  select: function (days) {
+    const cfg = twoincTermChips.config();
+    if (!cfg.select_url) return;
+    jQuery
+      .post(cfg.select_url, { days: days })
+      .done(function (response) {
+        if (response && response.success && response.data) {
+          cfg.selected = response.data.selected;
+          // Recalculate totals so the offset fee follows the new term;
+          // updated_checkout then re-renders the chips.
+          jQuery(document.body).trigger("update_checkout");
+        }
+      })
+      .fail(function () {
+        // Keep the previous selection on failure.
+      });
+  }
+};
+
 class Twoinc {
   constructor() {
     if (instance) {
@@ -1398,6 +1508,8 @@ class Twoinc {
     });
 
     twoincDomHelper.rearrangeDescription();
+
+    twoincTermChips.refresh();
   }
 
   /**

--- a/brands/two.php
+++ b/brands/two.php
@@ -3,7 +3,7 @@
 /**
  * Two brand configuration — the default brand of the base plugin.
  *
- * A brand overlay plugin (e.g. the ABN AMRO edition) supplies its own
+ * A brand overlay plugin supplies its own
  * file with the same shape via the `twoinc_brand_file` filter; its
  * values are merged over these defaults, so an overlay declares only
  * what differs.

--- a/brands/two.php
+++ b/brands/two.php
@@ -41,4 +41,12 @@ return [
     // (merchant-saved titles always win). sprintf'd with the invoice
     // day count, so a brand default may carry one %s.
     'title_default' => 'Business invoice - %s days',
+    // Terms the brand may offer in the checkout chip selector (the
+    // merchant narrows the set in settings; WC_Twoinc_Payment_Terms is
+    // the only reader). Mirrors the Magento brand descriptor's
+    // available_payment_terms.
+    'available_terms' => [14, 30, 60, 90],
+    // Buyer-facing label for the offset-pricing fee line; null uses the
+    // translated "Service charge" default.
+    'fee_line_label' => null,
 ];

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -79,6 +79,13 @@ if (!class_exists('WC_Twoinc')) {
             // when unmet. Config-driven; the Two brand sets no gate.
             add_filter('woocommerce_available_payment_gateways', [$this, 'apply_brand_availability_gate']);
 
+            // Payment terms chip selector + offset pricing fee (TWO-24751).
+            // Business logic lives in WC_Twoinc_Payment_Terms; the JS layer
+            // renders only what these endpoints return.
+            add_action('woocommerce_cart_calculate_fees', ['WC_Twoinc_Payment_Terms', 'apply_cart_fee']);
+            add_action('wc_ajax_two_term_fees', ['WC_Twoinc_Payment_Terms', 'ajax_term_fees']);
+            add_action('wc_ajax_two_select_term', ['WC_Twoinc_Payment_Terms', 'ajax_select_term']);
+
             if (is_admin()) {
                 // Notice banner if plugin is not setup properly
 
@@ -276,6 +283,7 @@ if (!class_exists('WC_Twoinc')) {
             return sprintf(
                 '<div>
                     <div class="twoinc-pay-box twoinc-explainer">%s</div>
+                    <div class="twoinc-term-chips hidden" role="radiogroup"></div>
                     <div class="twoinc-pay-box twoinc-loader hidden"></div>
                     <div class="twoinc-pay-box twoinc-intent-approved hidden">%s</div>
                     <div class="twoinc-pay-box twoinc-err-payment-default hidden">%s</div>
@@ -286,6 +294,22 @@ if (!class_exists('WC_Twoinc')) {
                 sprintf(__('Invoice purchase with %s is not available for this order.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')),
                 __('Phone number is invalid.', 'twoinc-payment-gateway')
             );
+        }
+
+        /**
+         * Admin option list of the brand's term days, for the payment-terms
+         * settings fields.
+         *
+         * @return array<string, string>
+         */
+        private function get_payment_term_day_options(): array
+        {
+            $options = [];
+            $brand_terms = WC_Twoinc_Brand::get('available_terms');
+            foreach (is_array($brand_terms) ? $brand_terms : [] as $days) {
+                $options[strval((int) $days)] = sprintf(__('%s days', 'twoinc-payment-gateway'), (int) $days);
+            }
+            return $options;
         }
 
         /**
@@ -1111,6 +1135,11 @@ if (!class_exists('WC_Twoinc')) {
             $vendor_name = $this->get_option('vendor_name');
             $order->update_meta_data('vendor_name', $vendor_name);
 
+            $payment_terms = WC_Twoinc_Payment_Terms::get_order_payload_terms($this, $order);
+            if ($payment_terms) {
+                $order->update_meta_data(WC_Twoinc_Brand::meta_key('selected_term_days'), $payment_terms['terms']['duration_days']);
+            }
+
             $order->save();
 
             // Save to user meta
@@ -1144,7 +1173,9 @@ if (!class_exists('WC_Twoinc')) {
                 $payment_reference,
                 $payment_reference_type,
                 $vendor_name,
-                $tracking_id
+                $tracking_id,
+                false,
+                $payment_terms
             ));
 
             if (is_wp_error($response)) {
@@ -1663,6 +1694,58 @@ if (!class_exists('WC_Twoinc')) {
                     'label'       => ' ',
                     'type'        => 'checkbox',
                     'default'     => 'yes'
+                ],
+                'section_payment_terms' => [
+                    'type'  => 'title',
+                    'title' => __('Payment terms and offset pricing', 'twoinc-payment-gateway'),
+                ],
+                'enable_payment_terms' => [
+                    'title'       => __('Enable payment terms selection', 'twoinc-payment-gateway'),
+                    'description' => __('Lets the buyer choose their invoice term at checkout from the terms offered below.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'label'       => ' ',
+                    'type'        => 'checkbox',
+                    'default'     => 'no'
+                ],
+                'payment_terms_days' => [
+                    'title'       => __('Offered terms', 'twoinc-payment-gateway'),
+                    'description' => __('Terms shown to the buyer. Leave empty to offer all terms available to this brand.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'type'        => 'multiselect',
+                    'class'       => 'wc-enhanced-select',
+                    'options'     => $this->get_payment_term_day_options(),
+                    'default'     => []
+                ],
+                'default_payment_term' => [
+                    'title'       => __('Default term', 'twoinc-payment-gateway'),
+                    'description' => __('Pre-selected term at checkout. Falls back to the shortest offered term.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'type'        => 'select',
+                    'options'     => $this->get_payment_term_day_options(),
+                    'default'     => ''
+                ],
+                'enable_offset_pricing' => [
+                    'title'       => __('Enable offset pricing', 'twoinc-payment-gateway'),
+                    'description' => __('Passes some or all of the service fee to the buyer as a separate line at checkout. The fee is computed by the platform pricing service.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'label'       => ' ',
+                    'type'        => 'checkbox',
+                    'default'     => 'no'
+                ],
+                'offset_pricing_percentage' => [
+                    'title'       => __('Fee pass-through percentage', 'twoinc-payment-gateway'),
+                    'description' => __('How much of the fee the buyer pays, 0-100. Invalid values fall back to 100.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'type'        => 'text',
+                    'default'     => '100'
+                ],
+                'offset_pricing_reference_days' => [
+                    'title'       => __('Reference term (incremental mode)', 'twoinc-payment-gateway'),
+                    'description' => __('When set, the buyer only pays the fee difference versus this baseline term (the baseline term itself shows no surcharge). When unset, the configured percentage of the full fee is passed through.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'type'        => 'select',
+                    'options'     => ['' => __('None - simple pass-through', 'twoinc-payment-gateway')] + $this->get_payment_term_day_options(),
+                    'default'     => ''
                 ],
                 'section_debug' => [
                     'type'  => 'title',

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -52,7 +52,7 @@ if (!class_exists('WC_Twoinc')) {
             );
             /**
              * Filter the checkout payment-box description so a brand
-             * overlay can replace the copy wholesale (the ABN edition
+             * overlay can replace the copy wholesale (a brand overlay
              * ships its own bullet list).
              *
              * Applied once at gateway construction: like
@@ -263,7 +263,7 @@ if (!class_exists('WC_Twoinc')) {
             /**
              * Filter the "about" block inside the payment-box subtitle —
              * the piece of the description brand overlays actually
-             * replace (the ABN edition ships its own bullet list).
+             * replace (a brand overlay ships its own bullet list).
              * Register by plugins_loaded (computed at gateway
              * construction).
              *
@@ -861,7 +861,7 @@ if (!class_exists('WC_Twoinc')) {
         /**
          * Remove the gateway from checkout when the brand's availability
          * gate (availability_gate in the brand config) is unmet. Mirrors
-         * the ABN fork's gate semantics: front-end only, minimum is
+         * Brand availability gate semantics: front-end only, minimum is
          * inclusive (an exactly-minimum basket passes).
          *
          * @param array $available_gateways
@@ -886,8 +886,8 @@ if (!class_exists('WC_Twoinc')) {
             }
 
             // Basket value on the configured basis: the platform minimum's
-            // basis is explicit (ABN's funding-partner rule is net; the
-            // platform's defaults are gross); the merchant minimum rides
+            // basis is explicit in brand config (funding-partner rules
+            // and platform defaults may differ); the merchant minimum rides
             // the same basis when a platform minimum exists.
             $basis = $gate ? $gate['basis'] : ($merchant_minimum['basis'] ?? 'gross');
             $basket_value = $basis === 'gross'
@@ -1038,7 +1038,7 @@ if (!class_exists('WC_Twoinc')) {
 
         /**
          * Brand veto on payment processing, resolved via the
-         * twoinc_payment_validation_error filter (e.g. the ABN edition's
+         * twoinc_payment_validation_error filter (e.g. a brand overlay's
          * required terms-acceptance checkbox). Returns the buyer-facing
          * error message, or null to proceed.
          *

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -2133,7 +2133,7 @@ if (!class_exists('WC_Twoinc')) {
          *
          * @return WP_Error|array
          */
-        private function make_request($endpoint, $payload = [], $method = 'POST', $params = array(), $api_key_override = null)
+        public function make_request($endpoint, $payload = [], $method = 'POST', $params = array(), $api_key_override = null)
         {
             $params['client'] = 'wp';
             $params['client_v'] = get_twoinc_plugin_version();

--- a/class/WC_Twoinc_Brand.php
+++ b/class/WC_Twoinc_Brand.php
@@ -107,7 +107,7 @@ if (!class_exists('WC_Twoinc_Brand')) {
         /**
          * Brand-prefixed hidden order meta key, e.g. 'order_reference'
          * -> '_twoinc_order_reference'. Live stores hold data under the
-         * brand's prefix (ABN stores hold _abn_*), so the prefix is
+         * brand's prefix (a brand overlay uses its own prefix), so the prefix is
          * load-bearing for existing orders — never hardcode the literal.
          *
          * @param string $name

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -256,6 +256,18 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                 'twoinc_plugin_url' => WC_TWOINC_PLUGIN_URL,
                 'client_name' => 'wp',
                 'client_version' => get_twoinc_plugin_version(),
+                // Chip selector bootstrap (TWO-24751). JS renders only; the
+                // live data (fees, selection) comes from the wc-ajax
+                // endpoints in WC_Twoinc_Payment_Terms.
+                'payment_terms' => [
+                    'days_label' => __('%s days', 'twoinc-payment-gateway'),
+                    'enabled' => WC_Twoinc_Payment_Terms::is_enabled($this->wc_twoinc),
+                    'terms' => WC_Twoinc_Payment_Terms::get_available_terms($this->wc_twoinc),
+                    'selected' => WC_Twoinc_Payment_Terms::get_selected_term($this->wc_twoinc),
+                    'offset_pricing_enabled' => WC_Twoinc_Payment_Terms::get_offset_settings($this->wc_twoinc)['enabled'],
+                    'fees_url' => class_exists('WC_AJAX') ? WC_AJAX::get_endpoint('two_term_fees') : '',
+                    'select_url' => class_exists('WC_AJAX') ? WC_AJAX::get_endpoint('two_select_term') : '',
+                ],
             ];
 
             $user_id = wp_get_current_user()->ID;

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -485,7 +485,8 @@ if (!class_exists('WC_Twoinc_Helper')) {
             $payment_reference_type = '',
             $vendor_name = '',
             $tracking_id = '',
-            $skip_nonce = false
+            $skip_nonce = false,
+            $payment_terms = null
         ) {
 
             $billing_address = [
@@ -572,6 +573,13 @@ if (!class_exists('WC_Twoinc_Helper')) {
 
             if ($vendor_name) {
                 $req_body['vendor_name'] = $vendor_name;
+            }
+
+            // Buyer-selected payment term + the offered set (TWO-24751);
+            // shape from WC_Twoinc_Payment_Terms::get_order_payload_terms.
+            if ($payment_terms) {
+                $req_body['terms'] = $payment_terms['terms'];
+                $req_body['available_terms'] = $payment_terms['available_terms'];
             }
 
             if (!$skip_nonce) {

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -1,0 +1,348 @@
+<?php
+
+/**
+ * Payment terms chip selector + offset pricing fee — business logic (TWO-24751).
+ *
+ * All term/fee decisioning lives here; assets/js/twoinc.js only renders what
+ * these methods return (the Gutenberg block checkout port must not need a
+ * business-logic rewrite, see TWO-24767).
+ *
+ * Term availability: `get_available_terms()` is the single seam. Today it
+ * resolves brand config (`available_terms`) intersected with the merchant's
+ * admin subset; when the backend grows a term-availability surface (planned
+ * convergence — backend owns which terms are offered) only this method
+ * changes. Do not read term lists anywhere else.
+ *
+ * Fee arithmetic is never done plugin-side: the offset settings are posted to
+ * POST /v1/pricing/order/fee as a `buyer_fee_share` block and the backend
+ * computes the buyer's share (mirrors Magento's SurchargeCalculator).
+ */
+
+if (!class_exists('WC_Twoinc_Payment_Terms')) {
+    class WC_Twoinc_Payment_Terms
+    {
+        public const SESSION_KEY = 'two_selected_term';
+
+        /** @var array<int, array|null> request-scoped fee quote cache, keyed by term days */
+        private static $fee_cache = [];
+
+        /**
+         * Whether the chip selector is active: merchant enabled it and the
+         * resolved term set is non-empty.
+         */
+        public static function is_enabled($gateway): bool
+        {
+            return $gateway->get_option('enable_payment_terms') === 'yes'
+                && count(self::get_available_terms($gateway)) > 0;
+        }
+
+        /**
+         * The terms offered at checkout, ascending. THE availability seam —
+         * see the file header before adding another term-list read.
+         *
+         * @return int[]
+         */
+        public static function get_available_terms($gateway): array
+        {
+            $brand_terms = WC_Twoinc_Brand::get('available_terms');
+            if (!is_array($brand_terms) || count($brand_terms) === 0) {
+                return [];
+            }
+            $brand_terms = array_map('intval', $brand_terms);
+
+            $admin_subset = $gateway->get_option('payment_terms_days');
+            if (is_array($admin_subset) && count($admin_subset) > 0) {
+                $admin_subset = array_map('intval', $admin_subset);
+                $terms = array_values(array_intersect($brand_terms, $admin_subset));
+            } else {
+                $terms = $brand_terms;
+            }
+
+            $terms = array_values(array_unique(array_filter($terms, static function ($days) {
+                return $days > 0;
+            })));
+            sort($terms);
+            return $terms;
+        }
+
+        /**
+         * The pre-selected term: the merchant's configured default when it is
+         * in the available set, else the shortest available term.
+         */
+        public static function get_default_term($gateway): ?int
+        {
+            $terms = self::get_available_terms($gateway);
+            if (count($terms) === 0) {
+                return null;
+            }
+            $configured = (int) $gateway->get_option('default_payment_term');
+            return in_array($configured, $terms, true) ? $configured : $terms[0];
+        }
+
+        /**
+         * The buyer's current selection from the WC session, validated against
+         * the available set (an invalid or stale selection falls back to the
+         * default rather than erroring).
+         */
+        public static function get_selected_term($gateway): ?int
+        {
+            $terms = self::get_available_terms($gateway);
+            if (count($terms) === 0) {
+                return null;
+            }
+            $session = function_exists('WC') ? (WC()->session ?? null) : null;
+            $selected = $session ? (int) $session->get(self::SESSION_KEY) : 0;
+            return in_array($selected, $terms, true) ? $selected : self::get_default_term($gateway);
+        }
+
+        /**
+         * Store the buyer's selection. Returns the term actually stored
+         * (invalid input resolves to the default).
+         */
+        public static function set_selected_term($gateway, $days): ?int
+        {
+            $terms = self::get_available_terms($gateway);
+            $days = (int) $days;
+            if (!in_array($days, $terms, true)) {
+                $days = self::get_default_term($gateway);
+            }
+            if (function_exists('WC') && (WC()->session ?? null)) {
+                WC()->session->set(self::SESSION_KEY, $days);
+            }
+            return $days;
+        }
+
+        /**
+         * Offset pricing settings resolved from gateway options.
+         *
+         * @return array{enabled: bool, percentage: string, reference_days: int|null}
+         */
+        public static function get_offset_settings($gateway): array
+        {
+            $reference_days = (int) $gateway->get_option('offset_pricing_reference_days');
+            $percentage = trim((string) $gateway->get_option('offset_pricing_percentage'));
+            if ($percentage === '' || !is_numeric($percentage) || (float) $percentage < 0 || (float) $percentage > 100) {
+                $percentage = '100';
+            }
+            return [
+                'enabled' => $gateway->get_option('enable_offset_pricing') === 'yes',
+                'percentage' => $percentage,
+                'reference_days' => $reference_days > 0 ? $reference_days : null,
+            ];
+        }
+
+        /**
+         * The buyer_fee_share block for POST /v1/pricing/order/fee. The
+         * backend computes the fee from this; the plugin does no arithmetic.
+         * With reference terms configured the backend prices the increment
+         * over the baseline term; without them, plain pass-through.
+         *
+         * @return array|null null when offset pricing is disabled
+         */
+        public static function build_buyer_fee_share($gateway): ?array
+        {
+            $settings = self::get_offset_settings($gateway);
+            if (!$settings['enabled']) {
+                return null;
+            }
+            $buyer_fee_share = ['percentage' => $settings['percentage']];
+            if ($settings['reference_days'] !== null) {
+                $buyer_fee_share['reference_terms'] = [
+                    'type' => 'NET_TERMS',
+                    'duration_days' => $settings['reference_days'],
+                ];
+            }
+            return $buyer_fee_share;
+        }
+
+        /**
+         * Quote the buyer's fee share for one term via the pricing endpoint.
+         * Fail-soft: returns null on any error (chip renders without a fee
+         * label; checkout is never blocked on a quote).
+         *
+         * @return array{buyer_fee_share: string, total_fee_tax_rate: string|null, currency: string}|null
+         */
+        public static function fetch_term_fee($gateway, int $days, float $gross_amount, string $buyer_country): ?array
+        {
+            if (array_key_exists($days, self::$fee_cache)) {
+                return self::$fee_cache[$days];
+            }
+
+            $buyer_fee_share = self::build_buyer_fee_share($gateway);
+            if ($buyer_fee_share === null || $gross_amount <= 0) {
+                return self::$fee_cache[$days] = null;
+            }
+
+            $response = $gateway->make_request('/v1/pricing/order/fee', [
+                'currency' => get_woocommerce_currency(),
+                'gross_amount' => strval(WC_Twoinc_Helper::round_amt($gross_amount)),
+                'buyer_country_code' => $buyer_country,
+                'order_terms' => [
+                    'type' => 'NET_TERMS',
+                    'duration_days' => $days,
+                ],
+                'buyer_fee_share' => $buyer_fee_share,
+            ]);
+
+            if (is_wp_error($response)) {
+                return self::$fee_cache[$days] = null;
+            }
+            $body = json_decode($response['body'] ?? '', true);
+            if (!is_array($body) || !isset($body['buyer_fee_share'])) {
+                return self::$fee_cache[$days] = null;
+            }
+
+            return self::$fee_cache[$days] = [
+                'buyer_fee_share' => strval($body['buyer_fee_share']),
+                'total_fee_tax_rate' => isset($body['total_fee_tax_rate']) ? strval($body['total_fee_tax_rate']) : null,
+                'currency' => strval($body['currency'] ?? get_woocommerce_currency()),
+            ];
+        }
+
+        /**
+         * Quote all available terms for the chip labels.
+         *
+         * @return array<int, array|null> keyed by term days
+         */
+        public static function fetch_term_fees($gateway, float $gross_amount, string $buyer_country): array
+        {
+            $fees = [];
+            foreach (self::get_available_terms($gateway) as $days) {
+                $fees[$days] = self::fetch_term_fee($gateway, $days, $gross_amount, $buyer_country);
+            }
+            return $fees;
+        }
+
+        /**
+         * The fee-quote basis: the cart's value excluding any fee this class
+         * added (the platform-rate-converted/priced fee enters the basket at
+         * the pricing endpoint's output and must not feed back into its own
+         * basis).
+         */
+        public static function get_fee_basis($cart): float
+        {
+            return (float) $cart->get_cart_contents_total()
+                + (float) $cart->get_cart_contents_tax()
+                + (float) $cart->get_shipping_total()
+                + (float) $cart->get_shipping_tax();
+        }
+
+        /**
+         * woocommerce_cart_calculate_fees hook: charge the buyer's fee share
+         * for the selected term as a WC cart fee. The amount from the pricing
+         * endpoint is net; WC applies the store's tax handling to the fee so
+         * the order's internal net + tax = gross consistency holds (the same
+         * posture as Magento's store-configured surcharge tax rate).
+         */
+        public static function apply_cart_fee($cart): void
+        {
+            $gateway = WC_Twoinc::get_instance();
+            if (!$gateway || !self::is_enabled($gateway)) {
+                return;
+            }
+            $settings = self::get_offset_settings($gateway);
+            if (!$settings['enabled']) {
+                return;
+            }
+            // Only charge when paying with this gateway
+            $chosen = function_exists('WC') && (WC()->session ?? null) ? WC()->session->get('chosen_payment_method') : null;
+            if ($chosen && $chosen !== $gateway->id) {
+                return;
+            }
+
+            $selected = self::get_selected_term($gateway);
+            if ($selected === null) {
+                return;
+            }
+
+            $customer = function_exists('WC') ? (WC()->customer ?? null) : null;
+            $buyer_country = $customer ? $customer->get_billing_country() : '';
+            $fee = self::fetch_term_fee($gateway, $selected, self::get_fee_basis($cart), $buyer_country);
+            if ($fee === null || (float) $fee['buyer_fee_share'] <= 0) {
+                return;
+            }
+
+            $cart->add_fee(self::get_fee_label(), (float) $fee['buyer_fee_share'], true);
+        }
+
+        /**
+         * Buyer-facing label for the fee line, brand-overridable.
+         */
+        public static function get_fee_label(): string
+        {
+            $label = WC_Twoinc_Brand::get('fee_line_label');
+            return $label ?: __('Service charge', 'twoinc-payment-gateway');
+        }
+
+        /**
+         * wc-ajax handler: per-term fee quotes for the chip labels.
+         */
+        public static function ajax_term_fees(): void
+        {
+            $gateway = WC_Twoinc::get_instance();
+            if (!$gateway || !self::is_enabled($gateway)) {
+                wp_send_json_error('Payment terms are not enabled');
+                return;
+            }
+            $cart = function_exists('WC') ? (WC()->cart ?? null) : null;
+            $customer = function_exists('WC') ? (WC()->customer ?? null) : null;
+            $basis = $cart ? self::get_fee_basis($cart) : 0.0;
+            $buyer_country = $customer ? $customer->get_billing_country() : '';
+
+            wp_send_json_success([
+                'terms' => self::get_available_terms($gateway),
+                'selected' => self::get_selected_term($gateway),
+                'fees' => self::fetch_term_fees($gateway, $basis, $buyer_country),
+            ]);
+        }
+
+        /**
+         * wc-ajax handler: persist the buyer's term selection in the session.
+         */
+        public static function ajax_select_term(): void
+        {
+            $gateway = WC_Twoinc::get_instance();
+            if (!$gateway || !self::is_enabled($gateway)) {
+                wp_send_json_error('Payment terms are not enabled');
+                return;
+            }
+            $days = isset($_POST['days']) ? (int) $_POST['days'] : 0;
+            $stored = self::set_selected_term($gateway, $days);
+            wp_send_json_success(['selected' => $stored]);
+        }
+
+        /**
+         * The terms block injected into the order create payload: the
+         * buyer's selected term plus the offered set (the backend records
+         * available_terms for parity with Magento's payload).
+         *
+         * @return array{terms: array, available_terms: int[]}|null
+         */
+        public static function get_order_payload_terms($gateway, $order): ?array
+        {
+            if (!self::is_enabled($gateway)) {
+                return null;
+            }
+            // The selection posts with the checkout form (hidden field kept in
+            // sync by JS) so order-pay-page submissions work without a session.
+            $posted = isset($_POST[self::SESSION_KEY]) ? (int) $_POST[self::SESSION_KEY] : 0;
+            $terms = self::get_available_terms($gateway);
+            $selected = in_array($posted, $terms, true) ? $posted : self::get_selected_term($gateway);
+            if ($selected === null) {
+                return null;
+            }
+            return [
+                'terms' => ['type' => 'NET_TERMS', 'duration_days' => $selected],
+                'available_terms' => $terms,
+            ];
+        }
+
+        /**
+         * Reset the request-scoped fee cache (tests).
+         */
+        public static function reset_fee_cache(): void
+        {
+            self::$fee_cache = [];
+        }
+    }
+}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -316,7 +316,17 @@ class StubOrder
     }
 }
 
+function is_wp_error($thing)
+{
+    return $thing instanceof WP_Error;
+}
+
+class WP_Error
+{
+}
+
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Brand.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Helper.php';
+require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Payment_Terms.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Checkout.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc.php';

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -49,6 +49,12 @@ final class BrandConfigSpec
             'testMerchantMinimumValidationSkipsFloorCheckAcrossCurrencies',
             'testPaymentValidationErrorFilterVetoes',
             'testConfirmationPageDetectionFollowsBrandPrefix',
+            'testPaymentTermsResolveBrandIntersectAdminSubset',
+            'testPaymentTermsDefaultFallsBackToShortest',
+            'testBuyerFeeShareShapes',
+            'testOrderPayloadCarriesSelectedAndAvailableTerms',
+            'testPaymentTermsInvalidPostFallsBackToDefault',
+            'testPaymentTermsDisabledMeansNoPayloadTerms',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -62,6 +68,8 @@ final class BrandConfigSpec
         WC_Twoinc_Brand::reset();
         putenv('TWO_BRAND_CODE');
         unset($GLOBALS['__twoinc_test_currency']);
+        unset($_POST[WC_Twoinc_Payment_Terms::SESSION_KEY]);
+        WC_Twoinc_Payment_Terms::reset_fee_cache();
         WC()->cart = null;
         WC()->customer = null;
         foreach (['twoinc_brand_file', 'twoinc_checkout_fields', 'twoinc_confirmation_url', 'twoinc_order_payload', 'twoinc_payment_terms_line', 'two_order_create', 'twoinc_payment_validation_error'] as $tag) {
@@ -455,6 +463,136 @@ final class BrandConfigSpec
         // merges harmlessly; all named keys keep their Two defaults.
         TinyAssert::same('Two', WC_Twoinc_Brand::get('product_name'));
         TinyAssert::same('woocommerce-gateway-tillit', WC_Twoinc_Brand::get('gateway_id'));
+    }
+
+    /**
+     * Gateway fake with configurable options for the payment-terms logic
+     * (the real gateway constructor needs a WooCommerce install).
+     */
+    private static function termsGateway(array $options): WC_Payment_Gateway
+    {
+        return new class ($options) extends WC_Payment_Gateway {
+            private $options;
+
+            public function __construct($options)
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+                $this->options = $options;
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $this->options[$key] ?? $empty_value ?? '';
+            }
+        };
+    }
+
+    private static function testPaymentTermsResolveBrandIntersectAdminSubset(): void
+    {
+        // Brand default set, no admin subset: all brand terms
+        $gateway = self::termsGateway(['enable_payment_terms' => 'yes']);
+        TinyAssert::same([14, 30, 60, 90], WC_Twoinc_Payment_Terms::get_available_terms($gateway));
+        TinyAssert::true(WC_Twoinc_Payment_Terms::is_enabled($gateway));
+
+        // Admin narrows within the brand set; entries outside it drop
+        $gateway = self::termsGateway(['enable_payment_terms' => 'yes', 'payment_terms_days' => ['60', '30', '7']]);
+        TinyAssert::same([30, 60], WC_Twoinc_Payment_Terms::get_available_terms($gateway));
+
+        // Feature off regardless of terms
+        $gateway = self::termsGateway(['enable_payment_terms' => 'no']);
+        TinyAssert::same(false, WC_Twoinc_Payment_Terms::is_enabled($gateway));
+    }
+
+    private static function testPaymentTermsDefaultFallsBackToShortest(): void
+    {
+        $gateway = self::termsGateway(['enable_payment_terms' => 'yes', 'default_payment_term' => '60']);
+        TinyAssert::same(60, WC_Twoinc_Payment_Terms::get_default_term($gateway));
+
+        // Configured default outside the offered set: shortest offered wins
+        $gateway = self::termsGateway([
+            'enable_payment_terms' => 'yes',
+            'payment_terms_days' => ['30', '90'],
+            'default_payment_term' => '60',
+        ]);
+        TinyAssert::same(30, WC_Twoinc_Payment_Terms::get_default_term($gateway));
+    }
+
+    private static function testBuyerFeeShareShapes(): void
+    {
+        // Disabled: no block at all
+        $gateway = self::termsGateway(['enable_offset_pricing' => 'no']);
+        TinyAssert::same(null, WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+
+        // Simple pass-through
+        $gateway = self::termsGateway(['enable_offset_pricing' => 'yes', 'offset_pricing_percentage' => '100']);
+        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+
+        // Partial pass-through
+        $gateway = self::termsGateway(['enable_offset_pricing' => 'yes', 'offset_pricing_percentage' => '50']);
+        TinyAssert::same(['percentage' => '50'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+
+        // Incremental: reference terms ride along
+        $gateway = self::termsGateway([
+            'enable_offset_pricing' => 'yes',
+            'offset_pricing_percentage' => '100',
+            'offset_pricing_reference_days' => '30',
+        ]);
+        TinyAssert::same(
+            ['percentage' => '100', 'reference_terms' => ['type' => 'NET_TERMS', 'duration_days' => 30]],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway)
+        );
+
+        // Malformed percentage falls back to full pass-through
+        $gateway = self::termsGateway(['enable_offset_pricing' => 'yes', 'offset_pricing_percentage' => '150']);
+        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+    }
+
+    private static function testOrderPayloadCarriesSelectedAndAvailableTerms(): void
+    {
+        $gateway = self::termsGateway(['enable_payment_terms' => 'yes']);
+        $_POST[WC_Twoinc_Payment_Terms::SESSION_KEY] = '60';
+
+        $payment_terms = WC_Twoinc_Payment_Terms::get_order_payload_terms($gateway, new StubOrder());
+        $body = WC_Twoinc_Helper::compose_twoinc_order(
+            new StubOrder(),
+            'test-order-reference',
+            '912345678',
+            '',
+            '',
+            '',
+            [],
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            false,
+            $payment_terms
+        );
+
+        TinyAssert::same(['type' => 'NET_TERMS', 'duration_days' => 60], $body['terms']);
+        TinyAssert::same([14, 30, 60, 90], $body['available_terms']);
+    }
+
+    private static function testPaymentTermsInvalidPostFallsBackToDefault(): void
+    {
+        $gateway = self::termsGateway(['enable_payment_terms' => 'yes', 'default_payment_term' => '30']);
+        $_POST[WC_Twoinc_Payment_Terms::SESSION_KEY] = '17';
+
+        $payment_terms = WC_Twoinc_Payment_Terms::get_order_payload_terms($gateway, new StubOrder());
+        TinyAssert::same(30, $payment_terms['terms']['duration_days']);
+    }
+
+    private static function testPaymentTermsDisabledMeansNoPayloadTerms(): void
+    {
+        $gateway = self::termsGateway(['enable_payment_terms' => 'no']);
+        TinyAssert::same(null, WC_Twoinc_Payment_Terms::get_order_payload_terms($gateway, new StubOrder()));
+
+        // And the composed body carries no terms keys at all
+        $body = self::composeOrder();
+        TinyAssert::same(false, array_key_exists('terms', $body));
+        TinyAssert::same(false, array_key_exists('available_terms', $body));
     }
 }
 

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -55,6 +55,7 @@ function load_twoinc_classes()
     // Load classes
     require_once __DIR__ . '/class/WC_Twoinc_Brand.php';
     require_once __DIR__ . '/class/WC_Twoinc_Helper.php';
+    require_once __DIR__ . '/class/WC_Twoinc_Payment_Terms.php';
     require_once __DIR__ . '/class/WC_Twoinc_Checkout.php';
     require_once __DIR__ . '/class/WC_Twoinc.php';
 


### PR DESCRIPTION
## What

Buyer-selectable invoice terms at checkout (chip selector, Magento parity) + optional offset pricing: the merchant's service fee passed to the buyer as a separate line, in three variants (simple 100%, partial percentage, incremental vs a reference term).

## Design

- **No plugin-side fee arithmetic.** Offset settings post to `POST /v1/pricing/order/fee` as a `buyer_fee_share` block; the backend's answer is charged verbatim (mirrors Magento's SurchargeCalculator pattern).
- **Business logic in PHP, JS renders only** (TWO-24751 checkout-type separation requirement; Gutenberg port needs only a new presentation layer). New `WC_Twoinc_Payment_Terms` class owns term resolution, selection validation, fee quoting, the cart fee, and payload terms. `twoinc.js` renders chips from two wc-ajax endpoints (`two_term_fees`, `two_select_term`).
- **Term availability behind a single seam.** `get_available_terms()` = brand `available_terms` (new key, 14/30/60/90 for Two) ∩ merchant admin subset. The planned backend term-availability surface replaces only this method — see the design-constraint comment on TWO-24751. **Deliberate divergence from the ticket text:** the admin day list is constrained to the brand set rather than free-form, so the future backend swap can't widen what a brand allows.
- **Fee enters the cart as a native WC fee** (taxed by store tax handling → order-internal net+tax=gross stays consistent; same posture as Magento's store-configured surcharge tax rate). It flows into the Two payload via the existing fee line-item path. Cart changes re-trigger quote + render on `updated_checkout`.
- **Fail-soft quotes**: a failed fee fetch renders chips without labels; checkout never blocks. Single term renders one non-interactive chip.
- Selected term + offered set ride the create-order payload as `terms` / `available_terms`; selection also posts with the checkout form (hidden field) so order-pay-page flows work sessionless.

## Tests

6 new unit specs (PHP 8.2 via `make test-unit`, all green): brand∩admin resolution, default fallback, the three buyer_fee_share shapes + malformed-percentage fallback, payload terms presence/absence, invalid-POST fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)