### PR TITLE
TWO-24739: Full Magento surcharge parity (per-term grid) + end-of-month terms → staging

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -364,6 +364,104 @@ if (!class_exists('WC_Twoinc')) {
         }
 
         /**
+         * Render the per-term surcharge grid (WC Settings API custom field
+         * `two_surcharge_grid`). One row per offered term, columns
+         * fixed/percentage/cap, mirroring the Magento surcharge grid. Values
+         * are stored as a single option array keyed by term days.
+         */
+        public function generate_two_surcharge_grid_html($key, $data)
+        {
+            $field_key = $this->get_field_key($key);
+            $data = wp_parse_args($data, ['title' => '', 'description' => '']);
+            $stored = $this->get_option($key);
+            $stored = is_array($stored) ? $stored : [];
+            $terms = class_exists('WC_Twoinc_Payment_Terms') ? WC_Twoinc_Payment_Terms::get_available_terms($this) : [];
+
+            ob_start();
+            ?>
+            <tr valign="top">
+                <th scope="row" class="titledesc"><label><?php echo wp_kses_post($data['title']); ?></label></th>
+                <td class="forminp">
+                    <?php if ($data['description']) : ?>
+                        <p class="description"><?php echo wp_kses_post($data['description']); ?></p>
+                    <?php endif; ?>
+                    <?php if (empty($terms)) : ?>
+                        <p><?php esc_html_e('No payment terms are offered yet — configure the offered terms above first.', 'twoinc-payment-gateway'); ?></p>
+                    <?php else : ?>
+                    <table class="widefat" style="max-width:620px">
+                        <thead><tr>
+                            <th><?php esc_html_e('Term (days)', 'twoinc-payment-gateway'); ?></th>
+                            <th><?php esc_html_e('Fixed', 'twoinc-payment-gateway'); ?></th>
+                            <th><?php esc_html_e('Percentage (%)', 'twoinc-payment-gateway'); ?></th>
+                            <th><?php esc_html_e('Cap', 'twoinc-payment-gateway'); ?></th>
+                        </tr></thead>
+                        <tbody>
+                        <?php foreach ($terms as $days) :
+                            $row = isset($stored[$days]) && is_array($stored[$days]) ? $stored[$days] : []; ?>
+                            <tr>
+                                <td><?php echo esc_html($days); ?></td>
+                                <td><input type="text" name="<?php echo esc_attr($field_key); ?>[<?php echo esc_attr($days); ?>][fixed]" value="<?php echo esc_attr(isset($row['fixed']) ? $row['fixed'] : ''); ?>" style="width:90px" /></td>
+                                <td><input type="text" name="<?php echo esc_attr($field_key); ?>[<?php echo esc_attr($days); ?>][percentage]" value="<?php echo esc_attr(isset($row['percentage']) ? $row['percentage'] : ''); ?>" style="width:90px" /></td>
+                                <td><input type="text" name="<?php echo esc_attr($field_key); ?>[<?php echo esc_attr($days); ?>][limit]" value="<?php echo esc_attr(isset($row['limit']) ? $row['limit'] : ''); ?>" style="width:90px" /></td>
+                            </tr>
+                        <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                    <?php endif; ?>
+                </td>
+            </tr>
+            <?php
+            return ob_get_clean();
+        }
+
+        /**
+         * Validate + normalise the posted surcharge grid into an array keyed
+         * by term days, each row holding the non-empty of fixed/percentage/
+         * limit as canonical numeric strings. Empty cells are dropped; blank
+         * rows omitted. Rejects negatives and out-of-range percentages.
+         */
+        public function validate_two_surcharge_grid_field($key, $value)
+        {
+            $clean = [];
+            if (!is_array($value)) {
+                return $clean;
+            }
+            foreach ($value as $days => $cols) {
+                $days = (int) $days;
+                if ($days <= 0 || !is_array($cols)) {
+                    continue;
+                }
+                $row = [];
+                foreach (['fixed', 'percentage', 'limit'] as $col) {
+                    $raw = isset($cols[$col]) ? trim(str_replace(',', '.', (string) $cols[$col])) : '';
+                    if ($raw === '') {
+                        continue;
+                    }
+                    if (!is_numeric($raw) || (float) $raw < 0) {
+                        throw new Exception(sprintf(
+                            /* translators: 1: column name, 2: term days */
+                            __('Surcharge %1$s for the %2$s-day term must be a non-negative number.', 'twoinc-payment-gateway'),
+                            $col,
+                            $days
+                        ));
+                    }
+                    if ($col === 'percentage' && (float) $raw > 100) {
+                        throw new Exception(sprintf(
+                            /* translators: %s: term days */
+                            __('Surcharge percentage for the %s-day term must be between 0 and 100.', 'twoinc-payment-gateway'),
+                            $days
+                        ));
+                    }
+                    $row[$col] = $raw;
+                }
+                if (!empty($row)) {
+                    $clean[$days] = $row;
+                }
+            }
+            return $clean;
+        }
+
+        /**
          * Get payment subtitle
          */
         public function get_pay_subtitle()
