### PR TITLE
TWO-24739/fix: register wc-ajax checkout endpoints at plugins_loaded

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -83,13 +83,9 @@ if (!class_exists('WC_Twoinc')) {
             // Business logic lives in WC_Twoinc_Payment_Terms; the JS layer
             // renders only what these endpoints return.
             add_action('woocommerce_cart_calculate_fees', ['WC_Twoinc_Payment_Terms', 'apply_cart_fee']);
-            add_action('wc_ajax_two_term_fees', ['WC_Twoinc_Payment_Terms', 'ajax_term_fees']);
-            add_action('wc_ajax_two_select_term', ['WC_Twoinc_Payment_Terms', 'ajax_select_term']);
-
-            // Sole trader checkout (TWO-24754). Same split: decisioning in
-            // WC_Twoinc_Sole_Trader, JS renders only what these return.
-            add_action('wc_ajax_two_sole_trader_availability', ['WC_Twoinc_Sole_Trader', 'ajax_availability']);
-            add_action('wc_ajax_two_sole_trader_tokens', ['WC_Twoinc_Sole_Trader', 'ajax_tokens']);
+            // NOTE: the wc_ajax_two_* endpoints are registered in
+            // load_twoinc_classes() (plugins_loaded), not here — the gateway
+            // constructor does not run on a standalone wc-ajax request.
 
             if (is_admin()) {
                 // Notice banner if plugin is not setup properly

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -60,6 +60,20 @@ function load_twoinc_classes()
     require_once __DIR__ . '/class/WC_Twoinc_Checkout.php';
     require_once __DIR__ . '/class/WC_Twoinc.php';
 
+    // Checkout AJAX endpoints (term-fee chips, term selection, sole-trader
+    // availability/tokens). Registered here at plugins_loaded — NOT in the
+    // gateway constructor — because a wc-ajax request is dispatched at
+    // template_redirect priority 0, before WooCommerce instantiates the
+    // payment gateways on demand. The constructor only runs on pages that
+    // load the gateway (e.g. checkout), so handlers registered there are
+    // absent on the standalone wc-ajax request and the action fires with no
+    // listener (empty 200). The handlers are static and lazily fetch the
+    // gateway via WC_Twoinc::get_instance(), so no instance is needed here.
+    add_action('wc_ajax_two_term_fees', ['WC_Twoinc_Payment_Terms', 'ajax_term_fees']);
+    add_action('wc_ajax_two_select_term', ['WC_Twoinc_Payment_Terms', 'ajax_select_term']);
+    add_action('wc_ajax_two_sole_trader_availability', ['WC_Twoinc_Sole_Trader', 'ajax_availability']);
+    add_action('wc_ajax_two_sole_trader_tokens', ['WC_Twoinc_Sole_Trader', 'ajax_tokens']);
+
     // Confirm order after returning from twoinc checkout-page, DO NOT CHANGE HOOKS
     add_action('template_redirect', 'WC_Twoinc::process_confirmation_header_redirect');
     // add_action('template_redirect', 'WC_Twoinc::before_process_confirmation');


### PR DESCRIPTION
## Problem

Live staging test of the surcharge parity work surfaced three checkout bugs:
- term-fee chips rendered (14/30/60/90) but with **no fee labels**;
- **no surcharge line** in the order totals;
- **no sole-trader toggle** despite the feature being enabled for a GB buyer.

Diagnosis: all three `wc-ajax` endpoints (`two_term_fees`, `two_select_term`, `two_sole_trader_availability`) returned a clean **200 with an empty body** — the signature of a `wc-ajax` action firing with no registered listener.

## Root cause

The four `wc_ajax_two_*` handlers were registered in the **gateway constructor**. WooCommerce only instantiates the gateway when it needs to (e.g. rendering the checkout payment box), so the constructor runs on the checkout *page* — which is why `window.twoinc` is well-formed — but **not** on a standalone `wc-ajax` request. Those requests are dispatched at `template_redirect` priority 0, before the payment gateways load on demand, so the action fired with no handler and emitted an empty body. The widget then fell back to "not available", chips had no fee data, and the sole-trader toggle never initialised.

## Fix

Move the four registrations to `load_twoinc_classes()` (`plugins_loaded`, runs on every request). The handlers are static and fetch the gateway lazily via `WC_Twoinc::get_instance()`, so no instance is required at registration time. `apply_cart_fee` (the `woocommerce_cart_calculate_fees` hook) stays in the constructor — it only needs to fire during cart calculation, which happens in gateway-loaded contexts.

Syntax-clean on PHP 7.4 and 8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)