### PR TITLE
TWO-24954/feat: read + enforce funding-partner surcharge cap from GET /v1/merchant

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -365,6 +365,70 @@ if (!class_exists('WC_Twoinc')) {
         }
 
         /**
+         * The merchant's fixed-fee surcharge cap from GET /v1/merchant
+         * (surcharge_limit_amount/_currency — the funding partner's upper
+         * bound on what a merchant may pass on per order, TWO-24950), as
+         * ['amount', 'currency'] or null when none is configured. Mirrors
+         * Magento's SettingsProvider::getSurchargeLimit (TWO-24954).
+         *
+         * Cached for 15 minutes in dedicated brand-prefixed wp_options with
+         * the term-cache posture: read-only by default (the value gates an
+         * admin save, never a checkout render), refresh only where
+         * $refresh = true is passed — the surcharge grid render and its
+         * save-time validation. Serve-stale on fetch failure: a stale cap
+         * still enforces; dropping it on an API blip would let an
+         * over-limit fixed fee through.
+         *
+         * @param bool $refresh allow a TTL-gated fetch on this call
+         * @return array|null
+         */
+        public function get_merchant_surcharge_limit(bool $refresh = false)
+        {
+            $limit_option = WC_Twoinc_Brand::prefixed_name('merchant_surcharge_limit');
+            $checked_option = WC_Twoinc_Brand::prefixed_name('merchant_surcharge_limit_checked_on');
+            $checked_on = get_option($checked_option);
+
+            if ($refresh && (!$checked_on || ((int) $checked_on + 900) <= time())) {
+                if ($this->get_merchant_id() && $this->get_option('api_key')) {
+                    update_option($checked_option, time(), false);
+                    $record = $this->fetch_merchant_record();
+                    if (is_array($record)) {
+                        $amount = $record['surcharge_limit_amount'] ?? null;
+                        $currency = $record['surcharge_limit_currency'] ?? null;
+                        $limit = null;
+                        if (
+                            is_numeric($amount) && (float) $amount > 0
+                            && is_string($currency) && $currency !== ''
+                        ) {
+                            $limit = [
+                                'amount' => (float) $amount,
+                                'currency' => strtoupper($currency),
+                            ];
+                        }
+                        // A successful record without the fields means the
+                        // backend says "no limit" — cache that outcome too.
+                        update_option($limit_option, $limit ? wp_json_encode($limit) : '', false);
+                    }
+                }
+            }
+
+            $cached = get_option($limit_option);
+            if (!$cached) {
+                return null;
+            }
+            $limit = json_decode((string) $cached, true);
+            if (!is_array($limit) || !isset($limit['amount'], $limit['currency'])) {
+                return null;
+            }
+            // JSON round-trip turns whole floats into ints — re-cast so the
+            // shape is stable for callers regardless of cache state.
+            return [
+                'amount' => (float) $limit['amount'],
+                'currency' => (string) $limit['currency'],
+            ];
+        }
+
+        /**
          * The merchant's offerable payment terms (net days, ascending) from
          * `available_terms` on GET /v1/merchant/{id} — the backend resolves
          * them from the merchant's pricing packages, so this is the
@@ -460,6 +524,8 @@ if (!class_exists('WC_Twoinc')) {
                 'days_on_invoice_checked_on',
                 'platform_minimum_order',
                 'platform_minimum_order_checked_on',
+                'merchant_surcharge_limit',
+                'merchant_surcharge_limit_checked_on',
             ];
             foreach ($names as $name) {
                 delete_option(WC_Twoinc_Brand::prefixed_name($name));
@@ -639,6 +705,13 @@ if (!class_exists('WC_Twoinc')) {
             $stored = $this->get_option($key);
             $stored = is_array($stored) ? $stored : [];
             $terms = class_exists('WC_Twoinc_Payment_Terms') ? WC_Twoinc_Payment_Terms::get_available_terms($this) : [];
+            // The grid render is a sanctioned refresh point for the
+            // funding-partner cap (admin context, TWO-24954); shown only
+            // when a cap exists, omitted entirely otherwise.
+            $fixed_limit = $this->get_merchant_surcharge_limit(true);
+            $fixed_limit_label = $fixed_limit
+                ? $fixed_limit['currency'] . ' ' . rtrim(rtrim(number_format((float) $fixed_limit['amount'], 2, '.', ''), '0'), '.')
+                : '';
 
             ob_start();
             ?>
@@ -670,6 +743,13 @@ if (!class_exists('WC_Twoinc')) {
                         <?php endforeach; ?>
                         </tbody>
                     </table>
+                    <?php if ($fixed_limit_label !== '') : ?>
+                        <p class="description"><?php echo esc_html(sprintf(
+                            /* translators: %s: maximum fixed amount with currency, e.g. "EUR 25" */
+                            __('Enter the amount you want to charge your customer. Max %s.', 'twoinc-payment-gateway'),
+                            $fixed_limit_label
+                        )); ?></p>
+                    <?php endif; ?>
                     <?php endif; ?>
                 </td>
             </tr>