@@ -1787,27 +1885,51 @@ if (!class_exists('WC_Twoinc')) {
                     'options'     => $this->get_payment_term_day_options(),
                     'default'     => ''
                 ],
-                'enable_offset_pricing' => [
-                    'title'       => __('Enable offset pricing', 'twoinc-payment-gateway'),
-                    'description' => __('Passes some or all of the service fee to the buyer as a separate line at checkout. The fee is computed by the platform pricing service.', 'twoinc-payment-gateway'),
-                    'desc_tip'    => true,
-                    'label'       => ' ',
-                    'type'        => 'checkbox',
-                    'default'     => 'no'
-                ],
-                'offset_pricing_percentage' => [
-                    'title'       => __('Fee pass-through percentage', 'twoinc-payment-gateway'),
-                    'description' => __('How much of the fee the buyer pays, 0-100. Invalid values fall back to 100.', 'twoinc-payment-gateway'),
-                    'desc_tip'    => true,
-                    'type'        => 'text',
-                    'default'     => '100'
-                ],
-                'offset_pricing_reference_days' => [
-                    'title'       => __('Reference term (incremental mode)', 'twoinc-payment-gateway'),
-                    'description' => __('When set, the buyer only pays the fee difference versus this baseline term (the baseline term itself shows no surcharge). When unset, the configured percentage of the full fee is passed through.', 'twoinc-payment-gateway'),
+                'payment_terms_type' => [
+                    'title'       => __('Payment terms type', 'twoinc-payment-gateway'),
+                    'description' => __('Standard counts the term days from the invoice date. End of month counts them from the end of the invoice month.', 'twoinc-payment-gateway'),
                     'desc_tip'    => true,
                     'type'        => 'select',
-                    'options'     => ['' => __('None - simple pass-through', 'twoinc-payment-gateway')] + $this->get_payment_term_day_options(),
+                    'options'     => [
+                        'standard'     => __('Standard (from invoice date)', 'twoinc-payment-gateway'),
+                        'end_of_month' => __('End of month', 'twoinc-payment-gateway'),
+                    ],
+                    'default'     => 'standard'
+                ],
+                'surcharge_type' => [
+                    'title'       => __('Surcharge type', 'twoinc-payment-gateway'),
+                    'description' => __('How the buyer surcharge is calculated. The platform pricing service computes the fee from this configuration. None disables the surcharge.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'type'        => 'select',
+                    'options'     => [
+                        'none'                 => __('None', 'twoinc-payment-gateway'),
+                        'percentage'           => __('Percentage', 'twoinc-payment-gateway'),
+                        'fixed'                => __('Fixed', 'twoinc-payment-gateway'),
+                        'fixed_and_percentage' => __('Fixed and percentage', 'twoinc-payment-gateway'),
+                    ],
+                    'default'     => 'none'
+                ],
+                'surcharge_grid' => [
+                    'title'       => __('Surcharge per term', 'twoinc-payment-gateway'),
+                    'description' => __('Per payment term: a fixed amount, a percentage of the order, and an optional cap on the percentage portion. Leave a cell blank for zero. Fixed amounts and caps are in the store currency and are not converted for multi-currency stores.', 'twoinc-payment-gateway'),
+                    'type'        => 'two_surcharge_grid',
+                ],
+                'surcharge_differential' => [
+                    'title'       => __('Surcharge basis', 'twoinc-payment-gateway'),
+                    'description' => __('Full charges the configured surcharge for the chosen term. Differential charges only the difference versus the default term (which then shows no surcharge).', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'type'        => 'select',
+                    'options'     => [
+                        '0' => __('Full surcharge', 'twoinc-payment-gateway'),
+                        '1' => __('Differential (vs default term)', 'twoinc-payment-gateway'),
+                    ],
+                    'default'     => '0'
+                ],
+                'surcharge_line_description' => [
+                    'title'       => __('Surcharge line label', 'twoinc-payment-gateway'),
+                    'description' => __('Buyer-facing label for the surcharge line. Use %s for the term length in days. Leave blank to use the brand default.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'type'        => 'text',
                     'default'     => ''
                 ],
                 'surcharge_rounding_basis' => [

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -264,7 +264,7 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                     'enabled' => WC_Twoinc_Payment_Terms::is_enabled($this->wc_twoinc),
                     'terms' => WC_Twoinc_Payment_Terms::get_available_terms($this->wc_twoinc),
                     'selected' => WC_Twoinc_Payment_Terms::get_selected_term($this->wc_twoinc),
-                    'offset_pricing_enabled' => WC_Twoinc_Payment_Terms::get_offset_settings($this->wc_twoinc)['enabled'],
+                    'offset_pricing_enabled' => WC_Twoinc_Payment_Terms::get_surcharge_settings($this->wc_twoinc)['enabled'],
                     'fees_url' => class_exists('WC_AJAX') ? WC_AJAX::get_endpoint('two_term_fees') : '',
                     'select_url' => class_exists('WC_AJAX') ? WC_AJAX::get_endpoint('two_select_term') : '',
                     'nonce' => wp_create_nonce('twoinc_checkout'),

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -124,53 +124,99 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
         }
 
         /**
-         * Offset pricing settings resolved from gateway options.
+         * Surcharge settings resolved from gateway options, mirroring the
+         * Magento surcharge model: a type gate, a per-term grid of
+         * {fixed, percentage, limit}, a differential toggle and rounding.
          *
-         * @return array{enabled: bool, percentage: string, reference_days: int|null, rounding_basis: string, rounding_step: float|null}
+         * @return array{type: string, enabled: bool, differential: bool, grid: array<int,array>, rounding_basis: string, rounding_step: float|null}
          */
-        public static function get_offset_settings($gateway): array
+        public static function get_surcharge_settings($gateway): array
         {
-            $reference_days = (int) $gateway->get_option('offset_pricing_reference_days');
-            $percentage = trim((string) $gateway->get_option('offset_pricing_percentage'));
-            if ($percentage === '' || !is_numeric($percentage) || (float) $percentage < 0 || (float) $percentage > 100) {
-                $percentage = '100';
+            $type = (string) $gateway->get_option('surcharge_type');
+            if (!in_array($type, ['percentage', 'fixed', 'fixed_and_percentage'], true)) {
+                $type = 'none';
             }
+            $grid = $gateway->get_option('surcharge_grid');
+            $grid = is_array($grid) ? $grid : [];
             $rounding_step = (float) $gateway->get_option('surcharge_rounding_step');
             return [
-                'enabled' => $gateway->get_option('enable_offset_pricing') === 'yes',
-                'percentage' => $percentage,
-                'reference_days' => $reference_days > 0 ? $reference_days : null,
+                'type' => $type,
+                'enabled' => $type !== 'none',
+                'differential' => $gateway->get_option('surcharge_differential') === '1',
+                'grid' => $grid,
                 'rounding_basis' => (string) $gateway->get_option('surcharge_rounding_basis'),
                 'rounding_step' => $rounding_step > 0 ? $rounding_step : null,
             ];
         }
 
         /**
-         * The buyer_fee_share block for POST /v1/pricing/order/fee. The
-         * backend computes the fee from this; the plugin does no arithmetic.
-         * With reference terms configured the backend prices the increment
-         * over the baseline term; without them, plain pass-through.
+         * The buyer_fee_share block for POST /v1/pricing/order/fee for one
+         * term. The backend computes the fee from this; the plugin does no
+         * arithmetic. Mirrors Magento's SurchargeCalculator::buildBuyerFeeShare:
+         * percentage (0.0 when fixed-only, so the API default of 100% is never
+         * silently applied), surcharge_basis, the fixed surcharge (fixed/both
+         * types), a cap on the percentage portion, rounding (only with a
+         * percentage component) and, in differential mode, the default term as
+         * reference_terms.
          *
-         * @return array|null null when offset pricing is disabled
+         * @return array|null null when no surcharge is configured (type none)
          */
-        public static function build_buyer_fee_share($gateway): ?array
+        public static function build_buyer_fee_share($gateway, int $days): ?array
         {
-            $settings = self::get_offset_settings($gateway);
+            $settings = self::get_surcharge_settings($gateway);
             if (!$settings['enabled']) {
                 return null;
             }
-            $buyer_fee_share = ['percentage' => $settings['percentage']];
-            if ($settings['reference_days'] !== null) {
-                $buyer_fee_share['reference_terms'] = [
-                    'type' => 'NET_TERMS',
-                    'duration_days' => $settings['reference_days'],
-                ];
+            $has_percentage = in_array($settings['type'], ['percentage', 'fixed_and_percentage'], true);
+            $has_fixed = in_array($settings['type'], ['fixed', 'fixed_and_percentage'], true);
+            $row = isset($settings['grid'][$days]) && is_array($settings['grid'][$days]) ? $settings['grid'][$days] : [];
+
+            $buyer_fee_share = [
+                'percentage' => $has_percentage && isset($row['percentage']) ? (float) $row['percentage'] : 0.0,
+                'surcharge_basis' => 'buyer_pays',
+            ];
+
+            // Fixed amounts and caps are sent as configured, in the store
+            // currency. WooCommerce has no FX rate provider, so multi-currency
+            // conversion is NOT supported (the one parity gap vs Magento, which
+            // converts via Magento's currency rates) — fixed surcharge should
+            // be configured on single-currency stores only. Percentage-based
+            // surcharge is currency-agnostic and unaffected.
+            if ($has_fixed && isset($row['fixed']) && (float) $row['fixed'] > 0) {
+                $buyer_fee_share['surcharge'] = (float) $row['fixed'];
             }
-            $rounding = self::build_rounding($settings);
-            if ($rounding !== null) {
-                $buyer_fee_share['rounding'] = $rounding;
+            if ($has_percentage && isset($row['limit']) && (float) $row['limit'] > 0) {
+                $buyer_fee_share['cap'] = (float) $row['limit'];
+            }
+            if ($has_percentage) {
+                $rounding = self::build_rounding($settings);
+                if ($rounding !== null) {
+                    $buyer_fee_share['rounding'] = $rounding;
+                }
+            }
+            if ($settings['differential']) {
+                $default = self::get_default_term($gateway);
+                if ($default !== null) {
+                    $buyer_fee_share['reference_terms'] = self::build_terms_block($gateway, $default);
+                }
             }
             return $buyer_fee_share;
+        }
+
+        /**
+         * A NET_TERMS block for a duration, adding
+         * duration_days_calculated_from = END_OF_MONTH when the merchant has
+         * selected the end-of-month payment terms type (Magento parity).
+         *
+         * @return array{type: string, duration_days: int, duration_days_calculated_from?: string}
+         */
+        public static function build_terms_block($gateway, int $days): array
+        {
+            $block = ['type' => 'NET_TERMS', 'duration_days' => $days];
+            if ($gateway->get_option('payment_terms_type') === 'end_of_month') {
+                $block['duration_days_calculated_from'] = 'END_OF_MONTH';
+            }
+            return $block;
         }
 
         /**
@@ -208,7 +254,7 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
                 return self::$fee_cache[$days];
             }
 
-            $buyer_fee_share = self::build_buyer_fee_share($gateway);
+            $buyer_fee_share = self::build_buyer_fee_share($gateway, $days);
             if ($buyer_fee_share === null || $gross_amount <= 0) {
                 return self::$fee_cache[$days] = null;
             }
@@ -220,10 +266,7 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
                 'currency' => get_woocommerce_currency(),
                 'gross_amount' => strval(WC_Twoinc_Helper::round_amt($gross_amount)),
                 'buyer_country_code' => $buyer_country,
-                'order_terms' => [
-                    'type' => 'NET_TERMS',
-                    'duration_days' => $days,
-                ],
+                'order_terms' => self::build_terms_block($gateway, $days),
                 'buyer_fee_share' => $buyer_fee_share,
             ], 'POST', array(), null, 10);
 
@@ -283,7 +326,7 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
             if (!$gateway || !self::is_enabled($gateway)) {
                 return;
             }
-            $settings = self::get_offset_settings($gateway);
+            $settings = self::get_surcharge_settings($gateway);
             if (!$settings['enabled']) {
                 return;
             }
@@ -309,10 +352,19 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
         }
 
         /**
-         * Buyer-facing label for the fee line, brand-overridable.
+         * Buyer-facing label for the fee line. A merchant-set
+         * surcharge_line_description wins (with %s replaced by the selected
+         * term days, Magento parity); otherwise the brand label, else a
+         * translated default.
          */
         public static function get_fee_label(): string
         {
+            $gateway = WC_Twoinc::get_instance();
+            $template = $gateway ? trim((string) $gateway->get_option('surcharge_line_description')) : '';
+            if ($template !== '') {
+                $days = $gateway ? self::get_selected_term($gateway) : null;
+                return $days !== null ? str_replace('%s', (string) $days, $template) : $template;
+            }
             $label = WC_Twoinc_Brand::get('fee_line_label');
             return $label ?: __('Service charge', 'twoinc-payment-gateway');
         }
@@ -383,7 +435,7 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
                 return null;
             }
             return [
-                'terms' => ['type' => 'NET_TERMS', 'duration_days' => $selected],
+                'terms' => self::build_terms_block($gateway, $selected),
                 'available_terms' => $terms,
             ];
         }

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -55,6 +55,7 @@ final class BrandConfigSpec
             'testBuyerFeeShareRounding',
             'testRoundingStepOptionsCanonicalAndNarrowed',
             'testRoundingStepValidationEnforcesBrandOptions',
+            'testSurchargeGridValidationNormalisesAndRejects',
             'testOrderPayloadCarriesSelectedAndAvailableTerms',
             'testPaymentTermsInvalidPostFallsBackToDefault',
             'testPaymentTermsDisabledMeansNoPayloadTerms',
@@ -532,133 +533,151 @@ final class BrandConfigSpec
 
     private static function testBuyerFeeShareShapes(): void
     {
-        // Disabled: no block at all
-        $gateway = self::termsGateway(['enable_offset_pricing' => 'no']);
-        TinyAssert::same(null, WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+        // type none (and unset/invalid): no block at all
+        TinyAssert::same(null, WC_Twoinc_Payment_Terms::build_buyer_fee_share(self::termsGateway(['surcharge_type' => 'none']), 30));
+        TinyAssert::same(null, WC_Twoinc_Payment_Terms::build_buyer_fee_share(self::termsGateway([]), 30));
 
-        // Simple pass-through
-        $gateway = self::termsGateway(['enable_offset_pricing' => 'yes', 'offset_pricing_percentage' => '100']);
-        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
-
-        // Partial pass-through
-        $gateway = self::termsGateway(['enable_offset_pricing' => 'yes', 'offset_pricing_percentage' => '50']);
-        TinyAssert::same(['percentage' => '50'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
-
-        // Incremental: reference terms ride along
+        // percentage: the term's grid percentage + buyer_pays basis; no surcharge/cap
         $gateway = self::termsGateway([
-            'enable_offset_pricing' => 'yes',
-            'offset_pricing_percentage' => '100',
-            'offset_pricing_reference_days' => '30',
+            'surcharge_type' => 'percentage',
+            'surcharge_grid' => [30 => ['percentage' => '2.5']],
         ]);
         TinyAssert::same(
-            ['percentage' => '100', 'reference_terms' => ['type' => 'NET_TERMS', 'duration_days' => 30]],
-            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway)
+            ['percentage' => 2.5, 'surcharge_basis' => 'buyer_pays'],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30)
         );
 
-        // Malformed percentage falls back to full pass-through
-        $gateway = self::termsGateway(['enable_offset_pricing' => 'yes', 'offset_pricing_percentage' => '150']);
-        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+        // percentage with a cap (limit)
+        $gateway = self::termsGateway([
+            'surcharge_type' => 'percentage',
+            'surcharge_grid' => [30 => ['percentage' => '3', 'limit' => '50']],
+        ]);
+        TinyAssert::same(
+            ['percentage' => 3.0, 'surcharge_basis' => 'buyer_pays', 'cap' => 50.0],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30)
+        );
+
+        // fixed only: percentage 0.0 (never the API default 100), surcharge present, no cap
+        $gateway = self::termsGateway([
+            'surcharge_type' => 'fixed',
+            'surcharge_grid' => [30 => ['fixed' => '10', 'percentage' => '5', 'limit' => '50']],
+        ]);
+        TinyAssert::same(
+            ['percentage' => 0.0, 'surcharge_basis' => 'buyer_pays', 'surcharge' => 10.0],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30)
+        );
+
+        // fixed_and_percentage: both, plus cap
+        $gateway = self::termsGateway([
+            'surcharge_type' => 'fixed_and_percentage',
+            'surcharge_grid' => [30 => ['fixed' => '10', 'percentage' => '2', 'limit' => '40']],
+        ]);
+        TinyAssert::same(
+            ['percentage' => 2.0, 'surcharge_basis' => 'buyer_pays', 'surcharge' => 10.0, 'cap' => 40.0],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30)
+        );
+
+        // a term with no grid row → percentage 0.0, no surcharge/cap
+        $gateway = self::termsGateway([
+            'surcharge_type' => 'percentage',
+            'surcharge_grid' => [30 => ['percentage' => '2.5']],
+        ]);
+        TinyAssert::same(
+            ['percentage' => 0.0, 'surcharge_basis' => 'buyer_pays'],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 60)
+        );
+
+        // differential: the default term (brand shortest = 14) rides as reference_terms
+        $gateway = self::termsGateway([
+            'surcharge_type' => 'percentage',
+            'surcharge_grid' => [30 => ['percentage' => '2']],
+            'surcharge_differential' => '1',
+        ]);
+        TinyAssert::same(
+            ['percentage' => 2.0, 'surcharge_basis' => 'buyer_pays', 'reference_terms' => ['type' => 'NET_TERMS', 'duration_days' => 14]],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30)
+        );
+
+        // end_of_month: reference_terms carries duration_days_calculated_from
+        $gateway = self::termsGateway([
+            'surcharge_type' => 'percentage',
+            'surcharge_grid' => [30 => ['percentage' => '2']],
+            'surcharge_differential' => '1',
+            'payment_terms_type' => 'end_of_month',
+        ]);
+        TinyAssert::same(
+            ['percentage' => 2.0, 'surcharge_basis' => 'buyer_pays', 'reference_terms' => ['type' => 'NET_TERMS', 'duration_days' => 14, 'duration_days_calculated_from' => 'END_OF_MONTH']],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30)
+        );
+
+        // Fixed amounts are sent as configured (store currency); WooCommerce
+        // does no multi-currency conversion (documented parity gap vs Magento),
+        // so the amount rides regardless of the active display currency.
+        $GLOBALS['__twoinc_test_currency'] = 'GBP';
+        $gateway = self::termsGateway([
+            'surcharge_type' => 'fixed',
+            'surcharge_grid' => [30 => ['fixed' => '10']],
+        ]);
+        TinyAssert::same(
+            ['percentage' => 0.0, 'surcharge_basis' => 'buyer_pays', 'surcharge' => 10.0],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30)
+        );
+        unset($GLOBALS['__twoinc_test_currency']);
     }
 
     private static function testBuyerFeeShareRounding(): void
     {
-        // Each basis maps to its API value; step rides as a float
+        $base = ['surcharge_type' => 'percentage', 'surcharge_grid' => [30 => ['percentage' => '2']]];
+        $expectBase = ['percentage' => 2.0, 'surcharge_basis' => 'buyer_pays'];
+
+        // up/down/standard map to the API enum; step rides as a float
+        foreach ([['up', '1.00', 1.0, 'UP'], ['down', '0.50', 0.5, 'DOWN'], ['standard', '5.00', 5.0, 'STANDARD']] as $c) {
+            $gateway = self::termsGateway($base + ['surcharge_rounding_basis' => $c[0], 'surcharge_rounding_step' => $c[1]]);
+            TinyAssert::same(
+                $expectBase + ['rounding' => ['step' => $c[2], 'basis' => $c[3]]],
+                WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30)
+            );
+        }
+
+        // none / step<=0 / negative / unset / unmapped / empty basis → no rounding block
+        foreach ([['none', '1.00'], ['up', '0'], ['up', '-1.00'], ['up', ''], ['garbage', '1.00'], ['', '1.00']] as $c) {
+            $gateway = self::termsGateway($base + ['surcharge_rounding_basis' => $c[0], 'surcharge_rounding_step' => $c[1]]);
+            TinyAssert::same($expectBase, WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30));
+        }
+
+        // rounding is IGNORED for fixed-only (no percentage component, mirrors Magento $hasPercentage gate)
         $gateway = self::termsGateway([
-            'enable_offset_pricing' => 'yes',
+            'surcharge_type' => 'fixed',
+            'surcharge_grid' => [30 => ['fixed' => '10']],
             'surcharge_rounding_basis' => 'up',
             'surcharge_rounding_step' => '1.00',
         ]);
         TinyAssert::same(
-            ['percentage' => '100', 'rounding' => ['step' => 1.0, 'basis' => 'UP']],
-            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway)
+            ['percentage' => 0.0, 'surcharge_basis' => 'buyer_pays', 'surcharge' => 10.0],
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30)
         );
 
-        $gateway = self::termsGateway([
-            'enable_offset_pricing' => 'yes',
-            'surcharge_rounding_basis' => 'down',
-            'surcharge_rounding_step' => '0.50',
-        ]);
-        TinyAssert::same(
-            ['percentage' => '100', 'rounding' => ['step' => 0.5, 'basis' => 'DOWN']],
-            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway)
-        );
-
-        $gateway = self::termsGateway([
-            'enable_offset_pricing' => 'yes',
-            'surcharge_rounding_basis' => 'standard',
-            'surcharge_rounding_step' => '5.00',
-        ]);
-        TinyAssert::same(
-            ['percentage' => '100', 'rounding' => ['step' => 5.0, 'basis' => 'STANDARD']],
-            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway)
-        );
-
-        // None basis: no rounding block even with a step configured
-        $gateway = self::termsGateway([
-            'enable_offset_pricing' => 'yes',
-            'surcharge_rounding_basis' => 'none',
-            'surcharge_rounding_step' => '1.00',
-        ]);
-        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
-
-        // Direction set but step <= 0 (or unset): no rounding block (API rejects step <= 0)
-        $gateway = self::termsGateway([
-            'enable_offset_pricing' => 'yes',
-            'surcharge_rounding_basis' => 'up',
-            'surcharge_rounding_step' => '0',
-        ]);
-        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
-
-        // Negative step: no block (pins the > 0 guard from the negative side)
-        $gateway = self::termsGateway([
-            'enable_offset_pricing' => 'yes',
-            'surcharge_rounding_basis' => 'up',
-            'surcharge_rounding_step' => '-1.00',
-        ]);
-        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
-
-        $gateway = self::termsGateway(['enable_offset_pricing' => 'yes', 'surcharge_rounding_basis' => 'up']);
-        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
-
-        // Unmapped basis (not just 'none') with a valid step: no block. Guards
-        // the general "any unmapped value omits" contract, not only 'none'.
-        $gateway = self::termsGateway([
-            'enable_offset_pricing' => 'yes',
-            'surcharge_rounding_basis' => 'garbage',
-            'surcharge_rounding_step' => '1.00',
-        ]);
-        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
-
-        $gateway = self::termsGateway([
-            'enable_offset_pricing' => 'yes',
-            'surcharge_rounding_basis' => '',
-            'surcharge_rounding_step' => '1.00',
-        ]);
-        TinyAssert::same(['percentage' => '100'], WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
-
-        // Rounding rides alongside reference terms
-        $gateway = self::termsGateway([
-            'enable_offset_pricing' => 'yes',
-            'offset_pricing_reference_days' => '30',
+        // rounding rides alongside reference_terms (differential)
+        $gateway = self::termsGateway($base + [
+            'surcharge_differential' => '1',
             'surcharge_rounding_basis' => 'standard',
             'surcharge_rounding_step' => '0.50',
         ]);
         TinyAssert::same(
-            [
-                'percentage' => '100',
-                'reference_terms' => ['type' => 'NET_TERMS', 'duration_days' => 30],
+            $expectBase + [
                 'rounding' => ['step' => 0.5, 'basis' => 'STANDARD'],
+                'reference_terms' => ['type' => 'NET_TERMS', 'duration_days' => 14],
             ],
-            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway)
+            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30)
         );
 
-        // Offset disabled: no block at all, rounding ignored
+        // type none: no block at all, rounding ignored
         $gateway = self::termsGateway([
-            'enable_offset_pricing' => 'no',
+            'surcharge_type' => 'none',
             'surcharge_rounding_basis' => 'up',
             'surcharge_rounding_step' => '1.00',
         ]);
-        TinyAssert::same(null, WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway));
+        TinyAssert::same(null, WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30));
     }
 
     private static function testRoundingStepOptionsCanonicalAndNarrowed(): void
@@ -699,6 +718,41 @@ final class BrandConfigSpec
             $threw = true;
         }
         TinyAssert::true($threw);
+    }
+
+    private static function testSurchargeGridValidationNormalisesAndRejects(): void
+    {
+        $gateway = self::gateway();
+
+        // Comma decimals normalise to dots; empty cells drop; blank rows omit;
+        // non-positive term keys are skipped.
+        $clean = $gateway->validate_two_surcharge_grid_field('surcharge_grid', [
+            '30' => ['fixed' => '10,50', 'percentage' => '2.5', 'limit' => ''],
+            '60' => ['fixed' => '', 'percentage' => '', 'limit' => ''],
+            '0'  => ['fixed' => '5'],
+        ]);
+        TinyAssert::same([30 => ['fixed' => '10.50', 'percentage' => '2.5']], $clean);
+
+        // Negative value rejected
+        $threw = false;
+        try {
+            $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['fixed' => '-1']]);
+        } catch (Exception $e) {
+            $threw = true;
+        }
+        TinyAssert::true($threw);
+
+        // Percentage > 100 rejected
+        $threw = false;
+        try {
+            $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['percentage' => '150']]);
+        } catch (Exception $e) {
+            $threw = true;
+        }
+        TinyAssert::true($threw);
+
+        // Non-array input → empty grid
+        TinyAssert::same([], $gateway->validate_two_surcharge_grid_field('surcharge_grid', ''));
     }
 
     private static function testOrderPayloadCarriesSelectedAndAvailableTerms(): void


