### PR TITLE
TWO-24754/feat: Sole trader checkout for supported countries

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -211,3 +211,33 @@
   font-size: 0.85em;
   color: #3043d1;
 }
+
+/* Sole trader toggle (TWO-24754) */
+.twoinc-sole-trader-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin: 8px 0;
+}
+.twoinc-sole-trader-toggle.hidden {
+  display: none;
+}
+.twoinc-sole-trader-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin: 0;
+  cursor: pointer;
+}
+.twoinc-sole-trader-toggle__prompt {
+  flex-basis: 100%;
+  text-decoration: underline;
+}
+.twoinc-sole-trader-toggle__prompt.hidden {
+  display: none;
+}
+.twoinc-sole-trader-toggle__error {
+  flex-basis: 100%;
+  color: #b00020;
+}

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -986,6 +986,298 @@ let twoincTermChips = {
   }
 };
 
+/**
+ * Sole trader checkout — presentation only (TWO-24754).
+ *
+ * All business logic (country eligibility, token minting) lives in
+ * WC_Twoinc_Sole_Trader; this module renders a Business / Sole trader
+ * toggle, suppresses company search in sole-trader mode, opens Two's
+ * hosted signup popup, and autofills the company fields from
+ * GET /autofill/v1/buyer/current. Mirrors the Magento reference flow.
+ */
+let twoincSoleTrader = {
+  mode: "business", // 'business' | 'sole_trader'
+  availabilityByCountry: {},
+  tokens: null,
+  savedCompanySearch: null,
+  messageListenerBound: false,
+
+  config: function () {
+    return (window.twoinc && window.twoinc.sole_trader) || { enabled: false };
+  },
+
+  currentCountry: function () {
+    return (jQuery("#billing_country").val() || "").toUpperCase();
+  },
+
+  /**
+   * Re-evaluate the toggle after every checkout update or country change.
+   * Availability is decided server-side (registry endpoint + merchant
+   * toggle); responses are cached per country for the page's lifetime.
+   */
+  refresh: function () {
+    const cfg = twoincSoleTrader.config();
+    const $container = jQuery(".twoinc-sole-trader-toggle");
+    if (!cfg.enabled || !cfg.availability_url || $container.length === 0) {
+      twoincSoleTrader.hide();
+      return;
+    }
+    const country = twoincSoleTrader.currentCountry();
+    if (!country) {
+      twoincSoleTrader.hide();
+      return;
+    }
+    if (country in twoincSoleTrader.availabilityByCountry) {
+      twoincSoleTrader.apply(twoincSoleTrader.availabilityByCountry[country]);
+      return;
+    }
+    jQuery
+      .get(cfg.availability_url, { country: country })
+      .done(function (response) {
+        const available = !!(response && response.success && response.data && response.data.available);
+        twoincSoleTrader.availabilityByCountry[country] = available;
+        // The buyer may have changed country while the request was in
+        // flight; only apply if the answer is still for the current one.
+        if (twoincSoleTrader.currentCountry() === country) {
+          twoincSoleTrader.apply(available);
+        }
+      })
+      .fail(function () {
+        // Fail-soft: no sole trader option, checkout proceeds as business.
+        if (twoincSoleTrader.currentCountry() === country) {
+          twoincSoleTrader.apply(false);
+        }
+      });
+  },
+
+  apply: function (available) {
+    if (available) {
+      twoincSoleTrader.render();
+    } else {
+      twoincSoleTrader.hide();
+    }
+  },
+
+  hide: function () {
+    jQuery(".twoinc-sole-trader-toggle").addClass("hidden").empty();
+    if (twoincSoleTrader.mode === "sole_trader") {
+      twoincSoleTrader.setMode("business");
+    }
+  },
+
+  render: function () {
+    const cfg = twoincSoleTrader.config();
+    const $container = jQuery(".twoinc-sole-trader-toggle");
+    $container.empty().removeClass("hidden");
+
+    [
+      { value: "business", label: cfg.text.registered_business },
+      { value: "sole_trader", label: cfg.text.sole_trader }
+    ].forEach(function (option) {
+      const checked = twoincSoleTrader.mode === option.value;
+      const $label = jQuery("<label>", { class: "twoinc-sole-trader-toggle__option" });
+      $label.append(
+        jQuery("<input>", {
+          type: "radio",
+          name: "two_account_type",
+          value: option.value,
+          checked: checked
+        }).on("change", function () {
+          twoincSoleTrader.setMode(this.value);
+        })
+      );
+      $label.append(jQuery("<span>", { text: option.label }));
+      $container.append($label);
+    });
+
+    const $prompt = jQuery("<a>", {
+      href: "#",
+      class: "twoinc-sole-trader-toggle__prompt hidden",
+      text: cfg.text.popup_prompt
+    }).on("click", function (event) {
+      event.preventDefault();
+      twoincSoleTrader.openPopup();
+    });
+    $container.append($prompt);
+  },
+
+  setMode: function (mode) {
+    if (mode === twoincSoleTrader.mode) {
+      return;
+    }
+    twoincSoleTrader.mode = mode;
+    jQuery(".twoinc-sole-trader-toggle input[name='two_account_type']").each(function () {
+      this.checked = this.value === mode;
+    });
+
+    if (mode === "sole_trader") {
+      // Suppress company search by the same lever the "company not in
+      // list" button uses, restoring the merchant's setting on the way
+      // back to business mode.
+      if (twoincSoleTrader.savedCompanySearch === null) {
+        twoincSoleTrader.savedCompanySearch = window.twoinc.enable_company_search;
+      }
+      window.twoinc.enable_company_search = "no";
+      const $display = jQuery("#billing_company_display");
+      if ($display.data("select2")) {
+        $display.select2("destroy");
+      }
+      jQuery("#company_not_in_btn, #search_company_btn").hide();
+      twoincSoleTrader.setCompany("", "");
+      jQuery("#billing_company, #company_id").prop("readonly", true);
+      twoincDomHelper.toggleBusinessFields();
+      twoincSoleTrader.fetchTokens();
+    } else {
+      twoincSoleTrader.tokens = null;
+      jQuery(".twoinc-sole-trader-toggle__prompt").addClass("hidden");
+      jQuery("#billing_company, #company_id").prop("readonly", false);
+      if (twoincSoleTrader.savedCompanySearch !== null) {
+        window.twoinc.enable_company_search = twoincSoleTrader.savedCompanySearch;
+        twoincSoleTrader.savedCompanySearch = null;
+      }
+      twoincSoleTrader.setCompany("", "");
+      twoincDomHelper.toggleBusinessFields();
+      Twoinc.getInstance().enableCompanySearch();
+    }
+  },
+
+  setCompany: function (companyId, companyName) {
+    jQuery("#company_id").val(companyId);
+    jQuery("#billing_company").val(companyName);
+    const instance = Twoinc.getInstance();
+    instance.customerCompany.organization_number = companyId;
+    instance.customerCompany.company_name = companyName;
+    if (companyId) {
+      instance.getApproval();
+    }
+  },
+
+  fetchTokens: function () {
+    const cfg = twoincSoleTrader.config();
+    if (!cfg.tokens_url) {
+      return;
+    }
+    jQuery
+      .post(cfg.tokens_url)
+      .done(function (response) {
+        if (response && response.success && response.data && response.data.autofill_token) {
+          twoincSoleTrader.tokens = response.data;
+          twoincSoleTrader.bindPopupMessageListener();
+          twoincSoleTrader.getCurrentBuyer();
+        } else {
+          twoincSoleTrader.showError();
+        }
+      })
+      .fail(function () {
+        twoincSoleTrader.showError();
+      });
+  },
+
+  /**
+   * Autofill the company fields from the buyer's current Two sole-trader
+   * business. A 404 (or an email mismatch) means the buyer has no usable
+   * registration yet — show the signup prompt instead.
+   */
+  getCurrentBuyer: function () {
+    if (!twoincSoleTrader.tokens) {
+      return;
+    }
+    fetch(window.twoinc.twoinc_checkout_host + "/autofill/v1/buyer/current", {
+      credentials: "include",
+      headers: { "two-delegated-authority-token": twoincSoleTrader.tokens.autofill_token }
+    })
+      .then(function (response) {
+        if (response.ok) return response.json();
+        if (response.status === 404) return null;
+        throw new Error("autofill/v1/buyer/current failed");
+      })
+      .then(function (json) {
+        const checkoutEmail = jQuery("#billing_email").val();
+        if (json && json.email === checkoutEmail) {
+          twoincSoleTrader.setCompany(json.organization_number, json.company_name);
+          jQuery(".twoinc-sole-trader-toggle__prompt").addClass("hidden");
+        } else {
+          jQuery(".twoinc-sole-trader-toggle__prompt").removeClass("hidden");
+        }
+      })
+      .catch(function () {
+        twoincSoleTrader.showError();
+      });
+  },
+
+  openPopup: function () {
+    if (!twoincSoleTrader.tokens) {
+      return;
+    }
+    const prefill = {
+      email: jQuery("#billing_email").val(),
+      first_name: jQuery("#billing_first_name").val(),
+      last_name: jQuery("#billing_last_name").val(),
+      company_name: jQuery("#billing_company").val(),
+      phone_number: jQuery("#billing_phone").val(),
+      billing_address: {
+        street: jQuery("#billing_address_1").val(),
+        postal_code: jQuery("#billing_postcode").val(),
+        city: jQuery("#billing_city").val(),
+        region: jQuery("#billing_state").val() || "",
+        country_code: twoincSoleTrader.currentCountry()
+      }
+    };
+    const url =
+      twoincSoleTrader.tokens.signup_url +
+      "?businessToken=" +
+      encodeURIComponent(twoincSoleTrader.tokens.delegation_token) +
+      "&autofillToken=" +
+      encodeURIComponent(twoincSoleTrader.tokens.autofill_token) +
+      "&autofillData=" +
+      encodeURIComponent(btoa(JSON.stringify(prefill)));
+    window.open(
+      url,
+      "_blank",
+      "location=yes,resizable=yes,scrollbars=yes,status=yes,height=805,width=610"
+    );
+  },
+
+  /**
+   * The hosted signup posts 'ACCEPTED' back to the opener when the buyer
+   * completes registration; re-fetch the buyer to autofill.
+   */
+  bindPopupMessageListener: function () {
+    if (twoincSoleTrader.messageListenerBound) {
+      return;
+    }
+    twoincSoleTrader.messageListenerBound = true;
+    window.addEventListener("message", function (event) {
+      if (twoincSoleTrader.mode !== "sole_trader" || !twoincSoleTrader.tokens) {
+        return;
+      }
+      const signupOrigin = new URL(twoincSoleTrader.tokens.signup_url).origin;
+      if (event.origin !== signupOrigin) {
+        return;
+      }
+      if (event.data === "ACCEPTED") {
+        twoincSoleTrader.getCurrentBuyer();
+      } else {
+        twoincSoleTrader.showError();
+      }
+    });
+  },
+
+  showError: function () {
+    const cfg = twoincSoleTrader.config();
+    const $container = jQuery(".twoinc-sole-trader-toggle");
+    if (!cfg.text || !cfg.text.error || $container.length === 0) {
+      return;
+    }
+    let $error = $container.find(".twoinc-sole-trader-toggle__error");
+    if ($error.length === 0) {
+      $error = jQuery("<span>", { class: "twoinc-sole-trader-toggle__error" });
+      $container.append($error);
+    }
+    $error.text(cfg.text.error);
+  }
+};
+
 class Twoinc {
   constructor() {
     if (instance) {
@@ -1510,6 +1802,7 @@ class Twoinc {
     twoincDomHelper.rearrangeDescription();
 
     twoincTermChips.refresh();
+    twoincSoleTrader.refresh();
   }
 
   /**
@@ -1564,6 +1857,9 @@ class Twoinc {
     twoincDomHelper.toggleBusinessFields();
 
     twoincDomHelper.clearSelectedCompany();
+
+    // Sole trader availability is per-country; re-evaluate the toggle.
+    twoincSoleTrader.refresh();
 
     Twoinc.getInstance().getApproval();
   }

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1034,7 +1034,12 @@ let twoincSoleTrader = {
     jQuery
       .get(cfg.availability_url, { country: country })
       .done(function (response) {
-        const available = !!(response && response.success && response.data && response.data.available);
+        const available = !!(
+          response &&
+          response.success &&
+          response.data &&
+          response.data.available
+        );
         twoincSoleTrader.availabilityByCountry[country] = available;
         // The buyer may have changed country while the request was in
         // flight; only apply if the answer is still for the current one.

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -86,6 +86,11 @@ if (!class_exists('WC_Twoinc')) {
             add_action('wc_ajax_two_term_fees', ['WC_Twoinc_Payment_Terms', 'ajax_term_fees']);
             add_action('wc_ajax_two_select_term', ['WC_Twoinc_Payment_Terms', 'ajax_select_term']);
 
+            // Sole trader checkout (TWO-24754). Same split: decisioning in
+            // WC_Twoinc_Sole_Trader, JS renders only what these return.
+            add_action('wc_ajax_two_sole_trader_availability', ['WC_Twoinc_Sole_Trader', 'ajax_availability']);
+            add_action('wc_ajax_two_sole_trader_tokens', ['WC_Twoinc_Sole_Trader', 'ajax_tokens']);
+
             if (is_admin()) {
                 // Notice banner if plugin is not setup properly
 
@@ -283,6 +288,7 @@ if (!class_exists('WC_Twoinc')) {
             return sprintf(
                 '<div>
                     <div class="twoinc-pay-box twoinc-explainer">%s</div>
+                    <div class="twoinc-sole-trader-toggle hidden" role="radiogroup"></div>
                     <div class="twoinc-term-chips hidden" role="radiogroup"></div>
                     <div class="twoinc-pay-box twoinc-loader hidden"></div>
                     <div class="twoinc-pay-box twoinc-intent-approved hidden">%s</div>
@@ -1694,6 +1700,18 @@ if (!class_exists('WC_Twoinc')) {
                     'label'       => ' ',
                     'type'        => 'checkbox',
                     'default'     => 'yes'
+                ],
+                'section_sole_trader' => [
+                    'type'  => 'title',
+                    'title' => __('Sole trader checkout', 'twoinc-payment-gateway'),
+                ],
+                'enable_sole_trader' => [
+                    'title'       => __('Enable sole trader checkout', 'twoinc-payment-gateway'),
+                    'description' => __('Lets buyers in supported countries (currently the UK and US) check out as a sole trader by registering or logging in with Two. The option only appears where sole traders are legally supported.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'label'       => ' ',
+                    'type'        => 'checkbox',
+                    'default'     => 'no'
                 ],
                 'section_payment_terms' => [
                     'type'  => 'title',

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -268,6 +268,20 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                     'fees_url' => class_exists('WC_AJAX') ? WC_AJAX::get_endpoint('two_term_fees') : '',
                     'select_url' => class_exists('WC_AJAX') ? WC_AJAX::get_endpoint('two_select_term') : '',
                 ],
+                // Sole trader bootstrap (TWO-24754). JS renders only; country
+                // availability and token minting come from the wc-ajax
+                // endpoints in WC_Twoinc_Sole_Trader.
+                'sole_trader' => [
+                    'enabled' => WC_Twoinc_Sole_Trader::is_enabled($this->wc_twoinc),
+                    'availability_url' => class_exists('WC_AJAX') ? WC_AJAX::get_endpoint('two_sole_trader_availability') : '',
+                    'tokens_url' => class_exists('WC_AJAX') ? WC_AJAX::get_endpoint('two_sole_trader_tokens') : '',
+                    'text' => [
+                        'registered_business' => __('Registered company', 'twoinc-payment-gateway'),
+                        'sole_trader' => __('Sole trader', 'twoinc-payment-gateway'),
+                        'popup_prompt' => __('Click here to log in or sign up as a sole trader with Two.', 'twoinc-payment-gateway'),
+                        'error' => __('Something went wrong setting up sole trader checkout. Please try again.', 'twoinc-payment-gateway'),
+                    ],
+                ],
             ];
 
             $user_id = wp_get_current_user()->ID;

--- a/class/WC_Twoinc_Sole_Trader.php
+++ b/class/WC_Twoinc_Sole_Trader.php
@@ -26,7 +26,6 @@
 if (!class_exists('WC_Twoinc_Sole_Trader')) {
     class WC_Twoinc_Sole_Trader
     {
-        public const REGISTERED_BUSINESS = 'REGISTERED_BUSINESS';
         public const SOLE_TRADER = 'SOLE_TRADER';
 
         /** WC session key prefix; full key is prefix + ISO country code. */
@@ -47,11 +46,16 @@ if (!class_exists('WC_Twoinc_Sole_Trader')) {
         }
 
         /**
-         * The buyer company types Two supports for a billing country, from
-         * GET /registry/v1/supported-company-types/<ISO>. Cached per session
-         * for the endpoint's own max-age. Fail-soft: any error (network,
-         * non-200, malformed body) resolves to registered-business only —
-         * checkout never blocks, the sole trader option just doesn't show.
+         * The buyer company types the Two registry supports for a billing
+         * country, from GET /registry/v1/supported-company-types/<ISO> —
+         * only the types that need registry enrollment before they can buy
+         * (sole traders). Registered businesses need no enrollment and are
+         * always supported, so the endpoint deliberately omits them: an
+         * empty list means registered-business-only checkout. Cached per
+         * session for the endpoint's own max-age. Fail-soft: any error
+         * (network, non-200, malformed body) also resolves to an empty
+         * list — checkout never blocks, the sole trader option just
+         * doesn't show.
          *
          * @return string[]
          */
@@ -59,7 +63,7 @@ if (!class_exists('WC_Twoinc_Sole_Trader')) {
         {
             $country = strtoupper(trim($country));
             if (!preg_match('/^[A-Z]{2}$/', $country)) {
-                return [self::REGISTERED_BUSINESS];
+                return [];
             }
 
             if (array_key_exists($country, self::$types_cache)) {
@@ -99,14 +103,13 @@ if (!class_exists('WC_Twoinc_Sole_Trader')) {
         {
             $response = $gateway->make_request("/registry/v1/supported-company-types/{$country}", [], 'GET');
             if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
-                return [self::REGISTERED_BUSINESS];
+                return [];
             }
             $body = json_decode(wp_remote_retrieve_body($response), true);
             if (!is_array($body) || !isset($body['supported_company_types']) || !is_array($body['supported_company_types'])) {
-                return [self::REGISTERED_BUSINESS];
+                return [];
             }
-            $types = array_values(array_filter($body['supported_company_types'], 'is_string'));
-            return count($types) > 0 ? $types : [self::REGISTERED_BUSINESS];
+            return array_values(array_filter($body['supported_company_types'], 'is_string'));
         }
 
         /**

--- a/class/WC_Twoinc_Sole_Trader.php
+++ b/class/WC_Twoinc_Sole_Trader.php
@@ -1,0 +1,224 @@
+<?php
+
+/**
+ * Sole trader checkout support — business logic (TWO-24754).
+ *
+ * All decisioning lives here; assets/js/twoinc.js only renders what these
+ * methods return (the Gutenberg block checkout port must not need a
+ * business-logic rewrite, see TWO-24767).
+ *
+ * Two gates decide whether the Sole Trader option shows for a billing
+ * country, and both must pass:
+ *  - country-level legal truth from the registry endpoint
+ *    GET /registry/v1/supported-company-types/<ISO> (TWO-24753), and
+ *  - the merchant's `enable_sole_trader` admin toggle.
+ *
+ * The flow mirrors the Magento reference (gateway_method.js): the buyer
+ * switches to sole-trader mode, the plugin server-side mints two delegated
+ * authority tokens with the merchant API key, the buyer registers or logs in
+ * through Two's hosted signup popup, and the checkout autofills the company
+ * fields from GET /autofill/v1/buyer/current. No sole-trader-specific fields
+ * are collected at checkout and the order payload is unchanged — an enrolled
+ * sole trader's organization number (TWO:ST…) carries the semantics and the
+ * backend derives the company type from it (TWO-24749 spike).
+ */
+
+if (!class_exists('WC_Twoinc_Sole_Trader')) {
+    class WC_Twoinc_Sole_Trader
+    {
+        public const REGISTERED_BUSINESS = 'REGISTERED_BUSINESS';
+        public const SOLE_TRADER = 'SOLE_TRADER';
+
+        /** WC session key prefix; full key is prefix + ISO country code. */
+        public const SESSION_KEY_PREFIX = 'two_company_types_';
+
+        /** Matches the registry endpoint's Cache-Control max-age. */
+        public const CACHE_TTL_SECONDS = 3600;
+
+        /** @var array<string, string[]> request-scoped cache, keyed by country */
+        private static $types_cache = [];
+
+        /**
+         * Whether the merchant has opted into offering sole trader checkout.
+         */
+        public static function is_enabled($gateway): bool
+        {
+            return $gateway->get_option('enable_sole_trader') === 'yes';
+        }
+
+        /**
+         * The buyer company types Two supports for a billing country, from
+         * GET /registry/v1/supported-company-types/<ISO>. Cached per session
+         * for the endpoint's own max-age. Fail-soft: any error (network,
+         * non-200, malformed body) resolves to registered-business only —
+         * checkout never blocks, the sole trader option just doesn't show.
+         *
+         * @return string[]
+         */
+        public static function get_supported_company_types($gateway, string $country): array
+        {
+            $country = strtoupper(trim($country));
+            if (!preg_match('/^[A-Z]{2}$/', $country)) {
+                return [self::REGISTERED_BUSINESS];
+            }
+
+            if (array_key_exists($country, self::$types_cache)) {
+                return self::$types_cache[$country];
+            }
+
+            $session = function_exists('WC') ? (WC()->session ?? null) : null;
+            if ($session) {
+                $cached = $session->get(self::SESSION_KEY_PREFIX . $country);
+                if (
+                    is_array($cached)
+                    && isset($cached['types'], $cached['fetched_at'])
+                    && is_array($cached['types'])
+                    && time() - (int) $cached['fetched_at'] < self::CACHE_TTL_SECONDS
+                ) {
+                    return self::$types_cache[$country] = $cached['types'];
+                }
+            }
+
+            $types = self::fetch_supported_company_types($gateway, $country);
+
+            if ($session) {
+                $session->set(self::SESSION_KEY_PREFIX . $country, [
+                    'types' => $types,
+                    'fetched_at' => time(),
+                ]);
+            }
+            return self::$types_cache[$country] = $types;
+        }
+
+        /**
+         * Uncached registry call. @see get_supported_company_types()
+         *
+         * @return string[]
+         */
+        private static function fetch_supported_company_types($gateway, string $country): array
+        {
+            $response = $gateway->make_request("/registry/v1/supported-company-types/{$country}", [], 'GET');
+            if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
+                return [self::REGISTERED_BUSINESS];
+            }
+            $body = json_decode(wp_remote_retrieve_body($response), true);
+            if (!is_array($body) || !isset($body['supported_company_types']) || !is_array($body['supported_company_types'])) {
+                return [self::REGISTERED_BUSINESS];
+            }
+            $types = array_values(array_filter($body['supported_company_types'], 'is_string'));
+            return count($types) > 0 ? $types : [self::REGISTERED_BUSINESS];
+        }
+
+        /**
+         * Whether the Sole Trader option should be offered for a billing
+         * country: merchant toggle on AND the country legally supports it.
+         */
+        public static function is_available($gateway, string $country): bool
+        {
+            return self::is_enabled($gateway)
+                && in_array(self::SOLE_TRADER, self::get_supported_company_types($gateway, $country), true);
+        }
+
+        /**
+         * Mint the two delegated-authority tokens the sole-trader flow needs,
+         * server-side with the merchant API key (the key never reaches the
+         * browser). The Two API returns each token in the
+         * `two-delegated-authority-token` response HEADER, not the body.
+         *
+         * @return array{delegation_token: string, autofill_token: string}|null
+         */
+        public static function mint_tokens($gateway): ?array
+        {
+            $delegation_token = self::mint_token($gateway, '/registry/v1/delegation', [
+                'create_proposal' => true,
+                'read_current_business' => true,
+            ]);
+            $autofill_token = self::mint_token($gateway, '/autofill/v1/delegation', [
+                'read_current_buyer' => true,
+                'write_current_buyer' => true,
+            ]);
+            if ($delegation_token === null || $autofill_token === null) {
+                return null;
+            }
+            return [
+                'delegation_token' => $delegation_token,
+                'autofill_token' => $autofill_token,
+            ];
+        }
+
+        private static function mint_token($gateway, string $endpoint, array $payload): ?string
+        {
+            $response = $gateway->make_request($endpoint, $payload);
+            if (is_wp_error($response) || wp_remote_retrieve_response_code($response) >= 300) {
+                return null;
+            }
+            $token = wp_remote_retrieve_header($response, 'two-delegated-authority-token');
+            return is_string($token) && $token !== '' ? $token : null;
+        }
+
+        /**
+         * Base URL of Two's hosted sole-trader signup page (the checkout-page
+         * app, not the API). Brand overlays adjust via the
+         * `twoinc_sole_trader_signup_url` filter (e.g. appending brand params).
+         */
+        public static function get_signup_page_url($gateway): string
+        {
+            if ($gateway->get_option('checkout_env') === 'SANDBOX') {
+                $url = 'https://checkout.sandbox.two.inc/soletrader/signup';
+            } else {
+                $url = 'https://checkout.two.inc/soletrader/signup';
+            }
+            return apply_filters('twoinc_sole_trader_signup_url', $url);
+        }
+
+        /**
+         * wc-ajax handler: whether the sole trader option applies for a
+         * billing country. JS re-queries this when the billing country
+         * changes; the answer combines both gates server-side.
+         */
+        public static function ajax_availability(): void
+        {
+            $gateway = WC_Twoinc::get_instance();
+            if (!$gateway) {
+                wp_send_json_error('Gateway unavailable');
+                return;
+            }
+            $country = isset($_REQUEST['country']) ? sanitize_text_field(wp_unslash($_REQUEST['country'])) : '';
+            wp_send_json_success([
+                'available' => self::is_available($gateway, $country),
+            ]);
+        }
+
+        /**
+         * wc-ajax handler: mint the delegation + autofill tokens for the
+         * sole-trader flow and hand the browser everything it needs to open
+         * the hosted signup popup and autofill the buyer.
+         */
+        public static function ajax_tokens(): void
+        {
+            $gateway = WC_Twoinc::get_instance();
+            if (!$gateway || !self::is_enabled($gateway)) {
+                wp_send_json_error('Sole trader checkout is not enabled');
+                return;
+            }
+            $tokens = self::mint_tokens($gateway);
+            if ($tokens === null) {
+                wp_send_json_error('Could not initialise the sole trader flow');
+                return;
+            }
+            wp_send_json_success([
+                'delegation_token' => $tokens['delegation_token'],
+                'autofill_token' => $tokens['autofill_token'],
+                'signup_url' => self::get_signup_page_url($gateway),
+            ]);
+        }
+
+        /**
+         * Test seam: clear the request-scoped types cache.
+         */
+        public static function reset_cache(): void
+        {
+            self::$types_cache = [];
+        }
+    }
+}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -325,8 +325,41 @@ class WP_Error
 {
 }
 
+// wp_remote_* accessors over the ['response' => ['code' => …], 'body' => …,
+// 'headers' => …] response-array shape the gateway's make_request returns.
+
+function wp_remote_retrieve_response_code($response)
+{
+    if (is_wp_error($response) || !is_array($response)) {
+        return '';
+    }
+    return $response['response']['code'] ?? '';
+}
+
+function wp_remote_retrieve_body($response)
+{
+    if (is_wp_error($response) || !is_array($response)) {
+        return '';
+    }
+    return $response['body'] ?? '';
+}
+
+function wp_remote_retrieve_header($response, $header)
+{
+    if (is_wp_error($response) || !is_array($response)) {
+        return '';
+    }
+    foreach (($response['headers'] ?? []) as $name => $value) {
+        if (strtolower($name) === strtolower($header)) {
+            return $value;
+        }
+    }
+    return '';
+}
+
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Brand.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Helper.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Payment_Terms.php';
+require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Sole_Trader.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Checkout.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc.php';

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -55,6 +55,15 @@ final class BrandConfigSpec
             'testOrderPayloadCarriesSelectedAndAvailableTerms',
             'testPaymentTermsInvalidPostFallsBackToDefault',
             'testPaymentTermsDisabledMeansNoPayloadTerms',
+            'testSoleTraderAvailableWhenRegistryAndToggleAgree',
+            'testSoleTraderHiddenWhenToggleOff',
+            'testSoleTraderHiddenWhenRegistryOmitsIt',
+            'testSoleTraderRegistryErrorFallsBackToRegisteredBusiness',
+            'testSoleTraderRegistryRejectsMalformedCountry',
+            'testSoleTraderRegistryResponseCachedPerRequest',
+            'testSoleTraderTokenMintReadsHeaderCaseInsensitively',
+            'testSoleTraderTokenMintFailsClosed',
+            'testSoleTraderSignupUrlFollowsEnvAndFilter',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -70,9 +79,10 @@ final class BrandConfigSpec
         unset($GLOBALS['__twoinc_test_currency']);
         unset($_POST[WC_Twoinc_Payment_Terms::SESSION_KEY]);
         WC_Twoinc_Payment_Terms::reset_fee_cache();
+        WC_Twoinc_Sole_Trader::reset_cache();
         WC()->cart = null;
         WC()->customer = null;
-        foreach (['twoinc_brand_file', 'twoinc_checkout_fields', 'twoinc_confirmation_url', 'twoinc_order_payload', 'twoinc_payment_terms_line', 'two_order_create', 'twoinc_payment_validation_error'] as $tag) {
+        foreach (['twoinc_brand_file', 'twoinc_checkout_fields', 'twoinc_confirmation_url', 'twoinc_order_payload', 'twoinc_payment_terms_line', 'two_order_create', 'twoinc_payment_validation_error', 'twoinc_sole_trader_signup_url'] as $tag) {
             remove_all_filters($tag);
         }
     }
@@ -593,6 +603,181 @@ final class BrandConfigSpec
         $body = self::composeOrder();
         TinyAssert::same(false, array_key_exists('terms', $body));
         TinyAssert::same(false, array_key_exists('available_terms', $body));
+    }
+
+    /**
+     * Gateway fake whose make_request returns canned responses keyed by
+     * endpoint prefix (the sole-trader logic talks to the registry +
+     * delegation endpoints through it).
+     */
+    private static function soleTraderGateway(array $options, array $responses): WC_Payment_Gateway
+    {
+        return new class ($options, $responses) extends WC_Payment_Gateway {
+            private $options;
+            private $responses;
+            public $requests = [];
+
+            public function __construct($options, $responses)
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+                $this->options = $options;
+                $this->responses = $responses;
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $this->options[$key] ?? $empty_value ?? '';
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null)
+            {
+                $this->requests[] = $endpoint;
+                foreach ($this->responses as $prefix => $response) {
+                    if (strpos($endpoint, $prefix) === 0) {
+                        return $response;
+                    }
+                }
+                return new WP_Error();
+            }
+        };
+    }
+
+    private static function registryOk(array $types): array
+    {
+        return [
+            'response' => ['code' => 200],
+            'body' => json_encode(['supported_company_types' => $types]),
+        ];
+    }
+
+    private static function testSoleTraderAvailableWhenRegistryAndToggleAgree(): void
+    {
+        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+            '/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER']),
+        ]);
+        TinyAssert::true(WC_Twoinc_Sole_Trader::is_available($gateway, 'GB'));
+        // Lowercase input normalises to the same country
+        WC_Twoinc_Sole_Trader::reset_cache();
+        TinyAssert::true(WC_Twoinc_Sole_Trader::is_available($gateway, 'gb'));
+    }
+
+    private static function testSoleTraderHiddenWhenToggleOff(): void
+    {
+        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'no'], [
+            '/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER']),
+        ]);
+        TinyAssert::same(false, WC_Twoinc_Sole_Trader::is_available($gateway, 'GB'));
+    }
+
+    private static function testSoleTraderHiddenWhenRegistryOmitsIt(): void
+    {
+        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+            '/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS']),
+        ]);
+        TinyAssert::same(false, WC_Twoinc_Sole_Trader::is_available($gateway, 'NO'));
+    }
+
+    private static function testSoleTraderRegistryErrorFallsBackToRegisteredBusiness(): void
+    {
+        // Network error
+        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], []);
+        TinyAssert::same(['REGISTERED_BUSINESS'], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB'));
+
+        // Non-200
+        WC_Twoinc_Sole_Trader::reset_cache();
+        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+            '/registry/v1/supported-company-types/' => ['response' => ['code' => 404], 'body' => ''],
+        ]);
+        TinyAssert::same(['REGISTERED_BUSINESS'], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB'));
+
+        // Malformed body
+        WC_Twoinc_Sole_Trader::reset_cache();
+        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+            '/registry/v1/supported-company-types/' => ['response' => ['code' => 200], 'body' => 'not json'],
+        ]);
+        TinyAssert::same(['REGISTERED_BUSINESS'], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB'));
+    }
+
+    private static function testSoleTraderRegistryRejectsMalformedCountry(): void
+    {
+        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+            '/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER']),
+        ]);
+        // Never hits the API for junk country input
+        TinyAssert::same(['REGISTERED_BUSINESS'], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, ''));
+        TinyAssert::same(['REGISTERED_BUSINESS'], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'G'));
+        TinyAssert::same(['REGISTERED_BUSINESS'], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GBR'));
+        TinyAssert::same([], $gateway->requests);
+    }
+
+    private static function testSoleTraderRegistryResponseCachedPerRequest(): void
+    {
+        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+            '/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER']),
+        ]);
+        WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB');
+        WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB');
+        WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'gb');
+        TinyAssert::same(1, count($gateway->requests));
+        // A different country is its own cache entry
+        WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'US');
+        TinyAssert::same(2, count($gateway->requests));
+    }
+
+    private static function testSoleTraderTokenMintReadsHeaderCaseInsensitively(): void
+    {
+        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+            '/registry/v1/delegation' => [
+                'response' => ['code' => 200],
+                'headers' => ['Two-Delegated-Authority-Token' => 'reg-token'],
+            ],
+            '/autofill/v1/delegation' => [
+                'response' => ['code' => 200],
+                'headers' => ['two-delegated-authority-token' => 'autofill-token'],
+            ],
+        ]);
+        TinyAssert::same(
+            ['delegation_token' => 'reg-token', 'autofill_token' => 'autofill-token'],
+            WC_Twoinc_Sole_Trader::mint_tokens($gateway)
+        );
+    }
+
+    private static function testSoleTraderTokenMintFailsClosed(): void
+    {
+        // Second mint failing voids the pair — never hand the browser half a flow
+        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+            '/registry/v1/delegation' => [
+                'response' => ['code' => 200],
+                'headers' => ['two-delegated-authority-token' => 'reg-token'],
+            ],
+            '/autofill/v1/delegation' => ['response' => ['code' => 500], 'headers' => []],
+        ]);
+        TinyAssert::same(null, WC_Twoinc_Sole_Trader::mint_tokens($gateway));
+
+        // Missing header on a 200 also fails closed
+        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+            '/registry/v1/delegation' => ['response' => ['code' => 200], 'headers' => []],
+            '/autofill/v1/delegation' => [
+                'response' => ['code' => 200],
+                'headers' => ['two-delegated-authority-token' => 'autofill-token'],
+            ],
+        ]);
+        TinyAssert::same(null, WC_Twoinc_Sole_Trader::mint_tokens($gateway));
+    }
+
+    private static function testSoleTraderSignupUrlFollowsEnvAndFilter(): void
+    {
+        $gateway = self::soleTraderGateway([], []);
+        TinyAssert::same('https://checkout.two.inc/soletrader/signup', WC_Twoinc_Sole_Trader::get_signup_page_url($gateway));
+
+        $gateway = self::soleTraderGateway(['checkout_env' => 'SANDBOX'], []);
+        TinyAssert::same('https://checkout.sandbox.two.inc/soletrader/signup', WC_Twoinc_Sole_Trader::get_signup_page_url($gateway));
+
+        // Brand overlays adjust via the filter
+        add_filter('twoinc_sole_trader_signup_url', function ($url) {
+            return $url . '?brand=acme';
+        });
+        TinyAssert::same('https://checkout.sandbox.two.inc/soletrader/signup?brand=acme', WC_Twoinc_Sole_Trader::get_signup_page_url($gateway));
     }
 }
 

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -58,7 +58,7 @@ final class BrandConfigSpec
             'testSoleTraderAvailableWhenRegistryAndToggleAgree',
             'testSoleTraderHiddenWhenToggleOff',
             'testSoleTraderHiddenWhenRegistryOmitsIt',