@@ -685,6 +765,16 @@ if (!class_exists('WC_Twoinc')) {
          */
         public function validate_two_surcharge_grid_field($key, $value)
         {
+            // Funding-partner cap on the per-term fixed fee (TWO-24954).
+            // Only enforceable when the cap's currency matches the store
+            // currency — Woo does no FX conversion (unlike Magento), so on
+            // a mismatch the cap is skipped here and the backend enforces.
+            $max_fixed = null;
+            $limit = $this->get_merchant_surcharge_limit(true);
+            if ($limit && $limit['currency'] === strtoupper((string) get_woocommerce_currency())) {
+                $max_fixed = (float) $limit['amount'];
+            }
+
             $clean = [];
             // A non-array POST means NO grid rows were rendered (empty term
             // list at render time) — fall through to the preservation loop
@@ -714,6 +804,14 @@ if (!class_exists('WC_Twoinc')) {
                             /* translators: %s: term days */
                             __('Surcharge percentage for the %s-day term must be between 0 and 100.', 'twoinc-payment-gateway'),
                             $days
+                        ));
+                    }
+                    if ($col === 'fixed' && $max_fixed !== null && (float) $raw > $max_fixed) {
+                        throw new Exception(sprintf(
+                            /* translators: 1: term days, 2: maximum amount with currency */
+                            __('Surcharge fixed amount for the %1$s-day term exceeds the maximum of %2$s.', 'twoinc-payment-gateway'),
+                            $days,
+                            $limit['currency'] . ' ' . rtrim(rtrim(number_format($max_fixed, 2, '.', ''), '0'), '.')
                         ));
                     }
                     $row[$col] = $raw;

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -386,10 +386,12 @@ if (!class_exists('WC_Twoinc')) {
         {
             $limit_option = WC_Twoinc_Brand::prefixed_name('merchant_surcharge_limit');
             $checked_option = WC_Twoinc_Brand::prefixed_name('merchant_surcharge_limit_checked_on');
-            $checked_on = get_option($checked_option);
 
-            if ($refresh && (!$checked_on || ((int) $checked_on + 900) <= time())) {
-                if ($this->get_merchant_id() && $this->get_option('api_key')) {
+            if ($refresh && $this->get_merchant_id() && $this->get_option('api_key')) {
+                $checked_on = get_option($checked_option);
+                if (!$checked_on || ((int) $checked_on + 900) <= time()) {
+                    // Bump the clock before fetching (stampede guard), and
+                    // on failure too: one stall per TTL, not per view.
                     update_option($checked_option, time(), false);
                     $record = $this->fetch_merchant_record();
                     if (is_array($record)) {
@@ -401,7 +403,11 @@ if (!class_exists('WC_Twoinc')) {
                             && is_string($currency) && $currency !== ''
                         ) {
                             $limit = [
-                                'amount' => (float) $amount,
+                                // Round to 2dp at read: the label shows the
+                                // cap to two decimals, so a raw 25.555 would
+                                // display "Max 25.56" while rejecting 25.56.
+                                // The displayed maximum must be enterable.
+                                'amount' => round((float) $amount, 2),
                                 'currency' => strtoupper($currency),
                             ];
                         }
@@ -421,11 +427,25 @@ if (!class_exists('WC_Twoinc')) {
                 return null;
             }
             // JSON round-trip turns whole floats into ints — re-cast so the
-            // shape is stable for callers regardless of cache state.
+            // shape is stable for callers regardless of cache state. The
+            // round() also covers cache entries written before rounding
+            // moved to the fetch path.
             return [
-                'amount' => (float) $limit['amount'],
+                'amount' => round((float) $limit['amount'], 2),
                 'currency' => (string) $limit['currency'],
             ];
+        }
+
+        /**
+         * Human-readable "EUR 25" / "EUR 25.5" label for a surcharge cap
+         * (['amount', 'currency']) — the single formatting shared by the
+         * grid help text and the save-validation error, so the claimed and
+         * the enforced maximum can never drift apart.
+         */
+        private function format_surcharge_limit_label(array $limit): string
+        {
+            return $limit['currency'] . ' '
+                . rtrim(rtrim(number_format((float) $limit['amount'], 2, '.', ''), '0'), '.');
         }
 
         /**
@@ -706,11 +726,17 @@ if (!class_exists('WC_Twoinc')) {
             $stored = is_array($stored) ? $stored : [];
             $terms = class_exists('WC_Twoinc_Payment_Terms') ? WC_Twoinc_Payment_Terms::get_available_terms($this) : [];
             // The grid render is a sanctioned refresh point for the
-            // funding-partner cap (admin context, TWO-24954); shown only
-            // when a cap exists, omitted entirely otherwise.
+            // funding-partner cap (admin context, TWO-24954). The Max label
+            // carries the SAME currency guard as the save-validation: when
+            // the cap's currency differs from the store currency the cap is
+            // not enforced here (Woo does no FX conversion, unlike Magento,
+            // which converts and so can always show a local maximum), and
+            // the grid must not claim a limit it won't enforce — the
+            // backend enforces instead. Omitted entirely when no cap
+            // exists or on a currency mismatch.
             $fixed_limit = $this->get_merchant_surcharge_limit(true);
-            $fixed_limit_label = $fixed_limit
-                ? $fixed_limit['currency'] . ' ' . rtrim(rtrim(number_format((float) $fixed_limit['amount'], 2, '.', ''), '0'), '.')
+            $fixed_limit_label = $fixed_limit && $fixed_limit['currency'] === strtoupper((string) get_woocommerce_currency())
+                ? $this->format_surcharge_limit_label($fixed_limit)
                 : '';
 
             ob_start();
@@ -811,7 +837,7 @@ if (!class_exists('WC_Twoinc')) {
                             /* translators: 1: term days, 2: maximum amount with currency */
                             __('Surcharge fixed amount for the %1$s-day term exceeds the maximum of %2$s.', 'twoinc-payment-gateway'),
                             $days,
-                            $limit['currency'] . ' ' . rtrim(rtrim(number_format($max_fixed, 2, '.', ''), '0'), '.')
+                            $this->format_surcharge_limit_label($limit)
                         ));
                     }
                     $row[$col] = $raw;
@@ -830,6 +856,13 @@ if (!class_exists('WC_Twoinc')) {
             // posts its key, lands nothing in $clean, and is deliberately
             // dropped; an unrendered stored row survives untouched for the
             // term the backend (or the admin's ticks) later restores.
+            //
+            // Preserved rows deliberately bypass the funding-partner cap
+            // check above: the admin can neither see nor fix a row that
+            // was never rendered, so failing the whole save on it would be
+            // a dead end. Save-time enforcement is UX parity with Magento;
+            // the funding partner's backend is the authoritative
+            // enforcement point for anything that slips through.
             $stored = $this->get_option($key);
             foreach (is_array($stored) ? $stored : [] as $days => $row) {
                 $days = (int) $days;

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -55,6 +55,34 @@ function __($text, $domain = 'default')
     return $text;
 }
 
+function esc_html($text)
+{
+    return htmlspecialchars((string) $text, ENT_QUOTES);
+}
+
+function esc_attr($text)
+{
+    return htmlspecialchars((string) $text, ENT_QUOTES);
+}
+
+function esc_html_e($text, $domain = 'default')
+{
+    echo esc_html(__($text, $domain));
+}
+
+function wp_kses_post($content)
+{
+    return $content;
+}
+
+function wp_parse_args($args, $defaults = [])
+{
+    if (is_object($args)) {
+        $args = get_object_vars($args);
+    }
+    return is_array($args) ? array_merge($defaults, $args) : $defaults;
+}
+
 function get_home_url()
 {
     return 'https://shop.example';

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -73,6 +73,8 @@ final class BrandConfigSpec
             'testRoundingStepValidationEnforcesBrandOptions',
             'testSurchargeGridValidationNormalisesAndRejects',
             'testSurchargeGridEnforcesMerchantFixedCap',
+            'testSurchargeCapZeroAmountFromApiMeansNoLimit',
+            'testSurchargeGridHelpTextOmitsMaxOnCurrencyMismatch',
             'testPaymentTermsValidationRequiresSelection',
             'testDefaultTermCoercedToOfferedSet',
             'testOrderPayloadCarriesSelectedAndAvailableTerms',
@@ -1521,6 +1523,16 @@ final class BrandConfigSpec
         }
         TinyAssert::true(strpos($message, 'EUR 25') !== false, "cap message missing, got: $message");
 
+        // Locale comma input is normalised BEFORE the cap check — '25,01'
+        // is 25.01 over a 25 cap, not a string that dodges the comparison.
+        $message = '';
+        try {
+            $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['fixed' => '25,01']]);
+        } catch (Exception $e) {
+            $message = $e->getMessage();
+        }
+        TinyAssert::true(strpos($message, 'EUR 25') !== false, "comma-locale cap message missing, got: $message");
+
         // The cap binds the fixed column only — percentage and per-order
         // limit columns are governed by their own rules.
         $clean = $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['percentage' => '90', 'limit' => '100']]);