### PR DESCRIPTION
Phase B of the WooCommerce↔Magento parity work, onto **staging** (Phase A is already on staging via #329).

Brings WC surcharge/offset pricing to the Magento model:
- `surcharge_type` (none/percentage/fixed/fixed_and_percentage) — supersedes the simple offset model.
- **Per-term surcharge grid** (custom `two_surcharge_grid` settings field): fixed / percentage / cap per offered term.
- `build_buyer_fee_share` per-term, mirroring Magento's `buyer_fee_share` contract (percentage 0.0 when fixed-only, `surcharge_basis`, `surcharge`, `cap`, `rounding` only with a percentage component, `reference_terms` in differential mode).
- `surcharge_differential` toggle; `payment_terms_type` standard/**end_of_month** (`duration_days_calculated_from`); optional `surcharge_line_description`.

**Flagged framework-mismatch decisions** (WC ≠ Magento):
- **FX**: WC has no rate provider and no reliable store-vs-order currency signal at quote time → fixed/cap sent as configured in store currency, **no conversion** (single-currency assumption; documented parity gap). Percentage surcharge is currency-agnostic.
- **Tax**: WC fees use tax *classes*, not arbitrary rates → surcharge line keeps WC store tax (`add_fee` taxable); no `surcharge_tax_rate` field.

**Deferred follow-ups** (kept this PR focused): PO-number-in-payload; verify address-lookup (already wired here).

Tests rewritten for the grid model + grid-validator + end-of-month; green on PHP 7.4 + 8.2. Two adversarial review rounds → clean (first round caught a no-op FX guard / cap-stripping bug, now removed).

_(opened by Claude)_