### PR TITLE
TWO-24762/feat: forward shipment tracking to Two

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -1272,6 +1272,24 @@ if (!class_exists('WC_Twoinc')) {
                 return;
             }
 
+            // Push tracking (shipping_details) BEFORE fulfilling: the Two
+            // API only accepts order edits pre-fulfilment, so this is the
+            // last chance for the buyer's invoice to carry the tracking
+            // number. Gated on tracking actually being present so ordinary
+            // fulfilments don't grow an extra edit round-trip, and
+            // best-effort by design: an edit failure must never block
+            // fulfilment (process_update_twoinc_order only leaves an order
+            // note on failure). Tracking added AFTER completion cannot be
+            // forwarded — the edit endpoint rejects fulfilled orders
+            // (TWO-24762).
+            $shipping_details = WC_Twoinc_Helper::get_shipping_details($order);
+            if (!empty($shipping_details['tracking_number'])) {
+                $twoinc_meta = $this->get_save_twoinc_meta($order);
+                if ($twoinc_meta) {
+                    $this->process_update_twoinc_order($order, $twoinc_meta);
+                }
+            }
+
             // Change the order status
             $response = $this->make_request("/v1/order/{$twoinc_order_id}/fulfillments");
 

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -1285,8 +1285,15 @@ if (!class_exists('WC_Twoinc')) {
             $shipping_details = WC_Twoinc_Helper::get_shipping_details($order);
             if (!empty($shipping_details['tracking_number'])) {
                 $twoinc_meta = $this->get_save_twoinc_meta($order);
-                if ($twoinc_meta) {
-                    $this->process_update_twoinc_order($order, $twoinc_meta);
+                $tracking_synced = $twoinc_meta && $this->process_update_twoinc_order($order, $twoinc_meta);
+                if (!$tracking_synced) {
+                    // The generic edit-failure note already added downstream
+                    // says "contact support"; this one says what was
+                    // actually lost so the merchant isn't left guessing.
+                    $order->add_order_note(sprintf(
+                        __('The tracking number could not be attached to the %s order. The invoice will be sent without it.', 'twoinc-payment-gateway'),
+                        WC_Twoinc_Brand::get('product_name')
+                    ));
                 }
             }
 
@@ -2798,15 +2805,36 @@ if (!class_exists('WC_Twoinc')) {
         /**
          * Run the update execution
          *
+         * The Two API only accepts order edits before fulfilment, so once
+         * the order has reached a fulfilled/terminal state this is a no-op:
+         * without the gate, any post-completion change that lands in the
+         * composed body (most commonly a tracking number added after the
+         * order was marked completed) would poison the change hash and
+         * make EVERY subsequent admin save fire an edit request the API is
+         * guaranteed to reject, each leaving a "contact support" order
+         * note (TWO-24762 review).
+         *
          * @param $order
+         * @param $twoinc_meta
+         * @param $forced_reload
+         *
+         * @return boolean true when the remote order is in sync (updated,
+         *                 or no update needed), false when an update was
+         *                 attempted and failed or the state forbids edits.
          */
         private function process_update_twoinc_order($order, $twoinc_meta, $forced_reload = false)
         {
+            $state = $order->get_meta(WC_Twoinc_Brand::meta_key('order_state'), true);
+            if (in_array($state, ["FULFILLING", "FULFILLED", "DELIVERED", "CANCELLED", "REFUNDED", "PARTIALLY_REFUNDED"])) {
+                return false;
+            }
 
             $twoinc_order_hash = $order->get_meta(WC_Twoinc_Brand::meta_key('req_body_hash'));
             $twoinc_updated_order_hash = WC_Twoinc_Helper::hash_order($order, $twoinc_meta);
+            $updated = true;
             if (!$twoinc_order_hash || $twoinc_order_hash != $twoinc_updated_order_hash) {
-                if ($this->update_twoinc_order($order)) {
+                $updated = $this->update_twoinc_order($order, $twoinc_meta);
+                if ($updated) {
                     $order->update_meta_data(WC_Twoinc_Brand::meta_key('req_body_hash'), $twoinc_updated_order_hash);
                     $order->save();
                 }
@@ -2814,16 +2842,21 @@ if (!class_exists('WC_Twoinc')) {
                     WC_Twoinc_Helper::append_admin_force_reload();
                 }
             }
+            return $updated;
         }
 
         /**
          * Run the update
          *
          * @param $order
+         * @param $twoinc_meta Optional pre-fetched meta from
+         *                     get_save_twoinc_meta, to spare a duplicate
+         *                     fetch (which can itself cost a remote GET)
+         *                     on hot paths like fulfilment.
          *
          * @return boolean
          */
-        private function update_twoinc_order($order)
+        private function update_twoinc_order($order, $twoinc_meta = null)
         {
 
             $twoinc_order_id = $this->get_twoinc_order_id($order);
@@ -2835,7 +2868,9 @@ if (!class_exists('WC_Twoinc')) {
             }
 
             // 1. Get information from the current order
-            $twoinc_meta = $this->get_save_twoinc_meta($order);
+            if (!$twoinc_meta) {
+                $twoinc_meta = $this->get_save_twoinc_meta($order);
+            }
             if (!$twoinc_meta) {
                 return false;
             }

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -26,6 +26,13 @@ if (!class_exists('WC_Twoinc')) {
         public const MERCHANT_SIGNUP_URL = 'https://portal.two.inc/auth/merchant/signup';
         public const ALERT_EMAIL_ADDRESS = 'woocom-alerts@two.inc';
 
+        // Order states in which the Two API refuses order edits. Shared by
+        // the fulfilment skip-check and the edit gate in
+        // process_update_twoinc_order — their identity guarantees the
+        // tracking-failure note in on_order_completed can never be
+        // triggered by the state gate itself.
+        private const TERMINAL_ORDER_STATES = ["FULFILLING", "FULFILLED", "DELIVERED", "CANCELLED", "REFUNDED", "PARTIALLY_REFUNDED"];
+
         private bool $twoinc_process_confirmation_called = false;
 
         /**
@@ -1266,8 +1273,7 @@ if (!class_exists('WC_Twoinc')) {
             }
 
             $state = $order->get_meta(WC_Twoinc_Brand::meta_key('order_state'), true);
-            $skip = ["FULFILLING", "FULFILLED", "DELIVERED", "CANCELLED", "REFUNDED", "PARTIALLY_REFUNDED"];
-            if (in_array($state, $skip)) {
+            if (in_array($state, self::TERMINAL_ORDER_STATES)) {
                 // $order->add_order_note(sprintf(__('Order is already fulfilled with Two.', 'twoinc-payment-gateway'), $twoinc_order_id));
                 return;
             }
@@ -1283,7 +1289,7 @@ if (!class_exists('WC_Twoinc')) {
             // forwarded — the edit endpoint rejects fulfilled orders
             // (TWO-24762).
             $shipping_details = WC_Twoinc_Helper::get_shipping_details($order);
-            if (!empty($shipping_details['tracking_number'])) {
+            if (isset($shipping_details['tracking_number']) && $shipping_details['tracking_number'] !== '') {
                 $twoinc_meta = $this->get_save_twoinc_meta($order);
                 $tracking_synced = $twoinc_meta && $this->process_update_twoinc_order($order, $twoinc_meta);
                 if (!$tracking_synced) {
@@ -2825,7 +2831,7 @@ if (!class_exists('WC_Twoinc')) {
         private function process_update_twoinc_order($order, $twoinc_meta, $forced_reload = false)
         {
             $state = $order->get_meta(WC_Twoinc_Brand::meta_key('order_state'), true);
-            if (in_array($state, ["FULFILLING", "FULFILLED", "DELIVERED", "CANCELLED", "REFUNDED", "PARTIALLY_REFUNDED"])) {
+            if (in_array($state, self::TERMINAL_ORDER_STATES)) {
                 return false;
             }
 

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -532,10 +532,17 @@ if (!class_exists('WC_Twoinc_Helper')) {
          */
         private static function clean_tracking_field($entry, $key)
         {
-            if (!isset($entry[$key]) || !is_scalar($entry[$key])) {
+            if (!isset($entry[$key])) {
                 return '';
             }
-            return trim(strval($entry[$key]));
+            $value = $entry[$key];
+            // Booleans are excluded from the scalar family on purpose:
+            // strval(true) is '1', which would be kept as a "tracking
+            // number" rather than dropped as the garbage it is.
+            if (!is_string($value) && !is_int($value) && !is_float($value)) {
+                return '';
+            }
+            return trim(strval($value));
         }
 
         /**

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -452,6 +452,62 @@ if (!class_exists('WC_Twoinc_Helper')) {
         }
 
         /**
+         * Compose the shipping_details block for order create/edit bodies.
+         *
+         * WooCommerce core has no stable tracking-number storage (the core
+         * Fulfillments feature is still behind a beta flag), so tracking is
+         * sourced from the `_wc_shipment_tracking_items` order meta shared
+         * by the official WooCommerce Shipment Tracking extension and the
+         * zorem Advanced Shipment Tracking plugin: an array of entries with
+         * `tracking_number`, `tracking_provider` (predefined-carrier slug),
+         * `custom_tracking_provider` / `custom_tracking_link` (free-text
+         * carrier). Predefined carriers keep their tracking URL in the
+         * plugin's carrier list, not in meta, so `carrier_tracking_url` is
+         * only sent for custom entries. The most recent entry wins.
+         *
+         * @param WC_Order $order
+         *
+         * @return array
+         */
+        public static function get_shipping_details($order)
+        {
+            $shipping_details = [
+                'expected_delivery_date' => date('Y-m-d', strtotime('+ 7 days'))
+            ];
+
+            $tracking_items = $order->get_meta('_wc_shipment_tracking_items', true);
+            if (is_array($tracking_items) && count($tracking_items) > 0) {
+                $latest = end($tracking_items);
+                if (is_array($latest) && !empty($latest['tracking_number'])) {
+                    $shipping_details['tracking_number'] = strval($latest['tracking_number']);
+                    $carrier_name = '';
+                    if (!empty($latest['custom_tracking_provider'])) {
+                        $carrier_name = strval($latest['custom_tracking_provider']);
+                        if (!empty($latest['custom_tracking_link'])) {
+                            $shipping_details['carrier_tracking_url'] = strval($latest['custom_tracking_link']);
+                        }
+                    } elseif (!empty($latest['tracking_provider'])) {
+                        $carrier_name = strval($latest['tracking_provider']);
+                    }
+                    if ($carrier_name !== '') {
+                        $shipping_details['carrier_name'] = $carrier_name;
+                    }
+                }
+            }
+
+            /**
+             * Filter the shipping_details sent to the Two API.
+             *
+             * Escape hatch for merchants whose tracking data lives outside
+             * the `_wc_shipment_tracking_items` meta convention (TWO-24762).
+             *
+             * @param array    $shipping_details Composed shipping details.
+             * @param WC_Order $order            WooCommerce order.
+             */
+            return apply_filters('twoinc_shipping_details', $shipping_details, $order);
+        }
+
+        /**
          * Compose request body for twoinc create order
          *
          * Brand extension hooks fire in this order, each seeing the
@@ -563,12 +619,7 @@ if (!class_exists('WC_Twoinc_Helper')) {
                 ],
                 'billing_address' => $billing_address,
                 'shipping_address' => $shipping_address,
-                'shipping_details' => [
-                    // 'carrier_name' => '',
-                    // 'tracking_number' => '',
-                    // 'carrier_tracking_url' => '',
-                    'expected_delivery_date' => date('Y-m-d', strtotime('+ 7 days'))
-                ]
+                'shipping_details' => WC_Twoinc_Helper::get_shipping_details($order)
             ];
 
             if ($vendor_name) {
@@ -707,12 +758,7 @@ if (!class_exists('WC_Twoinc_Helper')) {
                 'merchant_reference' => '',
                 'billing_address' => $billing_address,
                 'shipping_address' => $shipping_address,
-                'shipping_details' => [
-                    // 'carrier_name' => '',
-                    // 'tracking_number' => '',
-                    // 'carrier_tracking_url' => '',
-                    'expected_delivery_date' => date('Y-m-d', strtotime('+ 7 days'))
-                ]
+                'shipping_details' => WC_Twoinc_Helper::get_shipping_details($order)
             ];
 
             if ($vendor_name) {

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -478,16 +478,20 @@ if (!class_exists('WC_Twoinc_Helper')) {
             $tracking_items = $order->get_meta('_wc_shipment_tracking_items', true);
             if (is_array($tracking_items) && count($tracking_items) > 0) {
                 $latest = end($tracking_items);
-                if (is_array($latest) && !empty($latest['tracking_number'])) {
-                    $shipping_details['tracking_number'] = strval($latest['tracking_number']);
-                    $carrier_name = '';
-                    if (!empty($latest['custom_tracking_provider'])) {
-                        $carrier_name = strval($latest['custom_tracking_provider']);
-                        if (!empty($latest['custom_tracking_link'])) {
-                            $shipping_details['carrier_tracking_url'] = strval($latest['custom_tracking_link']);
+                // The meta key is world-writable, so every field is treated
+                // as untrusted: non-scalar or whitespace-only values are
+                // dropped rather than coerced into garbage.
+                $tracking_number = is_array($latest) ? self::clean_tracking_field($latest, 'tracking_number') : '';
+                if ($tracking_number !== '') {
+                    $shipping_details['tracking_number'] = $tracking_number;
+                    $carrier_name = self::clean_tracking_field($latest, 'custom_tracking_provider');
+                    if ($carrier_name !== '') {
+                        $carrier_tracking_url = self::clean_tracking_field($latest, 'custom_tracking_link');
+                        if ($carrier_tracking_url !== '') {
+                            $shipping_details['carrier_tracking_url'] = $carrier_tracking_url;
                         }
-                    } elseif (!empty($latest['tracking_provider'])) {
-                        $carrier_name = strval($latest['tracking_provider']);
+                    } else {
+                        $carrier_name = self::clean_tracking_field($latest, 'tracking_provider');
                     }
                     if ($carrier_name !== '') {
                         $shipping_details['carrier_name'] = $carrier_name;
@@ -501,10 +505,37 @@ if (!class_exists('WC_Twoinc_Helper')) {
              * Escape hatch for merchants whose tracking data lives outside
              * the `_wc_shipment_tracking_items` meta convention (TWO-24762).
              *
+             * Fires on EVERY order body composition: checkout order
+             * creation (where no tracking exists yet), order edits, and up
+             * to three times per fulfilment (presence gate, change-detection
+             * hash, edit body). Callbacks must therefore be fast, pure and
+             * deterministic — a slow callback drags checkout and the admin
+             * order screen; a non-deterministic one churns the change hash
+             * and fires spurious edit requests, and can make the gate and
+             * the shipped body disagree. A non-array return is discarded.
+             *
              * @param array    $shipping_details Composed shipping details.
              * @param WC_Order $order            WooCommerce order.
              */
-            return apply_filters('twoinc_shipping_details', $shipping_details, $order);
+            $filtered = apply_filters('twoinc_shipping_details', $shipping_details, $order);
+            return is_array($filtered) ? $filtered : $shipping_details;
+        }
+
+        /**
+         * Return a trimmed string field from a shipment-tracking meta
+         * entry, or '' when absent, non-scalar or whitespace-only.
+         *
+         * @param array  $entry
+         * @param string $key
+         *
+         * @return string
+         */
+        private static function clean_tracking_field($entry, $key)
+        {
+            if (!isset($entry[$key]) || !is_scalar($entry[$key])) {
+                return '';
+            }
+            return trim(strval($entry[$key]));
         }
 
         /**
@@ -709,9 +740,13 @@ if (!class_exists('WC_Twoinc_Helper')) {
         /**
          * Compose request body for twoinc edit order
          *
-         * @param $order
+         * @param WC_Order $order
+         * @param string   $department
+         * @param string   $project
+         * @param string   $purchase_order_number
+         * @param string   $vendor_name
          *
-         * @return bool
+         * @return array
          */
         public static function compose_twoinc_edit_order(
             $order,

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -211,6 +211,15 @@ class WC_HTTPS
 
 class StubOrder
 {
+    // Order meta store; compose_twoinc_order reads
+    // `_wc_shipment_tracking_items` from here (TWO-24762 tests).
+    public $meta = [];
+
+    public function get_meta($key, $single = true)
+    {
+        return $this->meta[$key] ?? '';
+    }
+
     public function get_billing_company()
     {
         return 'Test Buyer AS';

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -211,8 +211,7 @@ class WC_HTTPS
 
 class StubOrder
 {
-    // Order meta store; compose_twoinc_order reads
-    // `_wc_shipment_tracking_items` from here (TWO-24762 tests).
+    // Meta store mirroring WC_Order::get_meta single-value behaviour.
     public $meta = [];
 
     public function get_meta($key, $single = true)

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -38,6 +38,7 @@ final class BrandConfigSpec
             'testEditOrderAppliesSameBrandHooks',
             'testShippingDetailsOmitTrackingWithoutMeta',
             'testShippingDetailsFromShipmentTrackingMeta',
+            'testProcessUpdateRefusesTerminalStates',
             'testShippingDetailsCarriedByCreateAndEditBodies',
             'testShippingDetailsFilterOverrides',
             'testShippingDetailsFilterGarbageDiscarded',
@@ -382,6 +383,56 @@ final class BrandConfigSpec
         $details = WC_Twoinc_Helper::get_shipping_details($order);
         TinyAssert::same(false, array_key_exists('tracking_number', $details));
         TinyAssert::same(false, array_key_exists('carrier_name', $details));
+
+        // Booleans are dropped, not coerced (strval(true) would emit '1').
+        $order->meta['_wc_shipment_tracking_items'] = [
+            ['tracking_provider' => 'dhl', 'tracking_number' => true],
+        ];
+        $details = WC_Twoinc_Helper::get_shipping_details($order);
+        TinyAssert::same(false, array_key_exists('tracking_number', $details));
+    }
+
+    private static function testProcessUpdateRefusesTerminalStates(): void
+    {
+        // The Two API rejects order edits once fulfilment has started;
+        // without this gate a post-completion change (tracking number
+        // added late) would fire a guaranteed-rejected edit on every
+        // admin save. No-HTTP is asserted structurally: composing and
+        // sending would fatal on StubOrder methods that don't exist.
+        $gateway = new class () extends WC_Twoinc {
+            public function __construct()
+            {
+            }
+        };
+        $method = new ReflectionMethod(WC_Twoinc::class, 'process_update_twoinc_order');
+        $method->setAccessible(true);
+
+        $twoinc_meta = [
+            'order_reference' => 'test-order-reference',
+            'company_id' => '912345678',
+            'department' => '',
+            'project' => '',
+            'purchase_order_number' => '',
+            'invoice_emails' => [],
+            'payment_reference_message' => '',
+            'payment_reference_ocr' => '',
+            'payment_reference' => '',
+            'payment_reference_type' => '',
+            'vendor_name' => '',
+        ];
+
+        foreach (["FULFILLING", "FULFILLED", "DELIVERED", "CANCELLED", "REFUNDED", "PARTIALLY_REFUNDED"] as $state) {
+            $order = new StubOrder();
+            $order->meta[WC_Twoinc_Brand::meta_key('order_state')] = $state;
+            TinyAssert::same(false, $method->invoke($gateway, $order, $twoinc_meta), "state $state must refuse the edit");
+        }
+
+        // Editable state whose body hash is already current: in sync,
+        // returns true, still without composing an HTTP request.
+        $order = new StubOrder();
+        $order->meta[WC_Twoinc_Brand::meta_key('order_state')] = 'CONFIRMED';
+        $order->meta[WC_Twoinc_Brand::meta_key('req_body_hash')] = WC_Twoinc_Helper::hash_order($order, $twoinc_meta);
+        TinyAssert::same(true, $method->invoke($gateway, $order, $twoinc_meta));
     }
 
     private static function testShippingDetailsCarriedByCreateAndEditBodies(): void

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -36,6 +36,10 @@ final class BrandConfigSpec
             'testOrderPayloadHookAugmentsBody',
             'testPaymentTermsLineHookAdjustsLineItems',
             'testEditOrderAppliesSameBrandHooks',
+            'testShippingDetailsOmitTrackingWithoutMeta',
+            'testShippingDetailsFromShipmentTrackingMeta',
+            'testShippingDetailsCarriedByCreateAndEditBodies',
+            'testShippingDetailsFilterOverrides',
             'testLegacyOrderCreateFilterRunsBeforeOrderPayload',
             'testBrandFileReturningNonArrayFallsBackToDefaults',
             'testMetaKeysDeriveFromBrandPrefix',
@@ -290,6 +294,103 @@ final class BrandConfigSpec
 
         TinyAssert::same('Brand line', $body['line_items'][0]['name']);
         TinyAssert::same('Overlay Vendor', $body['vendor_name']);
+    }
+
+    private static function testShippingDetailsOmitTrackingWithoutMeta(): void
+    {
+        $body = self::composeOrder();
+
+        TinyAssert::true(isset($body['shipping_details']['expected_delivery_date']));
+        TinyAssert::same(false, array_key_exists('tracking_number', $body['shipping_details']));
+        TinyAssert::same(false, array_key_exists('carrier_name', $body['shipping_details']));
+        TinyAssert::same(false, array_key_exists('carrier_tracking_url', $body['shipping_details']));
+    }
+
+    private static function testShippingDetailsFromShipmentTrackingMeta(): void
+    {
+        // Predefined-carrier entry: provider slug becomes carrier_name and
+        // no tracking URL is sent (it lives in the tracking plugin's
+        // carrier list, not in meta). The LATEST entry must win.
+        $order = new StubOrder();
+        $order->meta['_wc_shipment_tracking_items'] = [
+            ['tracking_provider' => 'dhl', 'tracking_number' => 'OLD-1'],
+            ['tracking_provider' => 'postnord-se', 'tracking_number' => 'PN123456789SE'],
+        ];
+
+        $details = WC_Twoinc_Helper::get_shipping_details($order);
+
+        TinyAssert::same('PN123456789SE', $details['tracking_number']);
+        TinyAssert::same('postnord-se', $details['carrier_name']);
+        TinyAssert::same(false, array_key_exists('carrier_tracking_url', $details));
+
+        // Custom-carrier entry: free-text provider name wins over the slug
+        // and its link is forwarded.
+        $order->meta['_wc_shipment_tracking_items'] = [
+            [
+                'tracking_provider' => '',
+                'custom_tracking_provider' => 'Nordic Couriers',
+                'custom_tracking_link' => 'https://track.example/PN1',
+                'tracking_number' => 'NC-42',
+            ],
+        ];
+
+        $details = WC_Twoinc_Helper::get_shipping_details($order);
+
+        TinyAssert::same('NC-42', $details['tracking_number']);
+        TinyAssert::same('Nordic Couriers', $details['carrier_name']);
+        TinyAssert::same('https://track.example/PN1', $details['carrier_tracking_url']);
+
+        // Malformed entries (no tracking_number, or non-array) must not
+        // emit partial tracking fields.
+        $order->meta['_wc_shipment_tracking_items'] = [
+            ['tracking_provider' => 'dhl', 'tracking_number' => ''],
+        ];
+        $details = WC_Twoinc_Helper::get_shipping_details($order);
+        TinyAssert::same(false, array_key_exists('tracking_number', $details));
+        TinyAssert::same(false, array_key_exists('carrier_name', $details));
+
+        $order->meta['_wc_shipment_tracking_items'] = ['not-an-entry'];
+        $details = WC_Twoinc_Helper::get_shipping_details($order);
+        TinyAssert::same(false, array_key_exists('tracking_number', $details));
+    }
+
+    private static function testShippingDetailsCarriedByCreateAndEditBodies(): void
+    {
+        $order = new StubOrder();
+        $order->meta['_wc_shipment_tracking_items'] = [
+            ['tracking_provider' => 'bring', 'tracking_number' => 'BR-7'],
+        ];
+
+        $create = WC_Twoinc_Helper::compose_twoinc_order(
+            $order,
+            'test-order-reference',
+            '912345678',
+            'IT',
+            'Project X',
+            '',
+            []
+        );
+        $edit = WC_Twoinc_Helper::compose_twoinc_edit_order($order, 'IT', 'Project X', '', '');
+
+        TinyAssert::same('BR-7', $create['shipping_details']['tracking_number']);
+        TinyAssert::same('bring', $create['shipping_details']['carrier_name']);
+        TinyAssert::same($create['shipping_details'], $edit['shipping_details']);
+    }
+
+    private static function testShippingDetailsFilterOverrides(): void
+    {
+        // Merchant escape hatch (TWO-24762 option 2): tracking data living
+        // outside the shipment-tracking meta convention can be injected.
+        add_filter('twoinc_shipping_details', static function ($details, $order) {
+            $details['tracking_number'] = 'FILTERED-1';
+            $details['carrier_name'] = 'Filter Carrier';
+            return $details;
+        }, 10, 2);
+
+        $body = self::composeOrder();
+
+        TinyAssert::same('FILTERED-1', $body['shipping_details']['tracking_number']);
+        TinyAssert::same('Filter Carrier', $body['shipping_details']['carrier_name']);
     }
 
     private static function testLegacyOrderCreateFilterRunsBeforeOrderPayload(): void

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -40,6 +40,7 @@ final class BrandConfigSpec
             'testShippingDetailsFromShipmentTrackingMeta',
             'testShippingDetailsCarriedByCreateAndEditBodies',
             'testShippingDetailsFilterOverrides',
+            'testShippingDetailsFilterGarbageDiscarded',
             'testLegacyOrderCreateFilterRunsBeforeOrderPayload',
             'testBrandFileReturningNonArrayFallsBackToDefaults',
             'testMetaKeysDeriveFromBrandPrefix',
@@ -101,7 +102,7 @@ final class BrandConfigSpec
         WC_Twoinc_Sole_Trader::reset_cache();
         WC()->cart = null;
         WC()->customer = null;
-        foreach (['twoinc_brand_file', 'twoinc_checkout_fields', 'twoinc_confirmation_url', 'twoinc_order_payload', 'twoinc_payment_terms_line', 'two_order_create', 'twoinc_payment_validation_error', 'twoinc_sole_trader_signup_url'] as $tag) {
+        foreach (['twoinc_brand_file', 'twoinc_checkout_fields', 'twoinc_confirmation_url', 'twoinc_order_payload', 'twoinc_payment_terms_line', 'two_order_create', 'twoinc_payment_validation_error', 'twoinc_sole_trader_signup_url', 'twoinc_shipping_details'] as $tag) {
             remove_all_filters($tag);
         }
     }
@@ -352,6 +353,35 @@ final class BrandConfigSpec
         $order->meta['_wc_shipment_tracking_items'] = ['not-an-entry'];
         $details = WC_Twoinc_Helper::get_shipping_details($order);
         TinyAssert::same(false, array_key_exists('tracking_number', $details));
+
+        // The meta key is world-writable: numeric values are normalised to
+        // strings, whitespace-only and non-scalar values are dropped, and
+        // a tracking number with no provider fields emits no carrier_name.
+        $order->meta['_wc_shipment_tracking_items'] = [
+            ['tracking_provider' => 'dhl', 'tracking_number' => 12345],
+        ];
+        $details = WC_Twoinc_Helper::get_shipping_details($order);
+        TinyAssert::same('12345', $details['tracking_number']);
+
+        $order->meta['_wc_shipment_tracking_items'] = [
+            ['tracking_number' => 'LONESOME-1'],
+        ];
+        $details = WC_Twoinc_Helper::get_shipping_details($order);
+        TinyAssert::same('LONESOME-1', $details['tracking_number']);
+        TinyAssert::same(false, array_key_exists('carrier_name', $details));
+
+        $order->meta['_wc_shipment_tracking_items'] = [
+            ['tracking_provider' => 'dhl', 'tracking_number' => '   '],
+        ];
+        $details = WC_Twoinc_Helper::get_shipping_details($order);
+        TinyAssert::same(false, array_key_exists('tracking_number', $details));
+
+        $order->meta['_wc_shipment_tracking_items'] = [
+            ['tracking_provider' => ['nested'], 'tracking_number' => ['nested']],
+        ];
+        $details = WC_Twoinc_Helper::get_shipping_details($order);
+        TinyAssert::same(false, array_key_exists('tracking_number', $details));
+        TinyAssert::same(false, array_key_exists('carrier_name', $details));
     }
 
     private static function testShippingDetailsCarriedByCreateAndEditBodies(): void
@@ -374,7 +404,10 @@ final class BrandConfigSpec
 
         TinyAssert::same('BR-7', $create['shipping_details']['tracking_number']);
         TinyAssert::same('bring', $create['shipping_details']['carrier_name']);
-        TinyAssert::same($create['shipping_details'], $edit['shipping_details']);
+        // Tracking fields only — expected_delivery_date is computed from
+        // "now" per call and would flake across a midnight rollover.
+        TinyAssert::same('BR-7', $edit['shipping_details']['tracking_number']);
+        TinyAssert::same('bring', $edit['shipping_details']['carrier_name']);
     }
 
     private static function testShippingDetailsFilterOverrides(): void
@@ -391,6 +424,22 @@ final class BrandConfigSpec
 
         TinyAssert::same('FILTERED-1', $body['shipping_details']['tracking_number']);
         TinyAssert::same('Filter Carrier', $body['shipping_details']['carrier_name']);
+    }
+
+    private static function testShippingDetailsFilterGarbageDiscarded(): void
+    {
+        // The filter fires at checkout order creation too — a broken
+        // merchant callback returning a non-array must not be able to put
+        // scalar garbage in the create body (that would break checkout,
+        // not just tracking). The composed value wins instead.
+        add_filter('twoinc_shipping_details', static function ($details, $order) {
+            return null;
+        }, 10, 2);
+
+        $body = self::composeOrder();
+
+        TinyAssert::true(is_array($body['shipping_details']));
+        TinyAssert::true(isset($body['shipping_details']['expected_delivery_date']));
     }
 
     private static function testLegacyOrderCreateFilterRunsBeforeOrderPayload(): void


### PR DESCRIPTION
## What

Closes the WooCommerce half of TWO-24762 (tracking number support). The `shipping_details` block in order create/edit bodies — previously commented-out stubs — is now composed by `WC_Twoinc_Helper::get_shipping_details()`:

- **Source**: `_wc_shipment_tracking_items` order meta, the convention shared by the official WooCommerce Shipment Tracking extension and zorem's Advanced Shipment Tracking (free). Latest entry wins. Predefined carriers send `tracking_number` + `carrier_name` (slug); custom carriers send the free-text name and their tracking link.
- **Escape hatch**: `apply_filters('twoinc_shipping_details', $details, $order)` for merchants whose tracking lives elsewhere (ticket option 2).
- **Timing**: the Two API only accepts order edits pre-fulfilment, so `on_order_completed` pushes a hash-gated order edit carrying the tracking *before* `POST /fulfillments`. Best-effort by design: an edit failure leaves an order note but never blocks fulfilment.

## Spike conclusion (ticket asked for this first)

WC core has **no** viable tracking source without a third-party plugin: the core Fulfillments feature (typed `get_tracking_number()` API) is still behind a beta flag as of WC 10.7 (Apr 2026); our staging shops run 10.3.8 with the flag off. The `_wc_shipment_tracking_items` meta is the de-facto standard (options 1+2 combined, no hard dependency — absent meta simply means no tracking fields, exactly as today).

## Known limitation

Tracking added *after* the order is completed cannot be forwarded — the edit endpoint rejects fulfilled orders. Documented in-code.

## Tests

4 new unit tests (meta absent / predefined + custom + malformed entries / create-edit body symmetry / filter override); suite green on PHP 8.5 locally, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)