### PR TITLE
TWO-24757/docs: Document the deliberate self-invoice upload gap

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -673,6 +673,17 @@ if (!class_exists('WC_Twoinc')) {
             $order->update_meta_data('_twoinc_order_state', 'FULFILLING');
             $order->save();
             do_action('twoinc_order_completed', $order, $body);
+
+            // Deliberate gap (TWO-24757): no merchant self-invoice upload on
+            // fulfilment. The PrestaShop plugin uploads its native invoice
+            // PDF to Two here when the merchant's
+            // invoice_distributed_by_merchant flag is set; WooCommerce has
+            // no native invoice renderer, so supporting this would mean
+            // bundling a PDF generator (e.g. dompdf) into client sites — a
+            // maintenance and security overhead we won't take on without
+            // demand. If that demand materialises, implement it here: queue
+            // an Action Scheduler background job after the fulfillments
+            // call above (TWO-24757 has the full design).
             return true;
         }
 


### PR DESCRIPTION
WooCommerce will **not** get merchant self-invoice upload (TWO-24757 cancelled). Unlike PrestaShop — which renders its native invoice PDF and uploads it on fulfilment — WooCommerce has no native invoice renderer, so the feature would mean bundling a PDF generator (dompdf) into client ecommerce sites. That is a maintenance and security overhead we are not taking on without merchant demand.

This PR adds a comment in `on_order_completed` marking exactly where the implementation goes (Action Scheduler job after the fulfillments call) if demand materialises; TWO-24757 retains the full design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)