### PR TITLE
TWO-25028/fix: register deactivation hook from the main plugin file

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -105,8 +105,9 @@ if (!class_exists('WC_Twoinc')) {
                 // Verify API key quietly
                 add_action('admin_enqueue_scripts', [$this, 'verify_api_key_action']);
 
-                // On plugin deactivated
-                add_action('deactivate_' . plugin_basename(__FILE__), [$this, 'on_deactivate_plugin']);
+                // Deactivation cleanup is registered in the main plugin file
+                // (register_deactivation_hook) — a registration here would key
+                // the hook off THIS file's basename and never fire (TWO-25028).
 
                 // Add js css to admin page
                 add_action('admin_enqueue_scripts', [$this, 'twoinc_admin_styles_scripts']);

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -1008,6 +1008,18 @@ final class BrandConfigSpec
             $GLOBALS['__twoinc_test_options'][$checked_option] = 999;
         };
 
+        // Toggle key absent from the settings blob: the state every merchant
+        // who never opened the toggle is in. Default is no-wipe, so nothing
+        // is deleted — same contract as an explicit 'no'.
+        $seed();
+        $absent_gateway = $make_gateway('no');
+        unset($absent_gateway->options['clear_options_on_deactivation']);
+        TinyAssert::same(false, array_key_exists('clear_options_on_deactivation', $absent_gateway->options));
+        $absent_gateway->on_deactivate_plugin();
+        TinyAssert::true(array_key_exists($settings_option, $GLOBALS['__twoinc_test_options']));
+        TinyAssert::true(array_key_exists($terms_option, $GLOBALS['__twoinc_test_options']));
+        TinyAssert::true(array_key_exists($checked_option, $GLOBALS['__twoinc_test_options']));
+
         // Toggle off: deactivation leaves everything in place
         $seed();
         $make_gateway('no')->on_deactivate_plugin();

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -61,6 +61,7 @@ final class BrandConfigSpec
             'testPaymentTermsResolveBackendIntersectAdminSubset',
             'testMerchantAvailableTermsFetchNormalisesCachesAndServesStale',
             'testMerchantAvailableTermsInvalidatedOnMerchantIdChange',
+            'testDeactivationCleanupClearsSettingsAndTermCache',
             'testPaymentTermsValidationNonDestructiveOnUnresolvedOrNarrowedList',
             'testSurchargeGridPreservesRowsNotOnTheForm',
             'testPaymentTermsSelectorVisibleOnlyWithMultiple',
@@ -976,6 +977,52 @@ final class BrandConfigSpec
         $gateway->responses[] = ['response' => ['code' => 200], 'body' => json_encode(['id' => 'new-merchant', 'short_name' => 'nm'])];
         $gateway->verify_api_key();
         TinyAssert::same('[30,60]', $GLOBALS['__twoinc_test_options'][$terms_option]);
+    }
+
+    private static function testDeactivationCleanupClearsSettingsAndTermCache(): void
+    {
+        $settings_option = 'woocommerce_woocommerce-gateway-tillit_settings';
+        $terms_option = WC_Twoinc_Brand::prefixed_name('merchant_available_terms');
+        $checked_option = WC_Twoinc_Brand::prefixed_name('merchant_available_terms_checked_on');
+
+        $make_gateway = static function (string $clear) {
+            $gateway = new class () extends WC_Twoinc {
+                public $options = [];
+
+                public function __construct()
+                {
+                    $this->id = 'woocommerce-gateway-tillit';
+                }
+
+                public function get_option($key, $empty_value = null)
+                {
+                    return $this->options[$key] ?? $empty_value ?? '';
+                }
+            };
+            $gateway->options['clear_options_on_deactivation'] = $clear;
+            return $gateway;
+        };
+        $seed = static function () use ($settings_option, $terms_option, $checked_option) {
+            $GLOBALS['__twoinc_test_options'][$settings_option] = ['api_key' => 'key'];
+            $GLOBALS['__twoinc_test_options'][$terms_option] = '[30,60]';
+            $GLOBALS['__twoinc_test_options'][$checked_option] = 999;
+        };
+
+        // Toggle off: deactivation leaves everything in place
+        $seed();
+        $make_gateway('no')->on_deactivate_plugin();
+        TinyAssert::true(array_key_exists($settings_option, $GLOBALS['__twoinc_test_options']));
+        TinyAssert::true(array_key_exists($terms_option, $GLOBALS['__twoinc_test_options']));
+        TinyAssert::true(array_key_exists($checked_option, $GLOBALS['__twoinc_test_options']));
+
+        // Toggle on: settings blob AND the dedicated term-cache options go —
+        // the cache lives outside the settings blob (TWO-24812), so clearing
+        // only the blob would leave orphaned rows.
+        $seed();
+        $make_gateway('yes')->on_deactivate_plugin();
+        TinyAssert::same(false, array_key_exists($settings_option, $GLOBALS['__twoinc_test_options']));
+        TinyAssert::same(false, array_key_exists($terms_option, $GLOBALS['__twoinc_test_options']));
+        TinyAssert::same(false, array_key_exists($checked_option, $GLOBALS['__twoinc_test_options']));
     }
 
     private static function testPaymentTermsValidationNonDestructiveOnUnresolvedOrNarrowedList(): void

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -34,6 +34,23 @@ define('WC_TWOINC_PLUGIN_PATH', plugin_dir_path(__FILE__));
 add_filter('woocommerce_payment_gateways', 'wc_twoinc_add_to_gateways');
 add_action('plugins_loaded', 'load_twoinc_classes');
 
+// Must be registered from the MAIN plugin file: register_deactivation_hook()
+// keys the hook by this file's plugin basename. The old registration inside
+// class/WC_Twoinc.php built the hook name from its own __FILE__, so it never
+// fired and the "clear options on deactivation" setting was dead (TWO-25028).
+register_deactivation_hook(__FILE__, 'twoinc_on_deactivate_plugin');
+
+function twoinc_on_deactivate_plugin()
+{
+    // Deactivation runs after plugins_loaded, so load_twoinc_classes() has
+    // already required the gateway class whenever WooCommerce is active.
+    // If WooCommerce is inactive this file returns before registering the
+    // hook at all, so cleanup only happens while WooCommerce is active.
+    if (class_exists('WC_Twoinc')) {
+        WC_Twoinc::get_instance()->on_deactivate_plugin();
+    }
+}
+
 if (is_admin() && !defined('DOING_AJAX')) {
     add_filter("plugin_action_links_" . plugin_basename(__FILE__), 'twoinc_settings_link');
 }


### PR DESCRIPTION
## Problem

The deactivation cleanup hook was registered inside `class/WC_Twoinc.php` as

```php
add_action('deactivate_' . plugin_basename(__FILE__), [$this, 'on_deactivate_plugin']);
```

`__FILE__` there is the class file, so the hook name resolves to `deactivate_tillit-payment-gateway/class/WC_Twoinc.php` — but WordPress fires `deactivate_tillit-payment-gateway/tillit-payment-gateway.php` (the main plugin basename). The hook never fired, so the **Clear options on deactivation** setting has been dead since it shipped.

## Fix

- `register_deactivation_hook(__FILE__, 'twoinc_on_deactivate_plugin')` in the main plugin file, delegating to `WC_Twoinc::get_instance()->on_deactivate_plugin()` — which already clears the settings blob **and** the dedicated term-cache options (`{prefix}_merchant_available_terms{,_checked_on}`, TWO-24812).
- Removed the dead registration from the gateway constructor, with a comment pointing at the main-file registration so it doesn't creep back.
- Unit test `testDeactivationCleanupClearsSettingsAndTermCache` covers both toggle states (off = everything kept; on = blob + both cache options deleted).

## Known limitation (pre-existing)

If WooCommerce is deactivated first, the plugin file returns before registering the hook, so deactivating Two afterwards skips cleanup. Same guard gates the whole plugin; not new behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn