### PR TITLE
TWO-25035/feat: explicit environment mode + brand host template

### DIFF
--- a/brands/two.php
+++ b/brands/two.php
@@ -20,6 +20,12 @@ return [
     'provider_full_name' => 'Two',
     'product_name' => 'Two',
     'sign_up_url' => 'https://portal.two.inc/auth/merchant/signup',
+    // sprintf template building environment hosts, mirroring the Magento
+    // brand descriptor's checkout_url_template: %s receives 'api' /
+    // 'checkout' in production, or 'api.<mode>' / 'checkout.<mode>' for
+    // any other checkout_env mode ('sandbox', 'staging', ...). Overlays
+    // set their own domain here — brand domains never live in base code.
+    'checkout_url_template' => 'https://%s.two.inc',
     'alert_email_address' => 'woocom-alerts@two.inc',
     'gateway_id' => 'woocommerce-gateway-tillit',
     'logo_url' => WC_TWOINC_PLUGIN_URL . 'assets/images/two-logo.svg',

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -186,9 +186,11 @@ if (!class_exists('WC_Twoinc')) {
             // TWOINC_DEV_HOSTNAMES env var, *.two.inc dev subdomains):
             // installs predating the explicit environment mode carry the
             // default mode and rely on the sniffed test host. Consulted only
-            // while checkout_env is still the default — an explicitly set
-            // mode always wins. Set checkout_env ('staging', 'sandbox', ...)
-            // instead of extending the sniffer.
+            // while the mode resolves to production — an explicit
+            // non-production mode ('staging', 'sandbox') always wins, while
+            // an explicit Production selection is indistinguishable from the
+            // never-configured default, so the sniffer still applies there.
+            // Set checkout_env instead of extending the sniffer.
             if (
                 WC_Twoinc_Helper::get_environment_mode($this) === 'production'
                 && WC_Twoinc_Helper::is_twoinc_development()
@@ -213,9 +215,20 @@ if (!class_exists('WC_Twoinc')) {
                 'PROD'    => __('Production', 'twoinc-payment-gateway'),
                 'SANDBOX' => __('Sandbox', 'twoinc-payment-gateway'),
             ];
-            $stored = (string) $this->get_option('checkout_env');
-            if ($stored !== '' && !in_array(strtolower($stored), ['prod', 'production', 'sandbox'], true)) {
-                $options[$stored] = ucfirst(strtolower($stored));
+            // Raw settings row, NOT $this->get_option(): this runs inside
+            // init_form_fields(), and WC_Settings_API::get_option() on a
+            // missing key re-enters get_form_fields() -> init_form_fields()
+            // — infinite recursion on any install whose settings blob lacks
+            // checkout_env (fresh installs, and dev shops where the field
+            // was previously unset from the form).
+            $saved = get_option($this->get_option_key(), null);
+            $stored = is_array($saved) ? (string) ($saved['checkout_env'] ?? '') : '';
+            $normalized = strtolower($stored);
+            if (
+                in_array($normalized, WC_Twoinc_Helper::ENVIRONMENT_MODES, true)
+                && !in_array($normalized, ['production', 'sandbox'], true)
+            ) {
+                $options[$stored] = ucfirst($normalized);
             }
             return $options;
         }
@@ -2513,12 +2526,12 @@ if (!class_exists('WC_Twoinc')) {
                 'test_checkout_host' => [
                     'type'        => 'text',
                     'title'       => sprintf(__('%s Test Server', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')),
-                    'default'     => 'https://api.staging.two.inc'
+                    'default'     => sprintf(WC_Twoinc_Brand::get('checkout_url_template'), 'api.staging')
                 ],
                 'checkout_env' => [
                     'type'        => 'select',
                     'title'       => __('Choose your settings', 'twoinc-payment-gateway'),
-                    'default'     => 'Production',
+                    'default'     => 'PROD',
                     'options'     => $this->get_checkout_env_options(),
                 ],
                 'clear_options_on_deactivation' => [

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -182,13 +182,42 @@ if (!class_exists('WC_Twoinc')) {
          */
         public function get_twoinc_checkout_host()
         {
-            if (WC_Twoinc_Helper::is_twoinc_development()) {
+            // Deprecated dev-environment sniffing (localhost, the
+            // TWOINC_DEV_HOSTNAMES env var, *.two.inc dev subdomains):
+            // installs predating the explicit environment mode carry the
+            // default mode and rely on the sniffed test host. Consulted only
+            // while checkout_env is still the default — an explicitly set
+            // mode always wins. Set checkout_env ('staging', 'sandbox', ...)
+            // instead of extending the sniffer.
+            if (
+                WC_Twoinc_Helper::get_environment_mode($this) === 'production'
+                && WC_Twoinc_Helper::is_twoinc_development()
+            ) {
                 return $this->get_option('test_checkout_host');
-            } elseif ($this->get_option('checkout_env') === 'SANDBOX') {
-                return 'https://api.sandbox.two.inc';
-            } else {
-                return 'https://api.two.inc';
             }
+            return WC_Twoinc_Helper::get_environment_host('api', $this);
+        }
+
+        /**
+         * Options for the checkout_env select. Merchants choose between
+         * Production and Sandbox; any other stored mode (e.g. 'staging' on
+         * Two's own staging shops, set via wp-cli rather than the UI) is
+         * preserved as a selectable option so saving the settings form
+         * doesn't silently reset it. Mirrors the Magento Mode source model.
+         *
+         * @return array
+         */
+        public function get_checkout_env_options()
+        {
+            $options = [
+                'PROD'    => __('Production', 'twoinc-payment-gateway'),
+                'SANDBOX' => __('Sandbox', 'twoinc-payment-gateway'),
+            ];
+            $stored = (string) $this->get_option('checkout_env');
+            if ($stored !== '' && !in_array(strtolower($stored), ['prod', 'production', 'sandbox'], true)) {
+                $options[$stored] = ucfirst(strtolower($stored));
+            }
+            return $options;
         }
 
         /**
@@ -2490,10 +2519,7 @@ if (!class_exists('WC_Twoinc')) {
                     'type'        => 'select',
                     'title'       => __('Choose your settings', 'twoinc-payment-gateway'),
                     'default'     => 'Production',
-                    'options'     => array(
-                        'PROD'     => 'Production',
-                        'SANDBOX'  => 'Sandbox'
-                    )
+                    'options'     => $this->get_checkout_env_options(),
                 ],
                 'clear_options_on_deactivation' => [
                     'title'       => __('Clear settings on deactivation of plug-in', 'twoinc-payment-gateway'),
@@ -2730,9 +2756,10 @@ if (!class_exists('WC_Twoinc')) {
                 ],
             ];
 
-            if (WC_Twoinc_Helper::is_twoinc_development()) {
-                unset($twoinc_form_fields['checkout_env']);
-            } else {
+            // checkout_env is always shown — it is the environment selector.
+            // The free-text test host only appears on sniffed dev
+            // environments, where it remains the legacy override.
+            if (!WC_Twoinc_Helper::is_twoinc_development()) {
                 unset($twoinc_form_fields['test_checkout_host']);
             }
 

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -916,23 +916,35 @@ if (!class_exists('WC_Twoinc_Helper')) {
         }
 
         /**
+         * Environment modes the host builder accepts. The mode string is
+         * spliced into the API hostname, and WooCommerce's select
+         * validation does not restrict POSTed values to the options list —
+         * so this allowlist is what keeps an admin-supplied string from
+         * steering the gateway's API calls to an arbitrary host.
+         */
+        public const ENVIRONMENT_MODES = ['production', 'sandbox', 'staging'];
+
+        /**
          * Resolve the gateway's configured environment mode.
          *
          * Mirrors the Magento config repository's mode setting: the stored
          * `checkout_env` option is normalised to lowercase, with the
          * historical 'PROD'/'Production' spellings mapping to 'production'.
-         * Any other stored value ('staging', ...) passes through as-is, so
-         * non-production shops select their environment explicitly instead
-         * of relying on hostname sniffing.
+         * Anything outside ENVIRONMENT_MODES (including the empty default)
+         * resolves to 'production' — the same host every unrecognised value
+         * produced before the template existed.
          *
          * @param WC_Payment_Gateway $gateway
          *
-         * @return string 'production', 'sandbox', 'staging', ...
+         * @return string one of ENVIRONMENT_MODES
          */
         public static function get_environment_mode($gateway)
         {
             $mode = strtolower((string) $gateway->get_option('checkout_env'));
-            if ($mode === '' || $mode === 'prod') {
+            if ($mode === 'prod') {
+                $mode = 'production';
+            }
+            if (!in_array($mode, self::ENVIRONMENT_MODES, true)) {
                 $mode = 'production';
             }
             return $mode;

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -911,13 +911,50 @@ if (!class_exists('WC_Twoinc_Helper')) {
                 return true;
             }
 
-            // Merchant's staging
-            if (in_array($hostname, array('staging.torn.no', 'proof-3.redflamingostudio.com', 'icecreamextreme.no', 'www.staging83.avshop.no'))) {
-                return true;
-            }
-
             // Neither local nor twoinc development site
             return false;
+        }
+
+        /**
+         * Resolve the gateway's configured environment mode.
+         *
+         * Mirrors the Magento config repository's mode setting: the stored
+         * `checkout_env` option is normalised to lowercase, with the
+         * historical 'PROD'/'Production' spellings mapping to 'production'.
+         * Any other stored value ('staging', ...) passes through as-is, so
+         * non-production shops select their environment explicitly instead
+         * of relying on hostname sniffing.
+         *
+         * @param WC_Payment_Gateway $gateway
+         *
+         * @return string 'production', 'sandbox', 'staging', ...
+         */
+        public static function get_environment_mode($gateway)
+        {
+            $mode = strtolower((string) $gateway->get_option('checkout_env'));
+            if ($mode === '' || $mode === 'prod') {
+                $mode = 'production';
+            }
+            return $mode;
+        }
+
+        /**
+         * Build an environment host from the brand's URL template, mirroring
+         * the Magento config repository: ('api', mode 'staging') on the Two
+         * brand -> https://api.staging.two.inc; production drops the mode
+         * suffix. The template itself comes from the brand registry, so a
+         * brand overlay carries its own domains.
+         *
+         * @param string             $service 'api' or 'checkout'
+         * @param WC_Payment_Gateway $gateway
+         *
+         * @return string
+         */
+        public static function get_environment_host($service, $gateway)
+        {
+            $mode = self::get_environment_mode($gateway);
+            $prefix = $mode === 'production' ? $service : $service . '.' . $mode;
+            return sprintf(WC_Twoinc_Brand::get('checkout_url_template'), $prefix);
         }
 
         /**

--- a/class/WC_Twoinc_Sole_Trader.php
+++ b/class/WC_Twoinc_Sole_Trader.php
@@ -179,11 +179,7 @@ if (!class_exists('WC_Twoinc_Sole_Trader')) {
          */
         public static function get_signup_page_url($gateway): string
         {
-            if ($gateway->get_option('checkout_env') === 'SANDBOX') {
-                $url = 'https://checkout.sandbox.two.inc/soletrader/signup';
-            } else {
-                $url = 'https://checkout.two.inc/soletrader/signup';
-            }
+            $url = WC_Twoinc_Helper::get_environment_host('checkout', $gateway) . '/soletrader/signup';
             return apply_filters('twoinc_sole_trader_signup_url', $url);
         }
 

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -85,7 +85,7 @@ function wp_parse_args($args, $defaults = [])
 
 function get_home_url()
 {
-    return 'https://shop.example';
+    return $GLOBALS['test_home_url'] ?? 'https://shop.example';
 }
 
 function wp_create_nonce($action = -1)

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -225,6 +225,11 @@ class WC_Payment_Gateway
     {
         return $this->plugin_id . $this->id . '_' . $key;
     }
+
+    public function get_option_key()
+    {
+        return $this->plugin_id . $this->id . '_settings';
+    }
 }
 
 class WC_HTTPS

--- a/tests/unit/fixtures/testbrand.php
+++ b/tests/unit/fixtures/testbrand.php
@@ -10,6 +10,7 @@ return [
     'product_name' => 'Testbrand',
     'gateway_id' => 'woocommerce-gateway-testbrand',
     'meta_prefix' => 'testbrand',
+    'checkout_url_template' => 'https://%s.testbrand.example',
     // Deliberately messy: an overlay narrows the step set; declared
     // unsorted and with invalid entries (<=0, non-numeric) that
     // get_rounding_step_options must skip rather than fatal on. Expected

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -92,6 +92,7 @@ final class BrandConfigSpec
             'testEnvironmentModeNormalisesStoredCheckoutEnv',
             'testEnvironmentHostFollowsModeAndBrandTemplate',
             'testCheckoutHostPrefersExplicitModeOverDevSniffing',
+            'testCheckoutEnvOptionsPreserveStoredModeWithoutSettingsApi',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -105,6 +106,7 @@ final class BrandConfigSpec
         WC_Twoinc_Brand::reset();
         putenv('TWO_BRAND_CODE');
         unset($GLOBALS['__twoinc_test_currency']);
+        unset($GLOBALS['test_home_url']);
         $GLOBALS['__twoinc_test_options'] = [];
         unset($_POST[WC_Twoinc_Payment_Terms::SESSION_KEY]);
         WC_Twoinc_Payment_Terms::reset_fee_cache();
@@ -1372,6 +1374,7 @@ final class BrandConfigSpec
             WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30)
         );
         unset($GLOBALS['__twoinc_test_currency']);
+        unset($GLOBALS['test_home_url']);
     }
 
     private static function testBuyerFeeShareRounding(): void
@@ -1547,6 +1550,7 @@ final class BrandConfigSpec
         $clean = $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['fixed' => '9999']]);
         TinyAssert::same([30 => ['fixed' => '9999']], $clean);
         unset($GLOBALS['__twoinc_test_currency']);
+        unset($GLOBALS['test_home_url']);
 
         // No cap configured: behaviour unchanged
         unset($GLOBALS['__twoinc_test_options'][$limit_option]);
@@ -1619,6 +1623,7 @@ final class BrandConfigSpec
         $html = $gateway->generate_two_surcharge_grid_html('surcharge_grid', []);
         TinyAssert::true(strpos($html, 'Max') === false, 'Max sentence must be omitted on currency mismatch');
         unset($GLOBALS['__twoinc_test_currency']);
+        unset($GLOBALS['test_home_url']);
     }
 
     private static function testPaymentTermsValidationRequiresSelection(): void
@@ -1904,6 +1909,12 @@ final class BrandConfigSpec
             ['Production', 'production'],
             ['SANDBOX', 'sandbox'],
             ['staging', 'staging'],
+            // Outside the allowlist -> production (the pre-template host for
+            // every unrecognised value). The mode splices into the API
+            // hostname, so hostile admin input must not steer it off-domain.
+            ['evil.example/', 'production'],
+            ['api.evil.example/#', 'production'],
+            ['foo', 'production'],
         ];
         foreach ($cases as [$stored, $expected]) {
             $gateway = self::soleTraderGateway(['checkout_env' => $stored], []);
@@ -1925,11 +1936,8 @@ final class BrandConfigSpec
         TinyAssert::same('https://checkout.staging.two.inc', WC_Twoinc_Helper::get_environment_host('checkout', $gateway));
 
         // A brand overlay's template carries the brand's own domain.
-        self::useTestbrand();
         WC_Twoinc_Brand::reset();
-        add_filter('twoinc_brand_file', static function ($file) {
-            return __DIR__ . '/fixtures/testbrand.php';
-        });
+        self::useTestbrand();
         TinyAssert::same(
             'https://api.staging.testbrand.example',
             WC_Twoinc_Helper::get_environment_host('api', $gateway)
@@ -1974,8 +1982,37 @@ final class BrandConfigSpec
         // Non-dev brand shop with explicit staging mode: no sniffing needed.
         $GLOBALS['test_home_url'] = 'https://brand-shop.staging.brand.example';
         TinyAssert::same('https://api.staging.two.inc', $make(['checkout_env' => 'staging'])->get_twoinc_checkout_host());
+    }
 
-        unset($GLOBALS['test_home_url']);
+    private static function testCheckoutEnvOptionsPreserveStoredModeWithoutSettingsApi(): void
+    {
+        // The options builder must read the raw settings row, never
+        // WC_Settings_API::get_option — that path re-enters
+        // init_form_fields() on installs missing the key (fresh installs)
+        // and recurses. The stub gateway would mask that, so assert the
+        // read goes through the wp option instead.
+        $gateway = new class () extends WC_Twoinc {
+            public function __construct()
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+            }
+            public function get_option($key, $empty_value = null)
+            {
+                throw new RuntimeException('settings API consulted from options builder');
+            }
+        };
+        $key = $gateway->get_option_key();
+
+        // Fresh install: no settings row at all.
+        TinyAssert::same(['PROD', 'SANDBOX'], array_keys($gateway->get_checkout_env_options()));
+
+        // Stored custom allowlisted mode is preserved as an option.
+        $GLOBALS['__twoinc_test_options'][$key] = ['checkout_env' => 'staging'];
+        TinyAssert::same(['PROD', 'SANDBOX', 'staging'], array_keys($gateway->get_checkout_env_options()));
+
+        // Garbage is NOT perpetuated as a selectable option.
+        $GLOBALS['__twoinc_test_options'][$key] = ['checkout_env' => 'evil.example/'];
+        TinyAssert::same(['PROD', 'SANDBOX'], array_keys($gateway->get_checkout_env_options()));
     }
 }
 

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -89,6 +89,9 @@ final class BrandConfigSpec
             'testSoleTraderTokenMintReadsHeaderCaseInsensitively',
             'testSoleTraderTokenMintFailsClosed',
             'testSoleTraderSignupUrlFollowsEnvAndFilter',
+            'testEnvironmentModeNormalisesStoredCheckoutEnv',
+            'testEnvironmentHostFollowsModeAndBrandTemplate',
+            'testCheckoutHostPrefersExplicitModeOverDevSniffing',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -1891,6 +1894,88 @@ final class BrandConfigSpec
             return $url . '?brand=acme';
         });
         TinyAssert::same('https://checkout.sandbox.two.inc/soletrader/signup?brand=acme', WC_Twoinc_Sole_Trader::get_signup_page_url($gateway));