-            'testSoleTraderRegistryErrorFallsBackToRegisteredBusiness',
+            'testSoleTraderRegistryErrorFallsBackToNoSoleTrader',
             'testSoleTraderRegistryRejectsMalformedCountry',
             'testSoleTraderRegistryResponseCachedPerRequest',
             'testSoleTraderTokenMintReadsHeaderCaseInsensitively',
@@ -653,7 +653,7 @@ final class BrandConfigSpec
     private static function testSoleTraderAvailableWhenRegistryAndToggleAgree(): void
     {
         $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
-            '/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER']),
+            '/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER']),
         ]);
         TinyAssert::true(WC_Twoinc_Sole_Trader::is_available($gateway, 'GB'));
         // Lowercase input normalises to the same country
@@ -664,56 +664,59 @@ final class BrandConfigSpec
     private static function testSoleTraderHiddenWhenToggleOff(): void
     {
         $gateway = self::soleTraderGateway(['enable_sole_trader' => 'no'], [
-            '/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER']),
+            '/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER']),
         ]);
         TinyAssert::same(false, WC_Twoinc_Sole_Trader::is_available($gateway, 'GB'));
     }
 
     private static function testSoleTraderHiddenWhenRegistryOmitsIt(): void
     {
+        // Countries without sole trader support return an empty list:
+        // registered businesses need no registry enrollment, so the
+        // endpoint deliberately omits them.
         $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
-            '/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS']),
+            '/registry/v1/supported-company-types/' => self::registryOk([]),
         ]);
         TinyAssert::same(false, WC_Twoinc_Sole_Trader::is_available($gateway, 'NO'));
     }
 
-    private static function testSoleTraderRegistryErrorFallsBackToRegisteredBusiness(): void
+    private static function testSoleTraderRegistryErrorFallsBackToNoSoleTrader(): void
     {
         // Network error
         $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], []);
-        TinyAssert::same(['REGISTERED_BUSINESS'], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB'));
+        TinyAssert::same([], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB'));
 
         // Non-200
         WC_Twoinc_Sole_Trader::reset_cache();
         $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
             '/registry/v1/supported-company-types/' => ['response' => ['code' => 404], 'body' => ''],
         ]);
-        TinyAssert::same(['REGISTERED_BUSINESS'], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB'));
+        TinyAssert::same([], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB'));
 
         // Malformed body
         WC_Twoinc_Sole_Trader::reset_cache();
         $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
             '/registry/v1/supported-company-types/' => ['response' => ['code' => 200], 'body' => 'not json'],
         ]);
-        TinyAssert::same(['REGISTERED_BUSINESS'], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB'));
+        TinyAssert::same([], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB'));
     }
 
     private static function testSoleTraderRegistryRejectsMalformedCountry(): void
     {
         $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
-            '/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER']),
+            '/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER']),
         ]);
         // Never hits the API for junk country input
-        TinyAssert::same(['REGISTERED_BUSINESS'], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, ''));
-        TinyAssert::same(['REGISTERED_BUSINESS'], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'G'));
-        TinyAssert::same(['REGISTERED_BUSINESS'], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GBR'));
+        TinyAssert::same([], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, ''));
+        TinyAssert::same([], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'G'));
+        TinyAssert::same([], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GBR'));
         TinyAssert::same([], $gateway->requests);
     }
 
     private static function testSoleTraderRegistryResponseCachedPerRequest(): void
     {
         $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
-            '/registry/v1/supported-company-types/' => self::registryOk(['REGISTERED_BUSINESS', 'SOLE_TRADER']),
+            '/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER']),
         ]);
         WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB');
         WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB');

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -56,6 +56,7 @@ function load_twoinc_classes()
     require_once __DIR__ . '/class/WC_Twoinc_Brand.php';
     require_once __DIR__ . '/class/WC_Twoinc_Helper.php';
     require_once __DIR__ . '/class/WC_Twoinc_Payment_Terms.php';
