### PR TITLE
TWO-24751: align WooCommerce payment-terms admin with Magento

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -460,6 +460,110 @@ if (!class_exists('WC_Twoinc')) {
         }
 
         /**
+         * Render the "Payment Terms" checkboxes (WC Settings API custom field
+         * `two_payment_terms`). One checkbox per term the brand makes available;
+         * the merchant ticks which to offer the buyer. Stored as a single option
+         * array of int day counts (the offered subset). Mirrors Magento's
+         * PaymentTermsCheckboxes admin field.
+         */
+        public function generate_two_payment_terms_html($key, $data)
+        {
+            $field_key = $this->get_field_key($key);
+            $data = wp_parse_args($data, ['title' => '', 'description' => '', 'desc_tip' => false]);
+            $stored = $this->get_option($key);
+            $stored = is_array($stored) ? array_map('intval', $stored) : [];
+            $options = $this->get_payment_term_day_options();
+            if (count($stored) === 0 && count($options) > 0) {
+                // Prepopulate the shortest available term so the form never loads
+                // with no selection (a selection is mandatory on save).
+                $days = array_map('intval', array_keys($options));
+                sort($days);
+                $stored = [$days[0]];
+            }
+
+            ob_start();
+            ?>
+            <tr valign="top">
+                <th scope="row" class="titledesc">
+                    <label><?php echo wp_kses_post($data['title']); ?></label>
+                    <?php echo $this->get_tooltip_html($data); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                </th>
+                <td class="forminp">
+                    <?php if (empty($options)) : ?>
+                        <p><?php esc_html_e('No payment terms are available for this brand.', 'twoinc-payment-gateway'); ?></p>
+                    <?php else : ?>
+                    <fieldset>
+                        <?php foreach ($options as $value => $label) :
+                            $days = (int) $value; ?>
+                            <label style="display:block;margin-bottom:4px">
+                                <input type="checkbox"
+                                       name="<?php echo esc_attr($field_key); ?>[]"
+                                       value="<?php echo esc_attr($days); ?>"
+                                       <?php checked(in_array($days, $stored, true)); ?> />
+                                <?php echo esc_html($label); ?>
+                            </label>
+                        <?php endforeach; ?>
+                    </fieldset>
+                    <?php endif; ?>
+                </td>
+            </tr>
+            <?php
+            return ob_get_clean();
+        }
+
+        /**
+         * Validate the posted "Payment Terms" checkboxes into a sorted array of
+         * unique int day counts, restricted to the brand's available terms.
+         *
+         * A selection is mandatory on save. "No selection" is well-defined
+         * internally (an empty offer falls through to the account default), but
+         * it gives the merchant no feedback on the resulting behaviour, so we
+         * insist on a selection every time they save. The custom-days sibling
+         * field (posted in the same form) also satisfies it, so a single
+         * off-preset term may be offered alone. Mirrors Magento's
+         * PaymentTermsCheckboxes::beforeSave guard.
+         */
+        public function validate_two_payment_terms_field($key, $value)
+        {
+            $allowed = array_map('intval', array_keys($this->get_payment_term_day_options()));
+            $clean = [];
+            if (is_array($value)) {
+                foreach ($value as $day) {
+                    $day = (int) $day;
+                    if ($day > 0 && in_array($day, $allowed, true)) {
+                        $clean[] = $day;
+                    }
+                }
+            }
+            $clean = array_values(array_unique($clean));
+            sort($clean);
+
+            $custom_key = $this->get_field_key('payment_terms_custom_days');
+            $posted_custom = isset($_POST[$custom_key]) ? (int) $_POST[$custom_key] : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            if (count($clean) === 0 && $posted_custom <= 0) {
+                throw new Exception(__('Select at least one payment term or enter a custom term.', 'twoinc-payment-gateway'));
+            }
+            return $clean;
+        }
+
+        /**
+         * Validate the optional custom payment term: a non-negative whole number
+         * of days, or blank. Mirrors Magento's payment_terms_duration_days
+         * (validate-digits validate-zero-or-greater).
+         */
+        public function validate_payment_terms_custom_days_field($key, $value)
+        {
+            $value = trim((string) $value);
+            if ($value === '') {
+                return '';
+            }
+            if (!ctype_digit($value)) {
+                throw new Exception(__('Custom Payment Term (days) must be a whole number of days.', 'twoinc-payment-gateway'));
+            }
+            return (string) (int) $value;
+        }
+
+        /**
          * Get payment subtitle
          */
         public function get_pay_subtitle()