+    }
+
+    private static function testEnvironmentModeNormalisesStoredCheckoutEnv(): void
+    {
+        $cases = [
+            ['', 'production'],
+            ['PROD', 'production'],
+            ['Production', 'production'],
+            ['SANDBOX', 'sandbox'],
+            ['staging', 'staging'],
+        ];
+        foreach ($cases as [$stored, $expected]) {
+            $gateway = self::soleTraderGateway(['checkout_env' => $stored], []);
+            TinyAssert::same($expected, WC_Twoinc_Helper::get_environment_mode($gateway), $stored ?: '(empty)');
+        }
+    }
+
+    private static function testEnvironmentHostFollowsModeAndBrandTemplate(): void
+    {
+        // Two brand (default): production drops the mode suffix.
+        $gateway = self::soleTraderGateway([], []);
+        TinyAssert::same('https://api.two.inc', WC_Twoinc_Helper::get_environment_host('api', $gateway));
+
+        $gateway = self::soleTraderGateway(['checkout_env' => 'SANDBOX'], []);
+        TinyAssert::same('https://api.sandbox.two.inc', WC_Twoinc_Helper::get_environment_host('api', $gateway));
+
+        $gateway = self::soleTraderGateway(['checkout_env' => 'staging'], []);
+        TinyAssert::same('https://api.staging.two.inc', WC_Twoinc_Helper::get_environment_host('api', $gateway));
+        TinyAssert::same('https://checkout.staging.two.inc', WC_Twoinc_Helper::get_environment_host('checkout', $gateway));
+
+        // A brand overlay's template carries the brand's own domain.
+        self::useTestbrand();
+        WC_Twoinc_Brand::reset();
+        add_filter('twoinc_brand_file', static function ($file) {
+            return __DIR__ . '/fixtures/testbrand.php';
+        });
+        TinyAssert::same(
+            'https://api.staging.testbrand.example',
+            WC_Twoinc_Helper::get_environment_host('api', $gateway)
+        );
+    }
+
+    private static function testCheckoutHostPrefersExplicitModeOverDevSniffing(): void
+    {
+        $make = static function (array $options) {
+            return new class ($options) extends WC_Twoinc {
+                private $options;
+                public function __construct($options)
+                {
+                    $this->id = WC_Twoinc_Brand::get('gateway_id');
+                    $this->options = $options;
+                }
+                public function get_option($key, $empty_value = null)
+                {
+                    return $this->options[$key] ?? $empty_value ?? '';
+                }
+            };
+        };
+
+        // Non-dev hostname, default mode: production host.
+        $GLOBALS['test_home_url'] = 'https://shop.merchant.example';
+        TinyAssert::same('https://api.two.inc', $make([])->get_twoinc_checkout_host());
+
+        // Dev-sniffed hostname (*.staging.two.inc) with the default mode:
+        // legacy behaviour, the configured test host wins.
+        $GLOBALS['test_home_url'] = 'https://woocom.staging.two.inc';
+        TinyAssert::same(
+            'https://api.staging.example',
+            $make(['test_checkout_host' => 'https://api.staging.example'])->get_twoinc_checkout_host()
+        );
+
+        // An explicit mode beats the sniffer — even on a dev hostname.
+        TinyAssert::same(
+            'https://api.staging.two.inc',
+            $make(['checkout_env' => 'staging', 'test_checkout_host' => 'https://api.staging.example'])->get_twoinc_checkout_host()
+        );
+
+        // Non-dev brand shop with explicit staging mode: no sniffing needed.
+        $GLOBALS['test_home_url'] = 'https://brand-shop.staging.brand.example';
+        TinyAssert::same('https://api.staging.two.inc', $make(['checkout_env' => 'staging'])->get_twoinc_checkout_host());
+
+        unset($GLOBALS['test_home_url']);
     }
 }
 


### PR DESCRIPTION
## Problem

The ABN staging shops (`woocom{,-dev}.staging.achterafbetalen.co`) show no merchant short name and never pick up payment terms: `is_twoinc_development()` only recognises `*.two.inc` dev hostnames, so those shops resolve the **Production** API host and every merchant-record fetch 401s with their staging key (verified live: same key 401s on the prod host, 200s on the staging host). The bump-then-fetch guard stamps `*_checked_on` anyway, masking the failure per TTL window.

Hardcoding brand staging domains in base would be a leak — base code must stay brand-agnostic.

## Fix — adopt the Magento pattern

Environment is an explicit mode, hosts come from a brand-owned template (mirrors `magento-plugin`'s `Config/Repository::getCheckoutApiUrl` + brand descriptor `checkoutUrlTemplate` + `Mode` source model):

- `checkout_env` = mode (`PROD`/`SANDBOX`/any custom value, e.g. `staging`), normalised by `WC_Twoinc_Helper::get_environment_mode()`.
- Host = `sprintf(brand's checkout_url_template, 'api'|'checkout' [+ '.mode'])` — Two brand template `https://%s.two.inc` reproduces today's prod/sandbox hosts exactly; overlays set their own domain in their brand file.
- Explicit non-default mode always wins. The dev-hostname sniffer stays as a **deprecated fallback** only while `checkout_env` is default — in-place wp.org upgrades and `*.staging.two.inc` shops keep today's behaviour untouched.
- Sole-trader signup URL rides the same template.
- `checkout_env` select preserves a stored custom mode as an option (Magento `Mode.php` trick) and is now always visible; the free-text test host shows only on sniffed dev environments.
- Hardcoded merchant-staging hostname list removed — all four hosts confirmed dead (3 have no DNS; staging.torn.no confirmed retired). `TWOINC_DEV_HOSTNAMES` remains the supported escape hatch.

## Rollout

1. Merge this + the abn overlay counterpart (template `https://%s.achterafbetalen.abnamro.nl`).
2. `wp option` `checkout_env=staging` on the ABN staging shops (and optionally the two.inc staging shops — sniffer covers them either way).

## Tests

66 unit tests green, incl. new: mode normalisation, template resolution (brand override), sniffer-vs-explicit-mode precedence matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn