### PR TITLE
INF-1598/ci: repoint actions to two-inc/actions monorepo

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -16,6 +16,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: two-inc/pre-commit-action@main
+      - uses: two-inc/actions/pre-commit@main
         with:
           python-version: "3.10"


### PR DESCRIPTION
Repoints GitHub Action references from the legacy `two-inc/<x>-action` repos to the consolidated [`two-inc/actions`](https://github.com/two-inc/actions) monorepo (INF-1598). No behaviour change - same actions, new path.

https://linear.app/tillit/issue/INF-1598