### PR TITLE
TWO-24739/fix: require a company before sending the order to the API

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -1239,6 +1239,25 @@ if (!class_exists('WC_Twoinc')) {
             $invoice_email = array_key_exists('invoice_email', $_POST) ? sanitize_text_field($_POST['invoice_email']) : '';
             $invoice_emails = $invoice_email ? array_map('sanitize_text_field', explode(',', $invoice_email)) : [];
 
+            // A company (organization number) is mandatory: the order API's
+            // CreateOrderRequestSchema requires buyer.company.organization_number
+            // and rejects an empty value with a 400 SCHEMA_ERROR. Fail fast with
+            // a clear checkout error instead of letting that raw 400 surface as a
+            // silent failure when no company has been selected (e.g. the company
+            // search result was never picked, or the selection was cleared by a
+            // later country change). Sole-trader checkout also populates
+            // company_id (via the resolved registry identity), so this guard is
+            // safe for both flows.
+            if ($company_id === '') {
+                WC_Twoinc_Helper::display_ajax_error(
+                    sprintf(
+                        __('Please select your company before paying with %s.', 'twoinc-payment-gateway'),
+                        WC_Twoinc_Brand::get('product_name')
+                    )
+                );
+                return;
+            }
+
             // Store the order meta
             $order->update_meta_data(WC_Twoinc_Brand::meta_key('order_reference'), $order_reference);
             $order->update_meta_data(WC_Twoinc_Brand::meta_key('merchant_id'), $merchant_id);


### PR DESCRIPTION
## Problem

A test surfaced a "Place order" that silently did nothing. The WC API log showed `POST /v1/order` → **400 `SCHEMA_ERROR`**: `buyer.company.organization_number: Invalid organization number: ''`. The order was POSTed with an **empty org number** and the resulting 400 was not surfaced to the buyer — a dead button with no notice.

## Fix

Guard in `process_payment`: when `company_id` is empty, fail fast with a clear checkout error ("Please select your company before paying with Two") instead of firing a request the API will reject. Mirrors the existing brand-validation pattern. Sole-trader checkout also populates `company_id` (resolved registry identity), so the guard is safe for both flows.

## Note on the related "company search didn't populate" symptom

Investigated and it is **not a plugin bug** — it was a Chrome-bridge/automation artifact: Select2 binds result selection to `mouseup`, and the test harness's synthetic single `click` (no `mouseup`) was silently ignored, leaving `#company_id` empty. A real mouse selection (`mousedown→mouseup`) populates `#company_id` correctly every time. This guard additionally makes any such empty-company submission non-silent.

Lints clean on PHP 7.4 and 8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)