### PR TITLE
TWO-25016/ci: version-combination support matrix (light two-axis scope)

### DIFF
--- a/.github/workflows/support-matrix.yaml
+++ b/.github/workflows/support-matrix.yaml
@@ -40,7 +40,8 @@ jobs:
         id: wc
         run: |
           set -o pipefail
-          if ! info=$(curl -fsSL "https://api.wordpress.org/plugins/info/1.0/woocommerce.json"); then
+          if ! info=$(curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
+            "https://api.wordpress.org/plugins/info/1.0/woocommerce.json"); then
             echo "::error::support-matrix: could not query wordpress.org plugin API"
             exit 1
           fi
@@ -69,67 +70,114 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    # Two matrix legs run in parallel and can land on the same runner, so
+    # every docker resource is namespaced per leg (run id + job index) to
+    # avoid name/volume/network collisions.
+    env:
+      SFX: ${{ github.run_id }}-${{ strategy.job-index }}
     steps:
       - uses: actions/checkout@v6
 
       - name: Boot WordPress + WooCommerce ${{ matrix.woocommerce }}
         run: |
           set -o pipefail
-          docker network create wpnet
-          docker volume create wpdata
-          docker run --detach --name db --network wpnet \
+          docker network create "wpnet-$SFX"
+          docker volume create "wpdata-$SFX"
+          docker run --detach --name "db-$SFX" --network "wpnet-$SFX" \
+            --network-alias db \
             -e MYSQL_DATABASE=wp -e MYSQL_USER=wp -e MYSQL_PASSWORD=wp \
             -e MYSQL_RANDOM_ROOT_PASSWORD=1 \
             --health-cmd="mysqladmin ping -h localhost -u wp -pwp" \
             --health-interval=5s --health-timeout=5s --health-retries=30 \
             mariadb:10.6
-          until [ "$(docker inspect -f '{{.State.Health.Status}}' db)" = "healthy" ]; do
+          n=0
+          until [ "$(docker inspect -f '{{.State.Health.Status}}' "db-$SFX")" = "healthy" ]; do
+            n=$((n + 1))
+            if [ "$n" -ge 60 ]; then
+              echo "::error::support-matrix: database never became healthy"
+              docker logs "db-$SFX" || true
+              exit 1
+            fi
             sleep 2
           done
           # Latest-WP images (no WP version pin): the latest WooCommerce can
           # require a WordPress newer than any fixed pin (10.9.x needs 6.9),
           # and this workflow's whole point is tracking upstream.
-          docker run --detach --name wp --network wpnet -v wpdata:/var/www/html \
+          docker run --detach --name "wp-$SFX" --network "wpnet-$SFX" \
+            --network-alias wp -v "wpdata-$SFX":/var/www/html \
             -e WORDPRESS_DB_HOST=db -e WORDPRESS_DB_USER=wp \
             -e WORDPRESS_DB_PASSWORD=wp -e WORDPRESS_DB_NAME=wp \
             wordpress:php8.2-apache
-          docker run --detach --name cli --network wpnet -v wpdata:/var/www/html \
+          docker run --detach --name "cli-$SFX" --network "wpnet-$SFX" \
+            --network-alias cli -v "wpdata-$SFX":/var/www/html \
             --user 33:33 \
             -e WORDPRESS_DB_HOST=db -e WORDPRESS_DB_USER=wp \
             -e WORDPRESS_DB_PASSWORD=wp -e WORDPRESS_DB_NAME=wp \
             --entrypoint sleep wordpress:cli-php8.2 infinity
-          until docker exec cli test -f /var/www/html/wp-config.php \
-            && docker exec cli wp core version >/dev/null 2>&1; do
+          n=0
+          until docker exec "cli-$SFX" test -f /var/www/html/wp-config.php \
+            && docker exec "cli-$SFX" wp core version >/dev/null 2>&1; do
+            n=$((n + 1))
+            if [ "$n" -ge 60 ]; then
+              echo "::error::support-matrix: WordPress never finished initialising"
+              docker logs "wp-$SFX" || true
+              exit 1
+            fi
             sleep 2
           done
-          docker exec cli wp core install --url=http://wp --title=Matrix \
+          # Install against http://localhost so the site's canonical URL
+          # matches the host the render probes hit — otherwise WordPress
+          # 301-redirects the probe to the canonical host and curl -f passes
+          # on the 3xx without ever rendering a page (false green).
+          docker exec "cli-$SFX" wp core install --url=http://localhost --title=Matrix \
             --admin_user=admin --admin_password=support-matrix-ci \
             --admin_email=admin@example.com
-          docker exec cli wp plugin install woocommerce \
-            --version="${{ matrix.woocommerce }}" --activate
+          # wp.org can transiently rate-limit / 5xx the download; retry a few
+          # times, then fail loud rather than blocking unrelated PRs.
+          n=0
+          until docker exec "cli-$SFX" wp plugin install woocommerce \
+            --version="${{ matrix.woocommerce }}" --activate; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::support-matrix: failed to install WooCommerce ${{ matrix.woocommerce }} after 3 attempts"
+              exit 1
+            fi
+            sleep 5
+          done
 
       - name: Install plugin HEAD + smoke
         run: |
           set -o pipefail
-          docker exec cli mkdir -p /var/www/html/wp-content/plugins/tillit-payment-gateway
+          docker exec "cli-$SFX" mkdir -p /var/www/html/wp-content/plugins/tillit-payment-gateway
           git ls-files -z | tar --null -cf - -T - \
-            | docker exec -i cli tar -xf - -C /var/www/html/wp-content/plugins/tillit-payment-gateway
-          docker exec cli wp plugin activate tillit-payment-gateway
+            | docker exec -i "cli-$SFX" tar -xf - -C /var/www/html/wp-content/plugins/tillit-payment-gateway
+          docker exec "cli-$SFX" wp plugin activate tillit-payment-gateway
           # The gateway class loads and boots under this WooCommerce version.
-          docker exec cli wp eval 'exit(class_exists("WC_Twoinc") ? 0 : 1);'
-          docker exec cli wp eval 'WC_Twoinc::get_instance(); echo "gateway boots\n";'
+          docker exec "cli-$SFX" wp eval 'exit(class_exists("WC_Twoinc") ? 0 : 1);'
+          docker exec "cli-$SFX" wp eval 'WC_Twoinc::get_instance(); echo "gateway boots\n";'
           # The gateway registers with WooCommerce's gateway registry.
-          docker exec cli wp eval '
+          docker exec "cli-$SFX" wp eval '
             $ids = array_keys(WC()->payment_gateways()->payment_gateways());
             exit(in_array("woocommerce-gateway-tillit", $ids, true) ? 0 : 1);'
-          # Storefront and checkout render without a fatal.
-          docker exec wp curl -sf http://localhost/ -o /dev/null
-          docker exec cli wp option get woocommerce_checkout_page_id \
-            | xargs -I{} docker exec wp curl -sf "http://localhost/?page_id={}" -o /dev/null
+          # Storefront renders without a fatal.
+          docker exec "wp-$SFX" curl -sf http://localhost/ -o /dev/null
+          # Checkout renders without a fatal. Resolve the checkout page id
+          # explicitly and assert it is a positive integer — an empty/zero id
+          # piped through xargs runs the probe zero times and passes green.
+          id=$(docker exec "cli-$SFX" wp option get woocommerce_checkout_page_id)
+          if [ -z "$id" ]; then
+            echo "::error::support-matrix: WooCommerce checkout page id is empty"
+            exit 1
+          fi
+          if ! [ "$id" -gt 0 ] 2>/dev/null; then
+            echo "::error::support-matrix: WooCommerce checkout page id is not a positive integer (got '$id')"
+            exit 1
+          fi
+          docker exec "wp-$SFX" curl -sf "http://localhost/?page_id=$id" -o /dev/null
 
       - name: Tear down
         if: always()
         run: |
-          docker rm -f wp cli db 2>/dev/null || true
-          docker network rm wpnet 2>/dev/null || true
-          docker volume rm wpdata 2>/dev/null || true
+          docker rm -f "wp-$SFX" "cli-$SFX" "db-$SFX" 2>/dev/null || true
+          docker network rm "wpnet-$SFX" 2>/dev/null || true
+          docker volume rm "wpdata-$SFX" 2>/dev/null || true

--- a/.github/workflows/support-matrix.yaml
+++ b/.github/workflows/support-matrix.yaml
@@ -86,15 +86,18 @@ jobs:
           until [ "$(docker inspect -f '{{.State.Health.Status}}' db)" = "healthy" ]; do
             sleep 2
           done
+          # Latest-WP images (no WP version pin): the latest WooCommerce can
+          # require a WordPress newer than any fixed pin (10.9.x needs 6.9),
+          # and this workflow's whole point is tracking upstream.
           docker run --detach --name wp --network wpnet -v wpdata:/var/www/html \
             -e WORDPRESS_DB_HOST=db -e WORDPRESS_DB_USER=wp \
             -e WORDPRESS_DB_PASSWORD=wp -e WORDPRESS_DB_NAME=wp \
-            wordpress:6.8-php8.2-apache
+            wordpress:php8.2-apache
           docker run --detach --name cli --network wpnet -v wpdata:/var/www/html \
             --user 33:33 \
             -e WORDPRESS_DB_HOST=db -e WORDPRESS_DB_USER=wp \
             -e WORDPRESS_DB_PASSWORD=wp -e WORDPRESS_DB_NAME=wp \
