### PR TITLE
TWO-24739/fix: send approved_on_recourse in pricing fee request

### DIFF
--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -266,6 +266,10 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
                 'currency' => get_woocommerce_currency(),
                 'gross_amount' => strval(WC_Twoinc_Helper::round_amt($gross_amount)),
                 'buyer_country_code' => $buyer_country,
+                // Required by OrderFeeRequestSchema. Hardcoded false for
+                // parity with Magento (SurchargeCalculator) — there is no
+                // admin recourse-pricing config on either plugin yet.
+                'approved_on_recourse' => false,
                 'order_terms' => self::build_terms_block($gateway, $days),
                 'buyer_fee_share' => $buyer_fee_share,
             ], 'POST', array(), null, 10);


### PR DESCRIPTION
## Problem

After the wc-ajax registration fix (#331), the term-fee endpoint returns JSON but every per-term fee is `null`. WooCommerce API logging on staging shows why: `POST /v1/pricing/order/fee` rejects every call with **HTTP 400 `SCHEMA_ERROR`**:

> `OrderFeeRequestSchema: approved_on_recourse: Field required [type=missing]`

The plugin never sent the (now-required) `approved_on_recourse` field, so the request fails validation before any fee is computed — no chip fee labels, no surcharge line.

## Fix

Add `approved_on_recourse => false` to the fee request payload, matching Magento's `SurchargeCalculator` (`Service/Order/SurchargeCalculator.php:116`), which hardcodes `false`. Neither plugin has an admin recourse-pricing config yet (Magento carries the same TODO).

Unit suite green on PHP 7.4 and 8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)