### PR TITLE
INF-1598/ci: repoint pre-commit to two-inc/actions-public monorepo

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -16,6 +16,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: two-inc/pre-commit-action@main
+      - uses: two-inc/actions-public/pre-commit@main
         with:
           python-version: "3.10"


### PR DESCRIPTION
Repoints `two-inc/pre-commit-action` -> `two-inc/actions-public/pre-commit` (the new public companion to the private `two-inc/actions` monorepo).

Public repos cannot consume the private `two-inc/actions` monorepo (GitHub blocks public->private action resolution even with org-access), so the two public-safe actions (pre-commit, claude-reviewer) live in the public `two-inc/actions-public`.

Part of INF-1598 actions consolidation.