### PR TITLE
TWO-24856/feat: Brand seams for checkout subtitle and API-key contact

### DIFF
--- a/brands/two.php
+++ b/brands/two.php
@@ -55,4 +55,13 @@ return [
     // Buyer-facing label for the offset-pricing fee line; null uses the
     // translated "Service charge" default.
     'fee_line_label' => null,
+    // Short tagline rendered under the payment-method title at checkout,
+    // above the about block. '' renders nothing (the Two default).
+    // WC_Twoinc::get_pay_subtitle is the only reader. Mirrors the
+    // Magento brand descriptor's checkout_subtitle.
+    'checkout_subtitle' => '',
+    // Contact address shown in the admin API-key field help for
+    // obtaining production keys. WC_Twoinc::init_form_fields is the only
+    // reader. A brand overlay substitutes its own support address.
+    'production_key_contact_email' => 'integration@two.inc',
 ];

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -706,8 +706,17 @@ if (!class_exists('WC_Twoinc')) {
          */
         public function get_pay_subtitle()
         {
+            $subtitle = WC_Twoinc_Brand::get('checkout_subtitle');
+            $subtitle_html = $subtitle
+                ? sprintf(
+                    '<div class="twoinc-payment-subtitle">%s</div>',
+                    esc_html(__($subtitle, 'twoinc-payment-gateway'))
+                )
+                : '';
+
             return sprintf(
-                '<div class="abt-twoinc">%s</div>',
+                '%s<div class="abt-twoinc">%s</div>',
+                $subtitle_html,
                 $this->get_abt_twoinc_html(),
             );
         }
@@ -2057,7 +2066,11 @@ if (!class_exists('WC_Twoinc')) {
                 'api_key' => [
                     'title'       => sprintf(__('%s API Key', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')),
                     'type'        => 'api_key_with_verification',
-                    'description' => '<div id="api-key-status" style="margin-top: 5px;"></div>',
+                    'description' => sprintf(
+                        /* translators: %s is the contact email address for obtaining production API keys */
+                        __('API key for the sandbox environment is available on your merchant portal (however please reach out to %s for access to production keys).', 'twoinc-payment-gateway'),
+                        esc_html(WC_Twoinc_Brand::get('production_key_contact_email'))
+                    ) . '<div id="api-key-status" style="margin-top: 5px;"></div>',
                 ],
                 'vendor_name' => [
                     'title'       => __('Optional vendor name if there are multiple sites', 'twoinc-payment-gateway'),

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -601,7 +601,7 @@ if (!class_exists('WC_Twoinc_Helper')) {
                  * Filter the confirmation URL sent to the Two API.
                  *
                  * Brand overlays use their own confirmation route (e.g.
-                 * abn-payment-gateway/confirm); without this hook an overlay
+                 * example-overlay-gateway/confirm); without this hook an overlay
                  * would have to duplicate process_payment().
                  *
                  * @param string $confirmation_url Default confirmation URL.

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -215,13 +215,13 @@ final class BrandConfigSpec
         $captured = [];
         add_filter('twoinc_confirmation_url', static function ($url, $order_id) use (&$captured) {
             $captured = [$url, $order_id];
-            return 'https://shop.example/abn-payment-gateway/confirm?order_id=' . $order_id;
+            return 'https://shop.example/example-overlay-gateway/confirm?order_id=' . $order_id;
         }, 10, 2);
 
         $body = self::composeOrder();
 
         TinyAssert::same(
-            'https://shop.example/abn-payment-gateway/confirm?order_id=42',
+            'https://shop.example/example-overlay-gateway/confirm?order_id=42',
             $body['merchant_urls']['merchant_confirmation_url']
         );
         TinyAssert::true(strpos($captured[0], '/twoinc-payment-gateway/confirm?order_id=42') !== false, 'Filter must receive the default URL: ' . $captured[0]);

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -150,6 +150,9 @@ final class BrandConfigSpec
         TinyAssert::same('https://portal.two.inc/auth/merchant/signup', WC_Twoinc_Brand::get('sign_up_url'));
         TinyAssert::same(WC_TWOINC_PLUGIN_URL . 'assets/images/two-logo.svg', WC_Twoinc_Brand::get('logo_url'));
         TinyAssert::same('Business invoice - %s days', WC_Twoinc_Brand::get('title_default'));
+        // Two ships no checkout subtitle; an overlay supplies one.
+        TinyAssert::same('', WC_Twoinc_Brand::get('checkout_subtitle'));
+        TinyAssert::same('integration@two.inc', WC_Twoinc_Brand::get('production_key_contact_email'));
         TinyAssert::same(null, WC_Twoinc_Brand::get('not_a_key'));
     }
 


### PR DESCRIPTION
## What
Two brand-overlayable surfaces on the brand-config layer, so a brand edition can match the cross-platform brand presentation without forking:

- **Checkout subtitle** — `get_pay_subtitle()` renders an optional `checkout_subtitle` brand key as a tagline above the about block. Default `''` (Two) renders nothing, so existing Two checkout is unchanged.
- **API-key production contact** — the admin API-key field help now names a production-key contact, sourced from a new `production_key_contact_email` brand key (default `integration@two.inc`). An overlay substitutes its own support address.

Also neutralises a partner-specific example slug in the tests + confirmation-URL docblock (now `example-overlay-gateway`) so the canonical plugin carries no partner identifiers. Illustrative only.

## Why
Closes the brand-seam half of the cross-platform brand parity audit (TWO-24856). The Magento brand layer already exposes equivalents; these were the missing WooCommerce seams.

## Test
`tests/unit` pins the new brand defaults; PHP 7.4 + 8.2 green.

Targets `staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)