@@ -1537,6 +1549,73 @@ final class BrandConfigSpec
         unset($GLOBALS['__twoinc_test_options'][$limit_option]);
         $clean = $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['fixed' => '9999']]);
         TinyAssert::same([30 => ['fixed' => '9999']], $clean);
+    }
+
+    private static function testSurchargeCapZeroAmountFromApiMeansNoLimit(): void
+    {
+        // A zero-amount cap record from the API means "no limit", not
+        // "nothing may be charged": it caches the no-limit marker, so no
+        // enforcement and no Max sentence downstream.
+        $gateway = new class () extends WC_Twoinc {
+            public $options = ['api_key' => 'key', 'merchant_id' => 'mid'];
+            public $responses = [];
+
+            public function __construct()
+            {
+            }
+
+            public function get_merchant_id()
+            {
+                return 'mid';
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $this->options[$key] ?? $empty_value ?? '';
+            }
+
+            public function update_option($key, $value = '')
+            {
+                $this->options[$key] = $value;
+                return true;
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+            {
+                return array_shift($this->responses);
+            }
+        };
+        $gateway->responses[] = ['response' => ['code' => 200], 'body' => json_encode([
+            'surcharge_limit_amount' => 0,
+            'surcharge_limit_currency' => 'eur',
+        ])];
+
+        TinyAssert::same(null, $gateway->get_merchant_surcharge_limit(true));
+        // The no-limit outcome is cached as the empty marker...
+        TinyAssert::same('', $GLOBALS['__twoinc_test_options'][WC_Twoinc_Brand::prefixed_name('merchant_surcharge_limit')]);
+        // ...and save-validation applies no cap.
+        $clean = $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['fixed' => '9999']]);
+        TinyAssert::same([30 => ['fixed' => '9999']], $clean);
+    }
+
+    private static function testSurchargeGridHelpTextOmitsMaxOnCurrencyMismatch(): void
+    {
+        $limit_option = WC_Twoinc_Brand::prefixed_name('merchant_surcharge_limit');
+        $GLOBALS['__twoinc_test_options'][$limit_option] = json_encode(['amount' => 25.0, 'currency' => 'EUR']);
+
+        // Matching store currency: the grid claims the enforced maximum.
+        $GLOBALS['__twoinc_test_currency'] = 'EUR';
+        $gateway = self::validationGateway(['payment_terms_days' => [30]], [30]);
+        $html = $gateway->generate_two_surcharge_grid_html('surcharge_grid', []);
+        TinyAssert::true(strpos($html, 'Max EUR 25.') !== false, 'expected Max sentence for matching currency');
+
+        // Store currency differs from the cap's: save-validation skips the
+        // cap (Woo does no FX conversion), so the help text must not claim
+        // a maximum it will not enforce.
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $html = $gateway->generate_two_surcharge_grid_html('surcharge_grid', []);
+        TinyAssert::true(strpos($html, 'Max') === false, 'Max sentence must be omitted on currency mismatch');
+        unset($GLOBALS['__twoinc_test_currency']);
     }
 
     private static function testPaymentTermsValidationRequiresSelection(): void

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -72,6 +72,7 @@ final class BrandConfigSpec
             'testRoundingStepOptionsCanonicalAndNarrowed',
             'testRoundingStepValidationEnforcesBrandOptions',
             'testSurchargeGridValidationNormalisesAndRejects',
+            'testSurchargeGridEnforcesMerchantFixedCap',
             'testPaymentTermsValidationRequiresSelection',
             'testDefaultTermCoercedToOfferedSet',
             'testOrderPayloadCarriesSelectedAndAvailableTerms',
@@ -1085,14 +1086,17 @@ final class BrandConfigSpec
             'min_order_currency' => 'nok',
             'min_order_basis' => 'net',
             'available_terms' => [30, 60],
+            'surcharge_limit_amount' => 25,
+            'surcharge_limit_currency' => 'eur',
         ];
         $gateway->responses[] = ['response' => ['code' => 200], 'body' => json_encode($record)];
 
-        // All three consumers in one request: exactly ONE wire fetch
+        // All four consumers in one request: exactly ONE wire fetch
         TinyAssert::same([30, 60], $gateway->get_merchant_available_terms(true));
         TinyAssert::same(21, $gateway->get_merchant_default_days_on_invoice());
         $minimum = $gateway->get_platform_minimum_order();
         TinyAssert::same(['amount' => 100.0, 'currency' => 'NOK', 'basis' => 'net'], $minimum);
+        TinyAssert::same(['amount' => 25.0, 'currency' => 'EUR'], $gateway->get_merchant_surcharge_limit(true));
         TinyAssert::same(1, $gateway->calls);
 
         // The caches live in dedicated wp_options, never the settings blob —
@@ -1110,7 +1114,7 @@ final class BrandConfigSpec
         // stall total (memo covers failures), each consumer keeps its own
         // degrade posture — days serves stale, minimum blanks to null,
         // terms serve stale.
-        foreach (['merchant_available_terms_checked_on', 'days_on_invoice_checked_on', 'platform_minimum_order_checked_on'] as $name) {
+        foreach (['merchant_available_terms_checked_on', 'days_on_invoice_checked_on', 'platform_minimum_order_checked_on', 'merchant_surcharge_limit_checked_on'] as $name) {
             $GLOBALS['__twoinc_test_options'][WC_Twoinc_Brand::prefixed_name($name)] = time() - 3601;
         }
         WC_Twoinc::reset_merchant_record_memo();
@@ -1119,6 +1123,7 @@ final class BrandConfigSpec
         TinyAssert::same([30, 60], $gateway->get_merchant_available_terms(true));
         TinyAssert::same(21, $gateway->get_merchant_default_days_on_invoice());
         TinyAssert::same(null, $gateway->get_platform_minimum_order());
+        TinyAssert::same(['amount' => 25.0, 'currency' => 'EUR'], $gateway->get_merchant_surcharge_limit(true));
         TinyAssert::same(2, $gateway->calls);
     }
 
@@ -1493,6 +1498,45 @@ final class BrandConfigSpec
 
         // Non-array input → empty grid
         TinyAssert::same([], $gateway->validate_two_surcharge_grid_field('surcharge_grid', ''));
