### PR TITLE
TWO-24739/fix: register surcharge cart-fee hook at plugins_loaded

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -82,10 +82,12 @@ if (!class_exists('WC_Twoinc')) {
             // Payment terms chip selector + offset pricing fee (TWO-24751).
             // Business logic lives in WC_Twoinc_Payment_Terms; the JS layer
             // renders only what these endpoints return.
-            add_action('woocommerce_cart_calculate_fees', ['WC_Twoinc_Payment_Terms', 'apply_cart_fee']);
-            // NOTE: the wc_ajax_two_* endpoints are registered in
-            // load_twoinc_classes() (plugins_loaded), not here — the gateway
-            // constructor does not run on a standalone wc-ajax request.
+            // NOTE: the surcharge cart-fee hook and the wc_ajax_two_*
+            // endpoints are registered in load_twoinc_classes()
+            // (plugins_loaded), not here — the gateway constructor is not
+            // guaranteed to have run before woocommerce_cart_calculate_fees
+            // fires on an update_order_review recalc, nor on a standalone
+            // wc-ajax request.
 
             if (is_admin()) {
                 // Notice banner if plugin is not setup properly

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -334,9 +334,13 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
             if (!$settings['enabled']) {
                 return;
             }
-            // Only charge when paying with this gateway
+            // Only charge when this gateway is the chosen payment method. The
+            // hook is registered globally (see load_twoinc_classes), so it
+            // also fires on the cart page and before any method is selected;
+            // require an explicit match rather than "apply unless another is
+            // chosen" so the surcharge never leaks onto a non-Two context.
             $chosen = function_exists('WC') && (WC()->session ?? null) ? WC()->session->get('chosen_payment_method') : null;
-            if ($chosen && $chosen !== $gateway->id) {
+            if ($chosen !== $gateway->id) {
                 return;
             }
 

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -69,6 +69,15 @@ function load_twoinc_classes()
     // absent on the standalone wc-ajax request and the action fires with no
     // listener (empty 200). The handlers are static and lazily fetch the
     // gateway via WC_Twoinc::get_instance(), so no instance is needed here.
+    //
+    // The surcharge cart fee is registered here for the same reason: on an
+    // update_order_review recalc, calculate_totals() (which fires
+    // woocommerce_cart_calculate_fees) can run before WooCommerce constructs
+    // the gateway, so a constructor-registered hook is missed and the fee
+    // never lands on the order total. apply_cart_fee is static and self-gates
+    // (enabled + chosen-payment-method + selected-term), so registering it on
+    // every request is safe.
+    add_action('woocommerce_cart_calculate_fees', ['WC_Twoinc_Payment_Terms', 'apply_cart_fee']);
     add_action('wc_ajax_two_term_fees', ['WC_Twoinc_Payment_Terms', 'ajax_term_fees']);
     add_action('wc_ajax_two_select_term', ['WC_Twoinc_Payment_Terms', 'ajax_select_term']);
     add_action('wc_ajax_two_sole_trader_availability', ['WC_Twoinc_Sole_Trader', 'ajax_availability']);


### PR DESCRIPTION
## Problem

Live checkout test after #332: the term chips correctly advertise the surcharge ("14 DAYS +5 GBP") but the **order totals show no fee line** — Total equals Subtotal (£3,074.00), the surcharge is never collected.

## Root cause

Same constructor-timing trap as the wc-ajax handlers (#331). `woocommerce_cart_calculate_fees` was registered in the gateway constructor, but on an `update_order_review` recalc `calculate_totals()` can fire before WooCommerce constructs the gateway, so the hook is missed and no fee is added.

## Fix

- Move the `woocommerce_cart_calculate_fees` registration to `load_twoinc_classes()` (`plugins_loaded`, every request). `apply_cart_fee` is static and self-gates.
- Because it now also runs on the cart page / before a method is chosen, tighten the payment-method guard from "apply unless another gateway is chosen" to "apply only when Two is the chosen method" (Magento parity — surcharge applies when paying with Two), so the fee can't leak onto a non-Two context.

Unit suite green on PHP 7.4 and 8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)