@@ -1877,33 +1981,22 @@ if (!class_exists('WC_Twoinc')) {
                     'type'  => 'title',
                     'title' => __('Payment terms and offset pricing', 'twoinc-payment-gateway'),
                 ],
-                'enable_payment_terms' => [
-                    'title'       => __('Enable payment terms selection', 'twoinc-payment-gateway'),
-                    'description' => __('Lets the buyer choose their invoice term at checkout from the terms offered below.', 'twoinc-payment-gateway'),
-                    'desc_tip'    => true,
-                    'label'       => ' ',
-                    'type'        => 'checkbox',
-                    'default'     => 'no'
-                ],
                 'payment_terms_days' => [
-                    'title'       => __('Offered terms', 'twoinc-payment-gateway'),
-                    'description' => __('Terms shown to the buyer. Leave empty to offer all terms available to this brand.', 'twoinc-payment-gateway'),
+                    'title'       => __('Payment Terms', 'twoinc-payment-gateway'),
+                    'description' => __('Select the payment term(s) you want to offer.', 'twoinc-payment-gateway'),
                     'desc_tip'    => true,
-                    'type'        => 'multiselect',
-                    'class'       => 'wc-enhanced-select',
-                    'options'     => $this->get_payment_term_day_options(),
-                    'default'     => []
+                    'type'        => 'two_payment_terms',
                 ],