+    }
+
+    private static function testSurchargeGridEnforcesMerchantFixedCap(): void
+    {
+        $limit_option = WC_Twoinc_Brand::prefixed_name('merchant_surcharge_limit');
+        $checked_option = WC_Twoinc_Brand::prefixed_name('merchant_surcharge_limit_checked_on');
+        $GLOBALS['__twoinc_test_options'][$limit_option] = json_encode(['amount' => 25.0, 'currency' => 'EUR']);
+        $GLOBALS['__twoinc_test_options'][$checked_option] = time();
+        $gateway = self::gateway();
+
+        // At the cap: allowed
+        $clean = $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['fixed' => '25']]);
+        TinyAssert::same([30 => ['fixed' => '25']], $clean);
+
+        // Above the cap: rejected, message names the cap
+        $message = '';
+        try {
+            $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['fixed' => '25.01']]);
+        } catch (Exception $e) {
+            $message = $e->getMessage();
+        }
+        TinyAssert::true(strpos($message, 'EUR 25') !== false, "cap message missing, got: $message");
+
+        // The cap binds the fixed column only — percentage and per-order
+        // limit columns are governed by their own rules.
+        $clean = $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['percentage' => '90', 'limit' => '100']]);
+        TinyAssert::same([30 => ['percentage' => '90', 'limit' => '100']], $clean);
+
+        // Store currency differs from the cap's: Woo does no FX conversion,
+        // so the cap is skipped here (the backend still enforces).
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $clean = $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['fixed' => '9999']]);
+        TinyAssert::same([30 => ['fixed' => '9999']], $clean);
+        unset($GLOBALS['__twoinc_test_currency']);
+
+        // No cap configured: behaviour unchanged
+        unset($GLOBALS['__twoinc_test_options'][$limit_option]);
+        $clean = $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['fixed' => '9999']]);
+        TinyAssert::same([30 => ['fixed' => '9999']], $clean);
     }
 
     private static function testPaymentTermsValidationRequiresSelection(): void


### PR DESCRIPTION
**Stacked on #345** (TWO-25024 merchant-record provider) — merge that first; this PR's diff vs its base is the surcharge-cap feature only.

## What

Feature B consumer (Woo base plugin had no surcharge-limit concept; built whole, mirroring Magento):

1. **Read**: `get_merchant_surcharge_limit()` — `surcharge_limit_amount`/`_currency` (TWO-24950, merged) read off the shared request-memoised merchant-record fetch from #345, so zero extra round-trips. Cached 15m in dedicated brand-prefixed wp_options; **serve-stale on failure** (a stale cap still enforces — dropping it on an API blip would let an over-limit fee through). Refresh gated to admin contexts: grid render + grid save validation.
2. **Enforce**: `validate_two_surcharge_grid_field` rejects per-term `fixed` above the cap with a message naming it ("…exceeds the maximum of EUR 25."), mirroring Magento's `SurchargeGrid::validateValue`. Currency guard: enforced only when the cap currency matches the store currency — Woo does no FX conversion (Magento converts to base); on mismatch the backend enforces alone.
3. **Help text**: conditional sentence under the grid using Magento's `getFixedLimitLabel` wording ("Enter the amount you want to charge your customer. Max EUR 25.") — omitted entirely when no cap is configured, so no-limit brands see no change.

## Tests

`testSurchargeGridEnforcesMerchantFixedCap`: at-cap allowed, above-cap rejected naming the cap, percentage/per-order-limit columns unaffected, currency-mismatch skip, no-cap unchanged. The shared-provider test now covers the fourth consumer (still exactly one wire fetch; serve-stale on API-down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn


---
Supersedes #346 (auto-closed when its stacked base branch was deleted on the #345 merge before GitHub retargeted it). Same branch, same commits; the adversarial-review audit trail lives on #346.