+    require_once __DIR__ . '/class/WC_Twoinc_Sole_Trader.php';
     require_once __DIR__ . '/class/WC_Twoinc_Checkout.php';
     require_once __DIR__ . '/class/WC_Twoinc.php';
 


### PR DESCRIPTION
## What

Sole-trader checkout support (UK + US), stacked on #323. Buyers in countries where Two legally supports sole traders see a **Registered company / Sole trader** toggle in the payment box. Sole-trader mode suppresses company search, mints delegation + autofill tokens server-side, opens Two's hosted signup popup, and autofills the buyer's `TWO:ST…` organization number from `GET /autofill/v1/buyer/current`.

## Design

- **Two gates, both server-side** (per TWO-24754): the registry endpoint `GET /registry/v1/supported-company-types/<ISO>` (TWO-24753, must be deployed first) and a new `enable_sole_trader` admin toggle (default off). Registry answers are session-cached for the endpoint's own Cache-Control max-age and fail soft to registered-business only — checkout never blocks on the registry.
- **Business logic in PHP, JS renders only** (TWO-24767 posture): `WC_Twoinc_Sole_Trader` owns eligibility + token minting behind two wc-ajax endpoints (`two_sole_trader_availability`, `two_sole_trader_tokens`); `twoincSoleTrader` in twoinc.js is a presentation module mirroring the terms-chips split.
- **Order payload unchanged.** Per the TWO-24749 spike there is no plugin-side buyer-type field — the `TWO:ST` org-number prefix carries the semantics and checkout-api enriches `company_type` itself. The ticket's original "personal name + trading name fields" scope was superseded by the spike: those are collected by Two's hosted signup, exactly as in the Magento reference.
- Tokens are minted with the merchant API key (never exposed to the browser) and read from the `two-delegated-authority-token` response **header**, matching Magento's adapter. Popup completion arrives via postMessage `ACCEPTED` from the checkout-page origin.
- `twoinc_sole_trader_signup_url` filter lets brand overlays adjust the signup URL. WC-ABN itself needs no sole-trader work: the ABN product is NL-only and NL fails the registry gate.

## Tests

9 new unit tests: both-gates matrix, registry error/404/malformed-body fail-soft, malformed-country short-circuit, per-request caching, case-insensitive token-header read, fail-closed token pair, signup URL env + filter. Full suite green (`make test-unit`).

## Deploy order

checkout-api TWO-24753 (PR 12277) must deploy before this releases; until then the registry call 404s and the toggle simply never shows (fail-soft path, manually exercised by the 404 unit test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)