-                'default_payment_term' => [
-                    'title'       => __('Default term', 'twoinc-payment-gateway'),
-                    'description' => __('Pre-selected term at checkout. Falls back to the shortest offered term.', 'twoinc-payment-gateway'),
-                    'desc_tip'    => true,
-                    'type'        => 'select',
-                    'options'     => $this->get_payment_term_day_options(),
-                    'default'     => ''
+                'payment_terms_custom_days' => [
+                    'title'             => __('Custom Payment Term (days)', 'twoinc-payment-gateway'),
+                    'description'       => __('Optional. Enter a custom number of days to offer alongside the selected terms above.', 'twoinc-payment-gateway'),
+                    'desc_tip'          => true,
+                    'type'              => 'number',
+                    'custom_attributes' => ['min' => '0', 'step' => '1'],
+                    'default'           => ''
                 ],
                 'payment_terms_type' => [
-                    'title'       => __('Payment terms type', 'twoinc-payment-gateway'),
+                    'title'       => __('Payment Terms Type', 'twoinc-payment-gateway'),
                     'description' => __('Standard counts the term days from the invoice date. End of month counts them from the end of the invoice month.', 'twoinc-payment-gateway'),
                     'desc_tip'    => true,
                     'type'        => 'select',
@@ -1913,44 +2006,52 @@ if (!class_exists('WC_Twoinc')) {
                     ],
                     'default'     => 'standard'
                 ],
+                'default_payment_term' => [
+                    'title'       => __('Default Payment Term', 'twoinc-payment-gateway'),
+                    'description' => __('Select the payment term that will be automatically selected for your customer.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'type'        => 'select',
+                    'options'     => $this->get_payment_term_day_options(),
+                    'default'     => ''
+                ],
                 'surcharge_type' => [
-                    'title'       => __('Surcharge type', 'twoinc-payment-gateway'),
-                    'description' => __('How the buyer surcharge is calculated. The platform pricing service computes the fee from this configuration. None disables the surcharge.', 'twoinc-payment-gateway'),
+                    'title'       => __('Surcharge Method', 'twoinc-payment-gateway'),
+                    'description' => __('Select a method to surcharge your customer.', 'twoinc-payment-gateway'),
                     'desc_tip'    => true,
                     'type'        => 'select',
                     'options'     => [
-                        'none'                 => __('None', 'twoinc-payment-gateway'),
+                        'none'                 => __('No surcharge applied', 'twoinc-payment-gateway'),
                         'percentage'           => __('Percentage', 'twoinc-payment-gateway'),
-                        'fixed'                => __('Fixed', 'twoinc-payment-gateway'),
-                        'fixed_and_percentage' => __('Fixed and percentage', 'twoinc-payment-gateway'),
+                        'fixed'                => __('Fixed fee', 'twoinc-payment-gateway'),
+                        'fixed_and_percentage' => __('Fixed fee and percentage', 'twoinc-payment-gateway'),
                     ],
                     'default'     => 'none'
                 ],
-                'surcharge_grid' => [
-                    'title'       => __('Surcharge per term', 'twoinc-payment-gateway'),
-                    'description' => __('Per payment term: a fixed amount, a percentage of the order, and an optional cap on the percentage portion. Leave a cell blank for zero. Fixed amounts and caps are in the store currency and are not converted for multi-currency stores.', 'twoinc-payment-gateway'),
-                    'type'        => 'two_surcharge_grid',
-                ],
                 'surcharge_differential' => [
-                    'title'       => __('Surcharge basis', 'twoinc-payment-gateway'),
-                    'description' => __('Full charges the configured surcharge for the chosen term. Differential charges only the difference versus the default term (which then shows no surcharge).', 'twoinc-payment-gateway'),
+                    'title'       => __('Surcharge Calculation Basis', 'twoinc-payment-gateway'),
+                    'description' => __('Total fee charges the configured surcharge for the chosen term. Fee difference charges only the difference versus the default term (which then shows no surcharge).', 'twoinc-payment-gateway'),
                     'desc_tip'    => true,
                     'type'        => 'select',
                     'options'     => [
-                        '0' => __('Full surcharge', 'twoinc-payment-gateway'),
-                        '1' => __('Differential (vs default term)', 'twoinc-payment-gateway'),
+                        '0' => __('Total fee for selected term', 'twoinc-payment-gateway'),
+                        '1' => __('Fee difference vs default payment term', 'twoinc-payment-gateway'),
                     ],
                     'default'     => '0'
                 ],
                 'surcharge_line_description' => [
-                    'title'       => __('Surcharge line label', 'twoinc-payment-gateway'),
+                    'title'       => __('Surcharge Line Description', 'twoinc-payment-gateway'),
                     'description' => __('Buyer-facing label for the surcharge line. Use %s for the term length in days. Leave blank to use the brand default.', 'twoinc-payment-gateway'),
                     'desc_tip'    => true,
                     'type'        => 'text',
                     'default'     => ''
                 ],
+                'surcharge_grid' => [
+                    'title'       => __('Payment Surcharge Configuration', 'twoinc-payment-gateway'),
+                    'description' => __('Per payment term: a fixed amount, a percentage of the order, and an optional cap on the percentage portion. Leave a cell blank for zero. Fixed amounts and caps are in the store currency and are not converted for multi-currency stores.', 'twoinc-payment-gateway'),
+                    'type'        => 'two_surcharge_grid',
+                ],
                 'surcharge_rounding_basis' => [
-                    'title'       => __('Surcharge rounding', 'twoinc-payment-gateway'),
+                    'title'       => __('Surcharge Rounding', 'twoinc-payment-gateway'),
                     'description' => __('Snap the buyer surcharge line to a clean increment. Select None for standard two-decimal amounts.', 'twoinc-payment-gateway'),
                     'desc_tip'    => true,
                     'type'        => 'select',
@@ -1963,7 +2064,7 @@ if (!class_exists('WC_Twoinc')) {
                     'default'     => 'none'
                 ],
                 'surcharge_rounding_step' => [
-                    'title'       => __('Rounding step', 'twoinc-payment-gateway'),
+                    'title'       => __('Rounding Step', 'twoinc-payment-gateway'),
                     'description' => __('Increment the surcharge is rounded to (e.g. 1 = whole units, 0.50 = nearest half). Applies only when a rounding direction is selected.', 'twoinc-payment-gateway'),
                     'desc_tip'    => true,
                     'type'        => 'select',

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -261,7 +261,9 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                 // endpoints in WC_Twoinc_Payment_Terms.
                 'payment_terms' => [
                     'days_label' => __('%s days', 'twoinc-payment-gateway'),
-                    'enabled' => WC_Twoinc_Payment_Terms::is_enabled($this->wc_twoinc),
+                    // Chip chooser shows only with >1 offered term; a single term
+                    // is applied silently (fee still applies via apply_cart_fee).
+                    'enabled' => WC_Twoinc_Payment_Terms::is_selector_visible($this->wc_twoinc),
                     'terms' => WC_Twoinc_Payment_Terms::get_available_terms($this->wc_twoinc),
                     'selected' => WC_Twoinc_Payment_Terms::get_selected_term($this->wc_twoinc),
                     'offset_pricing_enabled' => WC_Twoinc_Payment_Terms::get_surcharge_settings($this->wc_twoinc)['enabled'],

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -7,11 +7,14 @@
  * these methods return (the Gutenberg block checkout port must not need a
  * business-logic rewrite, see TWO-24767).
  *
- * Term availability: `get_available_terms()` is the single seam. Today it
- * resolves brand config (`available_terms`) intersected with the merchant's
- * admin subset; when the backend grows a term-availability surface (planned
- * convergence — backend owns which terms are offered) only this method
- * changes. Do not read term lists anywhere else.
+ * Term availability: `get_available_terms()` is the single seam. It resolves
+ * the merchant's ticked presets (brand `available_terms` ∩ admin subset) plus
+ * an optional custom term. An empty result means "offer nothing" — no term is
+ * sent and the backend applies the account default (pre-feature behaviour). The
+ * merchant cannot save into that empty state once terms are configured (see
+ * WC_Twoinc::validate_two_payment_terms_field). When the backend grows a
+ * term-availability surface (planned convergence — backend owns which terms are
+ * offered) only this method changes. Do not read term lists anywhere else.
  *
  * Fee arithmetic is never done plugin-side: the offset settings are posted to
  * POST /v1/pricing/order/fee as a `buyer_fee_share` block and the backend
@@ -38,35 +41,55 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
         private static $fee_cache = [];
 
         /**
-         * Whether the chip selector is active: merchant enabled it and the
-         * resolved term set is non-empty.
+         * Whether the term feature is active: at least one term is offered. When
+         * true a term is sent on the order and any configured surcharge applies.
+         * There is no merchant on/off toggle — the offered-term set is the single
+         * switch, and an empty set falls through to the account default.
          */
         public static function is_enabled($gateway): bool
         {
-            return $gateway->get_option('enable_payment_terms') === 'yes'
-                && count(self::get_available_terms($gateway)) > 0;
+            return count(self::get_available_terms($gateway)) > 0;
+        }
+
+        /**
+         * Whether the buyer sees a term chooser: only when more than one term is
+         * offered. A single offered term is applied silently (no chip selector),
+         * so selection is implicitly disabled when just one term is configured.
+         */
+        public static function is_selector_visible($gateway): bool
+        {
+            return count(self::get_available_terms($gateway)) > 1;
         }
 
         /**
          * The terms offered at checkout, ascending. THE availability seam —
          * see the file header before adding another term-list read.
          *
+         * The merchant's ticked presets (intersected with the brand's available
+         * terms) plus an optional custom term (unioned in — it may sit outside
+         * the brand's preset list). An empty result is meaningful: no term is
+         * offered, so none is sent and the backend applies the account default
+         * (parity with the pre-feature behaviour on main).
+         *
          * @return int[]
          */
         public static function get_available_terms($gateway): array
         {
             $brand_terms = WC_Twoinc_Brand::get('available_terms');
-            if (!is_array($brand_terms) || count($brand_terms) === 0) {
-                return [];
-            }
-            $brand_terms = array_map('intval', $brand_terms);
+            $brand_terms = is_array($brand_terms) ? array_map('intval', $brand_terms) : [];
 
+            $terms = [];
             $admin_subset = $gateway->get_option('payment_terms_days');
-            if (is_array($admin_subset) && count($admin_subset) > 0) {
+            if (is_array($admin_subset) && count($admin_subset) > 0 && count($brand_terms) > 0) {
                 $admin_subset = array_map('intval', $admin_subset);
                 $terms = array_values(array_intersect($brand_terms, $admin_subset));
-            } else {
-                $terms = $brand_terms;
+            }
+
+            // Custom term offered alongside the presets (Magento parity:
+            // payment_terms_duration_days). Unioned, not intersected.
+            $custom = (int) $gateway->get_option('payment_terms_custom_days');
+            if ($custom > 0) {
+                $terms[] = $custom;
             }
 
             $terms = array_values(array_unique(array_filter($terms, static function ($days) {

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -162,9 +162,16 @@ class WC_Payment_Gateway
 {
     public $id;
 
+    public $plugin_id = 'woocommerce_';
+
     public function get_option($key, $empty_value = null)
     {
         return $empty_value ?? '';
+    }
+
+    public function get_field_key($key)
+    {
+        return $this->plugin_id . $this->id . '_' . $key;
     }
 }
 

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -50,12 +50,14 @@ final class BrandConfigSpec
             'testPaymentValidationErrorFilterVetoes',
             'testConfirmationPageDetectionFollowsBrandPrefix',
             'testPaymentTermsResolveBrandIntersectAdminSubset',
+            'testPaymentTermsSelectorVisibleOnlyWithMultiple',
             'testPaymentTermsDefaultFallsBackToShortest',
             'testBuyerFeeShareShapes',
             'testBuyerFeeShareRounding',
             'testRoundingStepOptionsCanonicalAndNarrowed',
             'testRoundingStepValidationEnforcesBrandOptions',
             'testSurchargeGridValidationNormalisesAndRejects',
+            'testPaymentTermsValidationRequiresSelection',
             'testOrderPayloadCarriesSelectedAndAvailableTerms',
             'testPaymentTermsInvalidPostFallsBackToDefault',
             'testPaymentTermsDisabledMeansNoPayloadTerms',
@@ -503,28 +505,50 @@ final class BrandConfigSpec
 
     private static function testPaymentTermsResolveBrandIntersectAdminSubset(): void
     {
-        // Brand default set, no admin subset: all brand terms
-        $gateway = self::termsGateway(['enable_payment_terms' => 'yes']);
-        TinyAssert::same([14, 30, 60, 90], WC_Twoinc_Payment_Terms::get_available_terms($gateway));
-        TinyAssert::true(WC_Twoinc_Payment_Terms::is_enabled($gateway));
+        // No admin subset and no custom term: nothing offered → backend default
+        $gateway = self::termsGateway([]);
+        TinyAssert::same([], WC_Twoinc_Payment_Terms::get_available_terms($gateway));
+        TinyAssert::same(false, WC_Twoinc_Payment_Terms::is_enabled($gateway));
 
         // Admin narrows within the brand set; entries outside it drop
-        $gateway = self::termsGateway(['enable_payment_terms' => 'yes', 'payment_terms_days' => ['60', '30', '7']]);
+        $gateway = self::termsGateway(['payment_terms_days' => ['60', '30', '7']]);
         TinyAssert::same([30, 60], WC_Twoinc_Payment_Terms::get_available_terms($gateway));
+        TinyAssert::true(WC_Twoinc_Payment_Terms::is_enabled($gateway));
 
-        // Feature off regardless of terms
-        $gateway = self::termsGateway(['enable_payment_terms' => 'no']);
+        // A custom term is unioned in even when outside the brand presets
+        $gateway = self::termsGateway(['payment_terms_days' => ['30'], 'payment_terms_custom_days' => '45']);
+        TinyAssert::same([30, 45], WC_Twoinc_Payment_Terms::get_available_terms($gateway));
+
+        // Custom term alone (no presets ticked) still offers a term
+        $gateway = self::termsGateway(['payment_terms_custom_days' => '45']);
+        TinyAssert::same([45], WC_Twoinc_Payment_Terms::get_available_terms($gateway));
+        TinyAssert::true(WC_Twoinc_Payment_Terms::is_enabled($gateway));
+    }
+
+    private static function testPaymentTermsSelectorVisibleOnlyWithMultiple(): void
+    {
+        // One offered term: feature active but applied silently (no chooser)
+        $gateway = self::termsGateway(['payment_terms_days' => ['30']]);
+        TinyAssert::true(WC_Twoinc_Payment_Terms::is_enabled($gateway));
+        TinyAssert::same(false, WC_Twoinc_Payment_Terms::is_selector_visible($gateway));
+
+        // Two offered terms: chooser visible
+        $gateway = self::termsGateway(['payment_terms_days' => ['30', '60']]);
+        TinyAssert::true(WC_Twoinc_Payment_Terms::is_selector_visible($gateway));
+
+        // No terms: neither active nor visible
+        $gateway = self::termsGateway([]);
         TinyAssert::same(false, WC_Twoinc_Payment_Terms::is_enabled($gateway));
+        TinyAssert::same(false, WC_Twoinc_Payment_Terms::is_selector_visible($gateway));
     }
 
     private static function testPaymentTermsDefaultFallsBackToShortest(): void
     {
-        $gateway = self::termsGateway(['enable_payment_terms' => 'yes', 'default_payment_term' => '60']);
+        $gateway = self::termsGateway(['payment_terms_days' => ['30', '60'], 'default_payment_term' => '60']);
         TinyAssert::same(60, WC_Twoinc_Payment_Terms::get_default_term($gateway));
 
         // Configured default outside the offered set: shortest offered wins
         $gateway = self::termsGateway([
-            'enable_payment_terms' => 'yes',
             'payment_terms_days' => ['30', '90'],
             'default_payment_term' => '60',
         ]);
@@ -587,8 +611,9 @@ final class BrandConfigSpec
             WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 60)
         );
 
-        // differential: the default term (brand shortest = 14) rides as reference_terms
+        // differential: the default term (shortest offered = 14) rides as reference_terms
         $gateway = self::termsGateway([
+            'payment_terms_days' => ['14', '30'],
             'surcharge_type' => 'percentage',
             'surcharge_grid' => [30 => ['percentage' => '2']],
             'surcharge_differential' => '1',
@@ -600,6 +625,7 @@ final class BrandConfigSpec
 
         // end_of_month: reference_terms carries duration_days_calculated_from
         $gateway = self::termsGateway([
+            'payment_terms_days' => ['14', '30'],
             'surcharge_type' => 'percentage',
             'surcharge_grid' => [30 => ['percentage' => '2']],
             'surcharge_differential' => '1',
@@ -659,6 +685,7 @@ final class BrandConfigSpec
 
         // rounding rides alongside reference_terms (differential)
         $gateway = self::termsGateway($base + [
+            'payment_terms_days' => ['14', '30'],
             'surcharge_differential' => '1',
             'surcharge_rounding_basis' => 'standard',
             'surcharge_rounding_step' => '0.50',
@@ -755,9 +782,33 @@ final class BrandConfigSpec
         TinyAssert::same([], $gateway->validate_two_surcharge_grid_field('surcharge_grid', ''));
     }
 
+    private static function testPaymentTermsValidationRequiresSelection(): void
+    {
+        $gateway = self::gateway();
+        $custom_key = $gateway->get_field_key('payment_terms_custom_days');
+
+        // Valid selection normalises to sorted unique ints within brand terms
+        unset($_POST[$custom_key]);
+        TinyAssert::same([30, 60], $gateway->validate_two_payment_terms_field('payment_terms_days', ['60', '30', '7']));
+
+        // Empty selection + no custom term → rejected (selection mandatory)
+        $threw = false;
+        try {
+            $gateway->validate_two_payment_terms_field('payment_terms_days', []);
+        } catch (Exception $e) {
+            $threw = true;
+        }
+        TinyAssert::true($threw);
+
+        // Empty selection but a custom term posted → accepted
+        $_POST[$custom_key] = '45';
+        TinyAssert::same([], $gateway->validate_two_payment_terms_field('payment_terms_days', []));
+        unset($_POST[$custom_key]);
+    }
+
     private static function testOrderPayloadCarriesSelectedAndAvailableTerms(): void
     {
-        $gateway = self::termsGateway(['enable_payment_terms' => 'yes']);
+        $gateway = self::termsGateway(['payment_terms_days' => ['14', '30', '60', '90']]);
         $_POST[WC_Twoinc_Payment_Terms::SESSION_KEY] = '60';
 
         $payment_terms = WC_Twoinc_Payment_Terms::get_order_payload_terms($gateway, new StubOrder());
@@ -785,7 +836,7 @@ final class BrandConfigSpec
 
     private static function testPaymentTermsInvalidPostFallsBackToDefault(): void
     {
-        $gateway = self::termsGateway(['enable_payment_terms' => 'yes', 'default_payment_term' => '30']);
+        $gateway = self::termsGateway(['payment_terms_days' => ['30', '60'], 'default_payment_term' => '30']);
         $_POST[WC_Twoinc_Payment_Terms::SESSION_KEY] = '17';
 
         $payment_terms = WC_Twoinc_Payment_Terms::get_order_payload_terms($gateway, new StubOrder());
@@ -794,7 +845,8 @@ final class BrandConfigSpec
 
     private static function testPaymentTermsDisabledMeansNoPayloadTerms(): void
     {
-        $gateway = self::termsGateway(['enable_payment_terms' => 'no']);
+        // No terms configured: empty offer → no payload terms (backend default)
+        $gateway = self::termsGateway([]);
         TinyAssert::same(null, WC_Twoinc_Payment_Terms::get_order_payload_terms($gateway, new StubOrder()));
 
         // And the composed body carries no terms keys at all


### PR DESCRIPTION
## What

Reshapes the "Payment terms and offset pricing" gateway settings to match the Magento plugin's field set, names, captions and behaviour. The feature is unmerged/staging-only, so this is a clean greenfield reshape — no data migration.

- **Drop** the redundant "Enable payment terms selection" toggle. The offered-term set is the only switch: ≥1 term offered activates the feature, ≥2 shows the buyer chooser (`is_enabled` vs new `is_selector_visible`); a single term is applied silently.
- **"Offered terms" multiselect → "Payment Terms" checkboxes** (`two_payment_terms` field) + new **"Custom Payment Term (days)"** free field, unioned into the availability seam.
- A term selection is **mandatory on save** (custom-days also satisfies it); the checkboxes prepopulate the shortest available term so the form never loads empty. Empty offer at runtime still falls through to the account default.
- Labels/options/order renamed to the Magento captions (Surcharge Method, Surcharge Calculation Basis, Payment Surcharge Configuration, Default Payment Term, …).

`surcharge_tax_rate` intentionally **not** ported — WooCommerce taxes the fee natively via `add_fee(..., taxable=true)`, so a configured rate would fight WC's tax engine.

## Test

`php -l` clean (7.4 + 8.2); full unit suite green, including new payment-terms validation + selector-visibility + custom-days-union tests.

> Note: re-save the gateway settings on the staging shop after deploy (the dropped `enable_payment_terms` + reshaped fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)