-            --entrypoint sleep wordpress:cli-2.11.0-php8.2 infinity
+            --entrypoint sleep wordpress:cli-php8.2 infinity
           until docker exec cli test -f /var/www/html/wp-config.php \
             && docker exec cli wp core version >/dev/null 2>&1; do
             sleep 2

--- a/.github/workflows/support-matrix.yaml
+++ b/.github/workflows/support-matrix.yaml
@@ -1,0 +1,132 @@
+name: Support matrix
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: support-matrix-${{ github.ref_name }}
+  cancel-in-progress: true
+
+# Version-combination coverage (TWO-25016). Scope decision — a light
+# two-axis subset, NOT Magento's full N×M matrix:
+#
+#   * PHP axis: the unit-test workflow runs the dependency-free suite
+#     across the plugin's declared floor (7.4) up to current PHP — cheap,
+#     seconds per leg (see unit-tests.yaml).
+#   * WooCommerce axis (this workflow): boot-smoke the plugin HEAD against
+#     the LATEST WooCommerce release and the PREVIOUS MINOR line, both
+#     discovered live from the wordpress.org API at run time so the matrix
+#     tracks upstream without hand maintenance. WordPress and PHP stay at
+#     the image defaults here — WooCommerce gates its own WP/PHP support,
+#     so multiplying the axes re-tests WooCommerce, not this plugin.
+#
+# Honest-CI conventions (magento-plugin's support-matrix, TWO-24998): an
+# API/transport failure FAILS discovery rather than emitting an empty
+# matrix that would skip-green; every emitted leg is genuinely run.
+jobs:
+  discover:
+    name: Discover WooCommerce versions
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.wc.outputs.matrix }}
+    steps:
+      - name: Resolve latest + previous-minor WooCommerce
+        id: wc
+        run: |
+          set -o pipefail
+          if ! info=$(curl -fsSL "https://api.wordpress.org/plugins/info/1.0/woocommerce.json"); then
+            echo "::error::support-matrix: could not query wordpress.org plugin API"
+            exit 1
+          fi
+          latest=$(echo "$info" | jq -r '.version')
+          # Highest patch of the minor line BELOW the latest's minor —
+          # bare-semver keys only (the API also lists trunk/beta keys).
+          prev=$(echo "$info" | jq -r --arg latest "$latest" '
+            ($latest | split(".") | map(tonumber)) as $l
+            | .versions | keys
+            | map(select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$")))
+            | map(split(".") | map(tonumber))
+            | map(select(.[0] < $l[0] or (.[0] == $l[0] and .[1] < $l[1])))
+            | sort | last // empty | map(tostring) | join(".")')
+          if [ -z "$latest" ] || [ "$latest" = "null" ] || [ -z "$prev" ]; then
+            echo "::error::support-matrix: could not resolve latest ($latest) / previous minor ($prev)"
+            exit 1
+          fi
+          echo "WooCommerce legs: latest=$latest previous-minor=$prev"
+          echo "matrix={\"woocommerce\":[\"$latest\",\"$prev\"]}" >> "$GITHUB_OUTPUT"
+
+  boot-smoke:
+    name: Boot smoke (WooCommerce ${{ matrix.woocommerce }})
+    needs: discover
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Boot WordPress + WooCommerce ${{ matrix.woocommerce }}
+        run: |
+          set -o pipefail
+          docker network create wpnet
+          docker volume create wpdata
+          docker run --detach --name db --network wpnet \
+            -e MYSQL_DATABASE=wp -e MYSQL_USER=wp -e MYSQL_PASSWORD=wp \
+            -e MYSQL_RANDOM_ROOT_PASSWORD=1 \
+            --health-cmd="mysqladmin ping -h localhost -u wp -pwp" \
+            --health-interval=5s --health-timeout=5s --health-retries=30 \
+            mariadb:10.6
+          until [ "$(docker inspect -f '{{.State.Health.Status}}' db)" = "healthy" ]; do
+            sleep 2
+          done
+          docker run --detach --name wp --network wpnet -v wpdata:/var/www/html \
+            -e WORDPRESS_DB_HOST=db -e WORDPRESS_DB_USER=wp \
+            -e WORDPRESS_DB_PASSWORD=wp -e WORDPRESS_DB_NAME=wp \
+            wordpress:6.8-php8.2-apache
+          docker run --detach --name cli --network wpnet -v wpdata:/var/www/html \
+            --user 33:33 \
+            -e WORDPRESS_DB_HOST=db -e WORDPRESS_DB_USER=wp \
+            -e WORDPRESS_DB_PASSWORD=wp -e WORDPRESS_DB_NAME=wp \
+            --entrypoint sleep wordpress:cli-2.11.0-php8.2 infinity
+          until docker exec cli test -f /var/www/html/wp-config.php \
+            && docker exec cli wp core version >/dev/null 2>&1; do
+            sleep 2
+          done
+          docker exec cli wp core install --url=http://wp --title=Matrix \
+            --admin_user=admin --admin_password=support-matrix-ci \
+            --admin_email=admin@example.com
+          docker exec cli wp plugin install woocommerce \
+            --version="${{ matrix.woocommerce }}" --activate
+
+      - name: Install plugin HEAD + smoke
+        run: |
+          set -o pipefail
+          docker exec cli mkdir -p /var/www/html/wp-content/plugins/tillit-payment-gateway
+          git ls-files -z | tar --null -cf - -T - \
+            | docker exec -i cli tar -xf - -C /var/www/html/wp-content/plugins/tillit-payment-gateway
+          docker exec cli wp plugin activate tillit-payment-gateway
+          # The gateway class loads and boots under this WooCommerce version.
+          docker exec cli wp eval 'exit(class_exists("WC_Twoinc") ? 0 : 1);'
+          docker exec cli wp eval 'WC_Twoinc::get_instance(); echo "gateway boots\n";'
+          # The gateway registers with WooCommerce's gateway registry.
+          docker exec cli wp eval '
+            $ids = array_keys(WC()->payment_gateways()->payment_gateways());
+            exit(in_array("woocommerce-gateway-tillit", $ids, true) ? 0 : 1);'
+          # Storefront and checkout render without a fatal.
+          docker exec wp curl -sf http://localhost/ -o /dev/null
+          docker exec cli wp option get woocommerce_checkout_page_id \
+            | xargs -I{} docker exec wp curl -sf "http://localhost/?page_id={}" -o /dev/null
+
+      - name: Tear down
+        if: always()
+        run: |
+          docker rm -f wp cli db 2>/dev/null || true
+          docker network rm wpnet 2>/dev/null || true
+          docker volume rm wpdata 2>/dev/null || true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -24,7 +24,7 @@ jobs:
         # WooCommerce axis lives in support-matrix.yaml.
         php-version: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,9 +15,14 @@ jobs:
     permissions:
       contents: read
     strategy:
+      fail-fast: false
       matrix:
-        # Oldest PHP the plugin's syntax targets, plus current
-        php-version: ["7.4", "8.2"]
+        # The PHP axis of the support matrix (TWO-25016): the plugin's
+        # declared floor (7.4 — the oldest syntax the code targets) through
+        # every currently-supported PHP minor. The suite is dependency-free
+        # and runs in seconds, so full-span legs are effectively free; the
+        # WooCommerce axis lives in support-matrix.yaml.
+        php-version: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
     steps:
       - uses: actions/checkout@v4
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Tags: payment request, woocommerce
 Requires at least: 6
 Tested up to: 6.8.1
-Requires PHP: 7
+Requires PHP: 7.4
 Stable tag: 2.23.9
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## Scope decision (AC 1 — decided before building, documented in the workflow header)

**Light two-axis subset, not Magento's full N×M.** Magento's matrix multiplies Magento-minor × PHP because Adobe's support policy + the CI images make each combination a genuinely different runtime. For Woo the equivalent multiplication (WP × WC × PHP) mostly re-tests WooCommerce itself — WooCommerce gates its own WP/PHP support — so each axis is tested where it's cheapest and most meaningful:

- **PHP axis** → `unit-tests.yaml` matrix extended from `[7.4, 8.2]` to **7.4–8.4** (declared floor through every currently-supported minor). The tiny dependency-free suite makes full span effectively free, and this is where PHP-syntax/behaviour breakage actually surfaces.
- **WooCommerce axis** → new `support-matrix.yaml`: boot-smoke of plugin HEAD against the **latest WC release** and the **previous minor line**, both discovered live from the wordpress.org plugin API (no hand-maintained pins). Each leg: activate, `WC_Twoinc` boots, gateway present in WooCommerce's registry, storefront + checkout pages render without fatals.

## Honest-CI conventions carried over from Magento's matrix (TWO-24998)

- Discovery failure (API/transport) **fails** the job — never an empty matrix that skip-greens having tested nothing.
- Every emitted leg genuinely runs; `fail-fast: false` so one leg's failure doesn't mask the other's result.

## Not covered, deliberately

- No WC floor below previous-minor: the plugin declares no minimum WC version anywhere (readme says "tested up to", compose pins 9.9.5). If we want a support floor tested, that's a product declaration first — happy to add a third leg once one exists.
- No WP-version axis: WP ≥6 declared, but plugin surface is WC-API-bound; the WC axis exercises the integration seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn