### PR TITLE
TWO-24739: refresh merchant ID + short name on API-key validation

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -104,6 +104,19 @@ jQuery(function ($) {
     }
   }
 
+  // Refresh the displayed Merchant ID + short name from a verify response,
+  // so a key change reflects immediately without saving/reloading.
+  function updateMerchantInfo(data) {
+    if (!data || !data.merchant_id) {
+      return;
+    }
+    $("#twoinc-merchant-id").text(data.merchant_id);
+    const shortName = data.merchant_short_name || "";
+    $("#twoinc-merchant-short-name").text(shortName ? " · " + shortName : "");
+    $("#twoinc-merchant-info").show();
+    $("#twoinc-signup-prompt").hide();
+  }
+
   function verifyApiKey(apiKey) {
     if (!apiKey || apiKey.length < 10) {
       $verificationIcon.hide();
@@ -123,6 +136,7 @@ jQuery(function ($) {
       success: function (response) {
         if (response.success) {
           showVerificationStatus("valid");
+          updateMerchantInfo(response.data);
         } else {
           showVerificationStatus("invalid");
         }

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -699,8 +699,10 @@ if (!class_exists('WC_Twoinc')) {
                 $body = json_decode($response['body'], true);
                 $code = $response['response']['code'];
                 if ($code == 200 && isset($body['id']) && !$api_key) {
-                    // Only update merchant_id if we're verifying the saved API key
+                    // Only persist when verifying the saved API key. verify_api_key
+                    // returns {id, short_name}; cache both for the settings display.
                     $this->update_option('merchant_id', $body['id']);
+                    $this->update_option('merchant_short_name', isset($body['short_name']) ? (string) $body['short_name'] : '');
                 }
                 return ['body' => $body, 'code' => $code];
             }
@@ -2214,15 +2216,18 @@ if (!class_exists('WC_Twoinc')) {
                                 <span class="dashicons dashicons-update" style="color: #0073aa; display: none; animation: rotation 1s infinite linear; font-size: 18px;" id="api-key-loading"></span>
                             </span>
                         </div>
-                        <?php if ($this->get_option('api_key') && $merchant_id = $this->get_merchant_id()) : ?>
-                            <div style="margin-top: 8px; color: #666; font-size: 13px;">
-                                <strong><?php _e('Merchant ID:', 'twoinc-payment-gateway'); ?></strong> <?php echo esc_html($merchant_id); ?>
-                            </div>
-                        <?php else: ?>
-                            <div style="margin-top: 8px; color: #666; font-size: 13px;">
-                                <strong><?php printf(__('Don\'t have an API key? Get one by signing up <a href=\'%s\'>here</a>.', 'twoinc-payment-gateway'), esc_url(WC_Twoinc_Brand::get('sign_up_url'))); ?></strong>
-                            </div>
-                        <?php endif; ?>
+                        <?php
+                            $merchant_id = $this->get_option('api_key') ? $this->get_merchant_id() : '';
+                            $merchant_short_name = $merchant_id ? (string) $this->get_option('merchant_short_name') : '';
+                        ?>
+                        <?php // Merchant identity — populated server-side on load and refreshed live by admin.js when the key is (re)validated. ?>
+                        <div id="twoinc-merchant-info" style="margin-top: 8px; color: #666; font-size: 13px;<?php echo $merchant_id ? '' : ' display: none;'; ?>">
+                            <strong><?php _e('Merchant ID:', 'twoinc-payment-gateway'); ?></strong>
+                            <span id="twoinc-merchant-id"><?php echo esc_html($merchant_id); ?></span><span id="twoinc-merchant-short-name"><?php echo $merchant_short_name !== '' ? ' &middot; ' . esc_html($merchant_short_name) : ''; ?></span>
+                        </div>
+                        <div id="twoinc-signup-prompt" style="margin-top: 8px; color: #666; font-size: 13px;<?php echo $merchant_id ? ' display: none;' : ''; ?>">
+                            <strong><?php printf(__('Don\'t have an API key? Get one by signing up <a href=\'%s\'>here</a>.', 'twoinc-payment-gateway'), esc_url(WC_Twoinc_Brand::get('sign_up_url'))); ?></strong>
+                        </div>
                         <?php echo $this->get_description_html($data); // WPCS: XSS ok.
                         ?>
                     </fieldset>

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -205,7 +205,15 @@ function twoinc_ajax_verify_api_key()
     $result = $twoinc_instance->verify_api_key($api_key);
 
     if ($result && isset($result['code']) && $result['code'] == 200) {
-        wp_send_json_success(['message' => 'API key is valid', 'debug' => $result]);
+        // Echo the merchant identity back so the settings page can refresh the
+        // displayed Merchant ID + short name as soon as validation completes,
+        // without a reload (the key being typed is not persisted here).
+        $body = isset($result['body']) && is_array($result['body']) ? $result['body'] : [];
+        wp_send_json_success([
+            'message' => 'API key is valid',
+            'merchant_id' => isset($body['id']) ? (string) $body['id'] : '',
+            'merchant_short_name' => isset($body['short_name']) ? (string) $body['short_name'] : '',
+        ]);
     } else {
         $debug_info = [
             'result' => $result,


### PR DESCRIPTION
The settings page rendered the Merchant ID only on page load, so changing the API key left a stale ID until save + reload. `verify_api_key` returns `{id, short_name}`.

- Cache both `merchant_id` + `merchant_short_name` when the saved key verifies.
- Render a JS-updatable identity block (Merchant ID · short name) with a signup-prompt fallback.
- The verify AJAX now echoes `merchant_id` + `merchant_short_name`, so `admin.js` refreshes the display the moment validation completes — and now surfaces the merchant short name too.

Staging only. Item 6 of the parity polish; Magento + PrestaShop equivalents follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)