### PR TITLE
TWO-24892: buyer surcharge rounding (basis + brand-driven step)

### DIFF
--- a/brands/two.php
+++ b/brands/two.php
@@ -46,6 +46,12 @@ return [
     // the only reader). Mirrors the Magento brand descriptor's
     // available_payment_terms.
     'available_terms' => [14, 30, 60, 90],
+    // Increments the buyer surcharge line may be rounded to, offered in
+    // the admin Rounding Step dropdown (the merchant picks one; the None
+    // basis disables rounding). WC_Twoinc::get_rounding_step_options is
+    // the only reader. Mirrors the Magento brand descriptor's
+    // surcharge_rounding_steps; an overlay narrows the set.
+    'available_rounding_steps' => [0.10, 0.50, 1.00, 5.00, 10.00],
     // Buyer-facing label for the offset-pricing fee line; null uses the
     // translated "Service charge" default.
     'fee_line_label' => null,

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -313,6 +313,31 @@ if (!class_exists('WC_Twoinc')) {
         }
 
         /**
+         * Admin option list of the brand's surcharge rounding steps, in
+         * canonical two-decimal form so the stored value round-trips
+         * against the option list (WC_Twoinc_Payment_Terms reads it back).
+         * Mirrors the Magento RoundingStep source model.
+         *
+         * @return array<string, string>
+         */
+        private function get_rounding_step_options(): array
+        {
+            $options = [];
+            $brand_steps = WC_Twoinc_Brand::get('available_rounding_steps');
+            foreach (is_array($brand_steps) ? $brand_steps : [] as $step) {
+                if (!is_numeric($step) || (float) $step <= 0) {
+                    continue;
+                }
+                $value = number_format((float) $step, 2, '.', '');
+                $options[$value] = $value;
+            }
+            // Ascending, mirroring the Magento Loader's numeric sort (keys
+            // are the formatted strings, so equal values already dedup).
+            ksort($options, SORT_NUMERIC);
+            return $options;
+        }
+
+        /**
          * Get payment subtitle
          */
         public function get_pay_subtitle()
@@ -1745,6 +1770,27 @@ if (!class_exists('WC_Twoinc')) {
                     'desc_tip'    => true,
                     'type'        => 'select',
                     'options'     => ['' => __('None - simple pass-through', 'twoinc-payment-gateway')] + $this->get_payment_term_day_options(),
+                    'default'     => ''
+                ],
+                'surcharge_rounding_basis' => [
+                    'title'       => __('Surcharge rounding', 'twoinc-payment-gateway'),
+                    'description' => __('Snap the buyer surcharge line to a clean increment. Select None for standard two-decimal amounts.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'type'        => 'select',
+                    'options'     => [
+                        'none'     => __('None', 'twoinc-payment-gateway'),
+                        'up'       => __('Up', 'twoinc-payment-gateway'),
+                        'down'     => __('Down', 'twoinc-payment-gateway'),
+                        'standard' => __('Standard', 'twoinc-payment-gateway'),
+                    ],
+                    'default'     => 'none'
+                ],
+                'surcharge_rounding_step' => [
+                    'title'       => __('Rounding step', 'twoinc-payment-gateway'),
+                    'description' => __('Increment the surcharge is rounded to (e.g. 1 = whole units, 0.50 = nearest half). Applies only when a rounding direction is selected.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'type'        => 'select',
+                    'options'     => $this->get_rounding_step_options(),
                     'default'     => ''
                 ],
                 'section_debug' => [

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -23,6 +23,17 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
     {
         public const SESSION_KEY = 'two_selected_term';
 
+        /**
+         * Stored surcharge-rounding basis → pricing-API basis. "none" (and
+         * any unmapped value) omits the rounding block. Mirrors Magento's
+         * SurchargeCalculator::ROUNDING_BASIS_TO_API.
+         */
+        private const ROUNDING_BASIS_TO_API = [
+            'up' => 'UP',
+            'down' => 'DOWN',
+            'standard' => 'STANDARD',
+        ];
+
         /** @var array<int, array|null> request-scoped fee quote cache, keyed by term days */
         private static $fee_cache = [];
 
@@ -115,7 +126,7 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
         /**
          * Offset pricing settings resolved from gateway options.
          *
-         * @return array{enabled: bool, percentage: string, reference_days: int|null}
+         * @return array{enabled: bool, percentage: string, reference_days: int|null, rounding_basis: string, rounding_step: float|null}
          */
         public static function get_offset_settings($gateway): array
         {
@@ -124,10 +135,13 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
             if ($percentage === '' || !is_numeric($percentage) || (float) $percentage < 0 || (float) $percentage > 100) {
                 $percentage = '100';
             }
+            $rounding_step = (float) $gateway->get_option('surcharge_rounding_step');
             return [
                 'enabled' => $gateway->get_option('enable_offset_pricing') === 'yes',
                 'percentage' => $percentage,
                 'reference_days' => $reference_days > 0 ? $reference_days : null,
+                'rounding_basis' => (string) $gateway->get_option('surcharge_rounding_basis'),
+                'rounding_step' => $rounding_step > 0 ? $rounding_step : null,
             ];
         }
 
@@ -152,7 +166,33 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
                     'duration_days' => $settings['reference_days'],
                 ];
             }
+            $rounding = self::build_rounding($settings);
+            if ($rounding !== null) {
+                $buyer_fee_share['rounding'] = $rounding;
+            }
             return $buyer_fee_share;
+        }
+
+        /**
+         * The rounding block for buyer_fee_share, or null when rounding is
+         * off. The backend does the arithmetic; the plugin only relays
+         * {step, basis}. A None/unmapped basis or a non-positive step omits
+         * the block (the API requires both keys and rejects step <= 0).
+         * Mirrors Magento's SurchargeCalculator::buildRounding.
+         *
+         * @param array{rounding_basis: string, rounding_step: float|null} $settings
+         * @return array{step: float, basis: string}|null
+         */
+        private static function build_rounding(array $settings): ?array
+        {
+            $basis = $settings['rounding_basis'];
+            if (!isset(self::ROUNDING_BASIS_TO_API[$basis]) || $settings['rounding_step'] === null) {
+                return null;
+            }
+            return [
+                'step' => $settings['rounding_step'],
+                'basis' => self::ROUNDING_BASIS_TO_API[$basis],
+            ];
         }
 
         /**

--- a/tests/unit/fixtures/testbrand.php
+++ b/tests/unit/fixtures/testbrand.php
@@ -10,6 +10,11 @@ return [
     'product_name' => 'Testbrand',
     'gateway_id' => 'woocommerce-gateway-testbrand',
     'meta_prefix' => 'testbrand',
+    // Deliberately messy: an overlay narrows the step set; declared
+    // unsorted and with invalid entries (<=0, non-numeric) that
+    // get_rounding_step_options must skip rather than fatal on. Expected
+    // cleaned output: 0.50, 1.00.
+    'available_rounding_steps' => [1.00, 0.50, 0, -2, 'x'],
     'availability_gate' => [
         'min_order_amount' => 250.0,
         'currency' => 'EUR',

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -52,6 +52,8 @@ final class BrandConfigSpec
             'testPaymentTermsResolveBrandIntersectAdminSubset',
             'testPaymentTermsDefaultFallsBackToShortest',
             'testBuyerFeeShareShapes',
+            'testBuyerFeeShareRounding',
+            'testRoundingStepOptionsCanonicalAndNarrowed',
             'testOrderPayloadCarriesSelectedAndAvailableTerms',
             'testPaymentTermsInvalidPostFallsBackToDefault',
             'testPaymentTermsDisabledMeansNoPayloadTerms',
@@ -545,6 +547,129 @@ final class BrandConfigSpec
         // Malformed percentage falls back to full pass-through
         $gateway = self::termsGateway(['enable_offset_pricing' => 'yes', 'offset_pricing_percentage' => '150']);
         TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+    }
+
+    private static function testBuyerFeeShareRounding(): void
+    {
+        // Each basis maps to its API value; step rides as a float
+        $gateway = self::termsGateway([
+            'enable_offset_pricing' => 'yes',
+            'surcharge_rounding_basis' => 'up',
+            'surcharge_rounding_step' => '1.00',
+        ]);
+        TinyAssert::same(
+            ['percentage' => '100', 'rounding' => ['step' => 1.0, 'basis' => 'UP']],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway)
+        );
+
+        $gateway = self::termsGateway([
+            'enable_offset_pricing' => 'yes',
+            'surcharge_rounding_basis' => 'down',
+            'surcharge_rounding_step' => '0.50',
+        ]);
+        TinyAssert::same(
+            ['percentage' => '100', 'rounding' => ['step' => 0.5, 'basis' => 'DOWN']],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway)
+        );
+
+        $gateway = self::termsGateway([
+            'enable_offset_pricing' => 'yes',
+            'surcharge_rounding_basis' => 'standard',
+            'surcharge_rounding_step' => '5.00',
+        ]);
+        TinyAssert::same(
+            ['percentage' => '100', 'rounding' => ['step' => 5.0, 'basis' => 'STANDARD']],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway)
+        );
+
+        // None basis: no rounding block even with a step configured
+        $gateway = self::termsGateway([
+            'enable_offset_pricing' => 'yes',
+            'surcharge_rounding_basis' => 'none',
+            'surcharge_rounding_step' => '1.00',
+        ]);
+        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+
+        // Direction set but step <= 0 (or unset): no rounding block (API rejects step <= 0)
+        $gateway = self::termsGateway([
+            'enable_offset_pricing' => 'yes',
+            'surcharge_rounding_basis' => 'up',
+            'surcharge_rounding_step' => '0',
+        ]);
+        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+
+        // Negative step: no block (pins the > 0 guard from the negative side)
+        $gateway = self::termsGateway([
+            'enable_offset_pricing' => 'yes',
+            'surcharge_rounding_basis' => 'up',
+            'surcharge_rounding_step' => '-1.00',
+        ]);
+        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+
+        $gateway = self::termsGateway(['enable_offset_pricing' => 'yes', 'surcharge_rounding_basis' => 'up']);
+        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+
+        // Unmapped basis (not just 'none') with a valid step: no block. Guards
+        // the general "any unmapped value omits" contract, not only 'none'.
+        $gateway = self::termsGateway([
+            'enable_offset_pricing' => 'yes',
+            'surcharge_rounding_basis' => 'garbage',
+            'surcharge_rounding_step' => '1.00',
+        ]);
+        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+
+        $gateway = self::termsGateway([
+            'enable_offset_pricing' => 'yes',
+            'surcharge_rounding_basis' => '',
+            'surcharge_rounding_step' => '1.00',
+        ]);
+        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+
+        // Rounding rides alongside reference terms
+        $gateway = self::termsGateway([
+            'enable_offset_pricing' => 'yes',
+            'offset_pricing_reference_days' => '30',
+            'surcharge_rounding_basis' => 'standard',
+            'surcharge_rounding_step' => '0.50',
+        ]);
+        TinyAssert::same(
+            [
+                'percentage' => '100',
+                'reference_terms' => ['type' => 'NET_TERMS', 'duration_days' => 30],
+                'rounding' => ['step' => 0.5, 'basis' => 'STANDARD'],
+            ],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway)
+        );
+
+        // Offset disabled: no block at all, rounding ignored
+        $gateway = self::termsGateway([
+            'enable_offset_pricing' => 'no',
+            'surcharge_rounding_basis' => 'up',
+            'surcharge_rounding_step' => '1.00',
+        ]);
+        TinyAssert::same(null, WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+    }
+
+    private static function testRoundingStepOptionsCanonicalAndNarrowed(): void
+    {
+        $method = new ReflectionMethod(WC_Twoinc::class, 'get_rounding_step_options');
+        $method->setAccessible(true);
+        $gateway = self::gateway();
+
+        // Default brand: all five steps, canonical two-decimal, ascending
+        TinyAssert::same(
+            ['0.10' => '0.10', '0.50' => '0.50', '1.00' => '1.00', '5.00' => '5.00', '10.00' => '10.00'],
+            $method->invoke($gateway)
+        );
+
+        // Overlay narrows + reorders; invalid entries (<=0, non-numeric) are
+        // skipped, not fatal — fixture declares [1.00, 0.50, 0, -2, 'x']
+        self::useTestbrand();
+        WC_Twoinc_Brand::reset();
+        TinyAssert::same(
+            ['0.50' => '0.50', '1.00' => '1.00'],
+            $method->invoke($gateway)
+        );
     }
 
     private static function testOrderPayloadCarriesSelectedAndAvailableTerms(): void


### PR DESCRIPTION
## What
Ports the Magento buyer-surcharge-rounding feature to WooCommerce (TWO-24892, child of TWO-24739 plugin parity).

The merchant picks a rounding **basis** (None / Up / Down / Standard) and a rounding **step** from a brand-driven dropdown. The plugin relays `buyer_fee_share.rounding = {step: <float>, basis: "UP"|"DOWN"|"STANDARD"}` to `POST /v1/pricing/order/fee`. **All arithmetic stays server-side** — the plugin only relays the contract, mirroring Magento's `Service/Order/SurchargeCalculator`.

## How (mirrors magento-plugin 1:1)
- `brands/two.php` — new `available_rounding_steps` brand key (default `0.10 / 0.50 / 1.00 / 5.00 / 10.00`), the only source for the step dropdown. An overlay narrows the set (cf. `available_terms`).
- `WC_Twoinc::get_rounding_step_options()` — canonical two-decimal option list (`number_format(…,2)`) so the stored value round-trips, ascending (`ksort SORT_NUMERIC`); mirrors the Magento `RoundingStep` source model + `Loader` sort. Two new `select` fields in the offset-pricing section.
- `WC_Twoinc_Payment_Terms` — reads the options in `get_offset_settings()`; `build_rounding()` emits the block, omitting it for a None/unmapped basis or a non-positive step (the API requires both keys and rejects `step <= 0`).
- Tests — `build_buyer_fee_share` rounding cases (basis→API map, None/zero/negative/unmapped omission, rides alongside reference terms, ignored when offset disabled) + a Reflection test pinning the step-option producer (canonical format, sort, overlay narrowing, skip-invalid).

## Semantics
- **None** → no `rounding` block sent (standard 2dp).
- **Up / Down / Standard** → round to nearest step (Standard = commercial half-up). The backend does the maths.

## Stacking
Stacked on `doug/TWO-24751-terms-chips` (the only branch carrying both the `buyer_fee_share` builder and the brand-config layer). Rebases onto staging once TWO-24751 merges.

## Out of scope (blocked, separate tickets)
- **WC-ABN** narrowing (0.50/1.00) → TWO-24894 — blocked: offset-pricing parity not yet ported into the ABN overlay.
- **PrestaShop** rounding → TWO-24893 — blocked: PS has no surcharge/offset-pricing feature yet.

## Test / lint
`php tests/unit/run.php` green on PHP 7.4 + 8.2 (32/32); `php -l` clean. i18n `.pot` regeneration deferred to the Lokalise flow (no CI gate). Two adversarial review rounds → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_PR opened by Claude on Doug's behalf._