### PR TITLE
TWO-24751: payment-terms admin parity — default-term dropdown, inline fees, chip colours

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -189,6 +189,12 @@
 .twoinc-term-chips.hidden {
   display: none;
 }
+/*
+ * Chip palette mirrors the Magento checkout (.two-term-chip): brand blue
+ * text on a white fill for the unselected state, solid brand blue with
+ * white text when selected. Set an explicit colour so the chip text never
+ * inherits a theme's light-on-light foreground (white-on-white bug).
+ */
 .twoinc-term-chip {
   display: inline-flex;
   flex-direction: column;
@@ -197,19 +203,29 @@
   border: 1px solid #c4c9e8;
   border-radius: 16px;
   background: #fff;
+  color: #3043d1;
   cursor: pointer;
   line-height: 1.3;
 }
-.twoinc-term-chip--selected {
+.twoinc-term-chip:hover {
   border-color: #3043d1;
-  background: #eef0fb;
+}
+.twoinc-term-chip--selected,
+.twoinc-term-chip--selected:hover {
+  border-color: #3043d1;
+  background: #3043d1;
+  color: #fff;
 }
 .twoinc-term-chip--single {
   cursor: default;
 }
+.twoinc-term-chip__days {
+  font-weight: 500;
+}
 .twoinc-term-chip__fee {
   font-size: 0.85em;
-  color: #3043d1;
+  color: inherit;
+  opacity: 0.85;
 }
 
 /* Sole trader toggle (TWO-24754) */

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -147,4 +147,166 @@ jQuery(function ($) {
   if ($apiKeyField.val()) {
     verifyApiKey($apiKeyField.val());
   }
+
+  // ── Payment terms config (mirrors Magento payment-terms-config.js) ──────
+  //
+  // (A) Keep the "Default Payment Term" dropdown in sync with the offered
+  //     set (ticked checkboxes ∪ custom day) live, before save.
+  // (B) Render the merchant's per-term pricing rate beside each checkbox.
+  (function initPaymentTermsConfig() {
+    const prefix = "woocommerce_" + twoinc_admin.gateway_id + "_";
+    const $container = $(".twoinc-term-checkboxes").first();
+    if ($container.length === 0) {
+      return;
+    }
+    const $checkboxes = $container.find(".twoinc-term-checkbox");
+    const $customDays = $("#" + prefix + "payment_terms_custom_days");
+    const $defaultTerm = $("#" + prefix + "default_payment_term");
+    const daysLabel = twoinc_admin.days_label || "%s days";
+
+    function customDay() {
+      const c = parseInt($customDays.val(), 10);
+      return c > 0 ? c : 0;
+    }
+
+    function uniqueSorted(arr) {
+      return arr
+        .filter(function (v, i, a) {
+          return a.indexOf(v) === i;
+        })
+        .sort(function (a, b) {
+          return a - b;
+        });
+    }
+
+    // Offered set: ticked checkboxes ∪ custom day (feeds the default dropdown).
+    function offeredTerms() {
+      const terms = [];
+      $checkboxes.filter(":checked").each(function () {
+        const n = parseInt($(this).val(), 10);
+        if (n > 0) terms.push(n);
+      });
+      const c = customDay();
+      if (c > 0) terms.push(c);
+      return uniqueSorted(terms);
+    }
+
+    // ── (A) Default Payment Term dropdown ─────────────────────────────────
+    function rebuildDefaultTerm() {
+      if ($defaultTerm.length === 0) return;
+      const terms = offeredTerms();
+      const current = parseInt($defaultTerm.val(), 10) || 0;
+      $defaultTerm.empty();
+      $.each(terms, function (_, days) {
+        $defaultTerm.append(
+          $("<option></option>").attr("value", days).text(daysLabel.replace("%s", days))
+        );
+      });
+      if (terms.indexOf(current) !== -1) {
+        $defaultTerm.val(current);
+      } else if (terms.length) {
+        $defaultTerm.val(terms[0]);
+      }
+    }
+
+    // ── (B) Inline merchant-rate fees ─────────────────────────────────────
+    let lastFeesKey = null;
+
+    function formatAmount(n) {
+      const s = Number(n).toFixed(2);
+      const sep = String(twoinc_admin.decimal_separator || ".");
+      return sep === "." ? s : s.replace(".", sep);
+    }
+
+    function loadFees() {
+      if (!$container.data("fees")) {
+        return; // brand opted out of inline fees
+      }
+      // Fees show beside EVERY checkbox regardless of checked state, plus the
+      // custom day if set (mirrors Magento's loadFees).
+      let terms = $checkboxes
+        .map(function () {
+          return parseInt(this.value, 10);
+        })
+        .get()
+        .filter(function (n) {
+          return n > 0;
+        });
+      const c = customDay();
+      if (c > 0 && terms.indexOf(c) === -1) terms.push(c);
+      terms = uniqueSorted(terms);
+      if (!terms.length) return;
+
+      const key = terms.join(",");
+      if (key === lastFeesKey) return;
+      lastFeesKey = key;
+
+      $.ajax({
+        url: twoinc_admin.ajax_url,
+        type: "POST",
+        dataType: "json",
+        data: {
+          action: "twoinc_term_fees",
+          nonce: twoinc_admin.nonce,
+          terms: JSON.stringify(terms)
+        }
+      })
+        .done(function (response) {
+          if (!response || !response.success || !response.data || !response.data.fees) {
+            return; // leave spans empty
+          }
+          const fees = response.data.fees;
+          const currency = String(response.data.currency || "")
+            .toUpperCase()
+            .trim();
+          const suffix = currency !== "" ? " " + currency : "";
+          $container.find(".twoinc-term-fee").each(function () {
+            const $span = $(this);
+            const term = String($span.data("term"));
+            const fee = fees[term];
+            if (!fee) {
+              $span.text("");
+              return;
+            }
+            const pct = parseFloat(fee.percentage || 0);
+            const fixed = parseFloat(fee.fixed || 0);
+            const pctZero = pct === 0;
+            const fixedZero = fixed === 0;
+            // Without an API-supplied currency a fixed amount is ambiguous —
+            // drop it; a percentage carries its own unit and can stand alone.
+            if (currency === "") {
+              $span.text(pctZero ? "" : " (" + formatAmount(pct) + "%)");
+              return;
+            }
+            let inner;
+            if (pctZero && fixedZero) {
+              inner = formatAmount(0) + suffix;
+            } else if (pctZero) {
+              inner = formatAmount(fixed) + suffix;
+            } else if (fixedZero) {
+              inner = formatAmount(pct) + "%";
+            } else {
+              inner = formatAmount(pct) + "% + " + formatAmount(fixed) + suffix;
+            }
+            $span.text(" (" + inner + ")");
+          });
+        })
+        .fail(function () {
+          // Allow a retry on the same term-set and clear half-populated spans.
+          lastFeesKey = null;
+          $container.find(".twoinc-term-fee").text("");
+        });
+    }
+
+    function onTermsChanged() {
+      rebuildDefaultTerm();
+      loadFees();
+    }
+
+    $checkboxes.on("change", onTermsChanged);
+    $customDays.on("change keyup", onTermsChanged);
+
+    rebuildDefaultTerm();
+    loadFees();
+  })();
 });

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -317,6 +317,26 @@ if (!class_exists('WC_Twoinc')) {
         }
 
         /**
+         * Option list for the "Default Payment Term" select: exactly the terms
+         * the merchant currently offers (ticked checkboxes ∪ custom day), not
+         * every brand preset. Mirrors Magento's AvailablePaymentTerms source
+         * model, so the dropdown reflects the saved selection on render (admin
+         * JS keeps it in sync live before save).
+         *
+         * @return array<string, string>
+         */
+        private function get_offered_payment_term_options(): array
+        {
+            $options = [];
+            if (class_exists('WC_Twoinc_Payment_Terms')) {
+                foreach (WC_Twoinc_Payment_Terms::get_available_terms($this) as $days) {
+                    $options[strval((int) $days)] = sprintf(__('%s days', 'twoinc-payment-gateway'), (int) $days);
+                }
+            }
+            return $options;
+        }
+
+        /**
          * Admin option list of the brand's surcharge rounding steps, in
          * canonical two-decimal form so the stored value round-trips
          * against the option list (WC_Twoinc_Payment_Terms reads it back).
@@ -481,6 +501,12 @@ if (!class_exists('WC_Twoinc')) {
                 $stored = [$days[0]];
             }
 
+            // Inline merchant-rate fee beside each checkbox (mirrors Magento's
+            // showInlineFees). Brand overlays opt out by setting the brand
+            // 'inline_term_fees' config to false; default on.
+            $inline_fees = WC_Twoinc_Brand::get('inline_term_fees');
+            $show_fees = ($inline_fees === null) ? true : (bool) $inline_fees;
+
             ob_start();
             ?>
             <tr valign="top">
@@ -492,15 +518,19 @@ if (!class_exists('WC_Twoinc')) {
                     <?php if (empty($options)) : ?>
                         <p><?php esc_html_e('No payment terms are available for this brand.', 'twoinc-payment-gateway'); ?></p>
                     <?php else : ?>
-                    <fieldset>
+                    <fieldset class="twoinc-term-checkboxes"<?php echo $show_fees ? ' data-fees="1"' : ''; ?>>
                         <?php foreach ($options as $value => $label) :
                             $days = (int) $value; ?>
                             <label style="display:block;margin-bottom:4px">
                                 <input type="checkbox"
+                                       class="twoinc-term-checkbox"
                                        name="<?php echo esc_attr($field_key); ?>[]"
                                        value="<?php echo esc_attr($days); ?>"
                                        <?php checked(in_array($days, $stored, true)); ?> />
                                 <?php echo esc_html($label); ?>
+                                <?php if ($show_fees) : ?>
+                                    <span class="twoinc-term-fee" data-term="<?php echo esc_attr($days); ?>" style="color:#666"></span>
+                                <?php endif; ?>
                             </label>
                         <?php endforeach; ?>
                     </fieldset>
@@ -561,6 +591,46 @@ if (!class_exists('WC_Twoinc')) {
                 throw new Exception(__('Custom Payment Term (days) must be a whole number of days.', 'twoinc-payment-gateway'));
             }
             return (string) (int) $value;
+        }
+
+        /**
+         * Coerce the saved default to a term actually being offered. The
+         * offered set is computed from the POSTed sibling fields (they save in
+         * the same request, so the stored options are stale here), mirroring
+         * the offered set the admin JS rebuilds the dropdown from. If the
+         * posted default is no longer offered (e.g. its checkbox was just
+         * unticked), repoint to the shortest offered term so the stored
+         * default is always coherent. Mirrors Magento's payment-terms-config.js
+         * default-term repointing.
+         */
+        public function validate_default_payment_term_field($key, $value)
+        {
+            $offered = [];
+            $allowed = array_map('intval', array_keys($this->get_payment_term_day_options()));
+
+            $terms_key = $this->get_field_key('payment_terms_days');
+            $posted_terms = isset($_POST[$terms_key]) ? (array) $_POST[$terms_key] : []; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            foreach ($posted_terms as $day) {
+                $day = (int) $day;
+                if ($day > 0 && in_array($day, $allowed, true)) {
+                    $offered[] = $day;
+                }
+            }
+
+            $custom_key = $this->get_field_key('payment_terms_custom_days');
+            $posted_custom = isset($_POST[$custom_key]) ? (int) $_POST[$custom_key] : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            if ($posted_custom > 0) {
+                $offered[] = $posted_custom;
+            }
+
+            $offered = array_values(array_unique($offered));
+            sort($offered);
+
+            $value = (int) $value;
+            if (in_array($value, $offered, true)) {
+                return (string) $value;
+            }
+            return count($offered) > 0 ? (string) $offered[0] : '';
         }
 
         /**
@@ -694,7 +764,11 @@ if (!class_exists('WC_Twoinc')) {
             wp_localize_script('twoinc.admin', 'twoinc_admin', [
                 'gateway_id' => $this->id,
                 'nonce' => wp_create_nonce('twoinc_admin_nonce'),
-                'ajax_url' => admin_url('admin-ajax.php')
+                'ajax_url' => admin_url('admin-ajax.php'),
+                // %s days label for the live Default Payment Term rebuild.
+                'days_label' => __('%s days', 'twoinc-payment-gateway'),
+                // Decimal separator for rendering fetched inline fee amounts.
+                'decimal_separator' => wc_get_price_decimal_separator(),
             ]);
         }
 
@@ -2011,7 +2085,7 @@ if (!class_exists('WC_Twoinc')) {
                     'description' => __('Select the payment term that will be automatically selected for your customer.', 'twoinc-payment-gateway'),
                     'desc_tip'    => true,
                     'type'        => 'select',
-                    'options'     => $this->get_payment_term_day_options(),
+                    'options'     => $this->get_offered_payment_term_options(),
                     'default'     => ''
                 ],
                 'surcharge_type' => [

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -327,6 +327,72 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
         }
 
         /**
+         * Fetch the merchant's own pricing rate (percentage + fixed) per term
+         * for the admin inline-fee display beside the term checkboxes. This is
+         * the cost Two charges the MERCHANT, independent of any cart — distinct
+         * from the buyer surcharge quoted at checkout (fetch_term_fee). Mirrors
+         * Magento's Controller\Adminhtml\Config\Fees → /pricing/v1/merchant/rates
+         * (note the path order differs from the order-fee endpoint).
+         *
+         * @param int[]  $terms          requested net-term day counts
+         * @param string $buyer_country  ISO-2 code for the rate preview
+         * @return array{success: bool, currency?: string, fees?: array<string, array{percentage: float, fixed: float}>}
+         */
+        public static function fetch_merchant_rates($gateway, array $terms, string $buyer_country): array
+        {
+            $net_terms = [];
+            foreach ($terms as $t) {
+                $days = (int) $t;
+                if ($days > 0) {
+                    $net_terms[] = $days;
+                }
+            }
+            $net_terms = array_values(array_unique($net_terms));
+            if (count($net_terms) === 0) {
+                return ['success' => false];
+            }
+
+            $response = $gateway->make_request('/pricing/v1/merchant/rates', [
+                'buyer_country_code' => $buyer_country,
+                // No admin recourse-pricing config on either plugin yet —
+                // hardcoded false for parity with Magento's Fees controller.
+                'recourse_pricing' => false,
+                // payout_schedule omitted: the server infers it from the
+                // merchant's payee accounts (matches Magento).
+                'net_terms' => $net_terms,
+            ], 'POST', array(), null, 10);
+
+            if (is_wp_error($response)
+                || (int) wp_remote_retrieve_response_code($response) < 200
+                || (int) wp_remote_retrieve_response_code($response) >= 300) {
+                return ['success' => false];
+            }
+
+            $body = json_decode($response['body'] ?? '', true);
+            if (!is_array($body) || !isset($body['rates']) || !is_array($body['rates'])) {
+                return ['success' => false];
+            }
+
+            $fees = [];
+            foreach ($body['rates'] as $rate) {
+                if (!isset($rate['net_terms'])) {
+                    continue;
+                }
+                $days = (int) $rate['net_terms'];
+                $fees[strval($days)] = [
+                    'percentage' => (float) ($rate['percentage_fee'] ?? 0),
+                    'fixed' => (float) ($rate['fixed_fee'] ?? 0),
+                ];
+            }
+
+            return [
+                'success' => true,
+                'currency' => strval($body['currency'] ?? ''),
+                'fees' => $fees,
+            ];
+        }
+
+        /**
          * The fee-quote basis: the cart's value excluding any fee this class
          * added (the platform-rate-converted/priced fee enters the basket at
          * the pricing endpoint's output and must not feed back into its own

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -58,6 +58,7 @@ final class BrandConfigSpec
             'testRoundingStepValidationEnforcesBrandOptions',
             'testSurchargeGridValidationNormalisesAndRejects',
             'testPaymentTermsValidationRequiresSelection',
+            'testDefaultTermCoercedToOfferedSet',
             'testOrderPayloadCarriesSelectedAndAvailableTerms',
             'testPaymentTermsInvalidPostFallsBackToDefault',
             'testPaymentTermsDisabledMeansNoPayloadTerms',
@@ -804,6 +805,30 @@ final class BrandConfigSpec
         $_POST[$custom_key] = '45';
         TinyAssert::same([], $gateway->validate_two_payment_terms_field('payment_terms_days', []));
         unset($_POST[$custom_key]);
+    }
+
+    private static function testDefaultTermCoercedToOfferedSet(): void
+    {
+        $gateway = self::gateway();
+        $terms_key = $gateway->get_field_key('payment_terms_days');
+        $custom_key = $gateway->get_field_key('payment_terms_custom_days');
+
+        // Offered = ticked checkboxes; a default within it is kept verbatim.
+        $_POST[$terms_key] = ['30', '60'];
+        unset($_POST[$custom_key]);
+        TinyAssert::same('60', $gateway->validate_default_payment_term_field('default_payment_term', '60'));
+
+        // A default no longer offered repoints to the shortest offered term.
+        TinyAssert::same('30', $gateway->validate_default_payment_term_field('default_payment_term', '90'));
+
+        // The custom day joins the offered set and can become the default.
+        $_POST[$terms_key] = ['60'];
+        $_POST[$custom_key] = '45';
+        TinyAssert::same('45', $gateway->validate_default_payment_term_field('default_payment_term', '45'));
+        // Shortest of {45,60} wins when the posted default is not offered.
+        TinyAssert::same('45', $gateway->validate_default_payment_term_field('default_payment_term', '14'));
+
+        unset($_POST[$terms_key], $_POST[$custom_key]);
     }
 
     private static function testOrderPayloadCarriesSelectedAndAvailableTerms(): void

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -52,6 +52,9 @@ function load_twoinc_classes()
     // Add AJAX handlers for API key verification
     add_action('wp_ajax_twoinc_verify_api_key', 'twoinc_ajax_verify_api_key');
 
+    // Admin inline merchant-rate fees beside the payment-term checkboxes
+    add_action('wp_ajax_twoinc_term_fees', 'twoinc_ajax_term_fees');
+
     // Load classes
     require_once __DIR__ . '/class/WC_Twoinc_Brand.php';
     require_once __DIR__ . '/class/WC_Twoinc_Helper.php';
@@ -211,4 +214,58 @@ function twoinc_ajax_verify_api_key()
         ];
         wp_send_json_error(['message' => 'API key is invalid', 'debug' => $debug_info]);
     }
+}
+
+/**
+ * AJAX endpoint for the admin inline merchant-rate fees beside the payment-term
+ * checkboxes. Resolves the merchant's per-term pricing rate (percentage +
+ * fixed) so the config page can preview what Two charges the merchant for each
+ * offered term. Mirrors Magento's Controller\Adminhtml\Config\Fees.
+ *
+ * Fail-soft: on any error returns success:false; the admin JS leaves the fee
+ * spans empty so the config page never breaks on a pricing-API outage.
+ */
+function twoinc_ajax_term_fees()
+{
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        wp_send_json_error('Invalid request method');
+        return;
+    }
+
+    if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'twoinc_admin_nonce')) {
+        wp_send_json_error('Security check failed');
+        return;
+    }
+
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error('Insufficient permissions');
+        return;
+    }
+
+    $raw_terms = isset($_POST['terms']) ? wp_unslash($_POST['terms']) : '';
+    $decoded = is_string($raw_terms) ? json_decode($raw_terms, true) : $raw_terms;
+    $terms = is_array($decoded) ? array_map('intval', $decoded) : [];
+    if (count(array_filter($terms, static function ($d) {
+        return $d > 0;
+    })) === 0) {
+        wp_send_json_error('No terms');
+        return;
+    }
+
+    $twoinc_instance = WC_Twoinc::get_instance();
+    // No admin-side buyer-country config exists; use the shop base country as
+    // a stand-in for the rate preview (matches Magento's resolveBuyerCountry).
+    $buyer_country = strtoupper((string) WC()->countries->get_base_country());
+
+    $rates = WC_Twoinc_Payment_Terms::fetch_merchant_rates($twoinc_instance, $terms, $buyer_country);
+
+    if (empty($rates['success'])) {
+        wp_send_json_error('Could not fetch merchant rates');
+        return;
+    }
+
+    wp_send_json_success([
+        'currency' => $rates['currency'] ?? '',
+        'fees' => $rates['fees'] ?? [],
+    ]);
 }


### PR DESCRIPTION
Follow-up polish to the WooCommerce payment-terms admin (PR #335), closing the remaining behavioural gaps Doug flagged against the Magento plugin. Staging only.

## Changes
**Default Payment Term dropdown (#1, #2, #3)** — now offers exactly the merchant's offered set (ticked checkboxes ∪ custom day) instead of every brand preset.
- Server: options from `get_offered_payment_term_options()`; a save-guard repoints a stale default to the shortest offered term.
- Admin JS: rebuilds the dropdown live as checkboxes / custom day change (mirrors Magento `payment-terms-config.js`).

**Admin inline merchant-rate fees (#4)** — per-term pricing rate (percentage + fixed) rendered beside each checkbox, via a new fail-soft AJAX endpoint hitting `/pricing/v1/merchant/rates`. Gated on the brand `inline_term_fees` flag. Mirrors Magento `Adminhtml\Config\Fees`.

**Checkout chip colours (#5)** — explicit brand-blue text on white, solid blue + white text when selected; fixes the white-on-white theme inheritance. Matches the Magento `.two-term-chip` palette.

## Testing
- Unit tests pass on PHP 7.4 + 8.2 (`php tests/unit/run.php`), incl. new `testDefaultTermCoercedToOfferedSet`.
- prettier + php-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)