### PR TITLE
TWO-25041/feat: graceful invoice retrieval when order not yet fulfilled

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -131,6 +131,10 @@ if (!class_exists('WC_Twoinc')) {
                 // Add HTML in order edit page
                 add_action('woocommerce_admin_order_data_after_order_details', [$this, 'add_invoice_credit_note_urls']);
 
+                // One-shot notice from the invoice/credit-note download
+                // handler (ajax_download_invoice redirects back here)
+                add_action('admin_notices', [$this, 'render_invoice_download_notice']);
+
                 // Advanced Custom Fields plugin hides custom fields, we must display them
                 add_filter('acf/settings/remove_wp_meta_box', '__return_false');
 
@@ -1234,18 +1238,36 @@ if (!class_exists('WC_Twoinc')) {
 
             if ($twoinc_order_id) {
 
+                // Route the downloads through the plugin's admin-ajax handler
+                // (ajax_download_invoice) instead of linking straight at the
+                // API: a direct link surfaces the raw 400 ORDER_NOT_FULFILLED
+                // JSON when the order is still being fulfilled, while the
+                // handler can check the order state and show a proper notice
+                // (TWO-25041).
+                $download_url = function ($variant) use ($order) {
+                    return wp_nonce_url(
+                        add_query_arg(
+                            [
+                                'action' => 'twoinc_download_invoice',
+                                'order_id' => $order->get_id(),
+                                'variant' => $variant,
+                            ],
+                            admin_url('admin-ajax.php')
+                        ),
+                        'twoinc_admin_nonce'
+                    );
+                };
+
                 print('<div style="margin-top:20px;float:left;">');
 
-                print('<p><a href="' . $this->get_twoinc_checkout_host() . "/v1/invoice/{$twoinc_order_id}/pdf?v=original&lang="
-                    . WC_Twoinc_Helper::get_locale()
+                print('<p><a href="' . esc_url($download_url('original'))
                     . '"><button type="button" class="button">'
                     . sprintf(__('Download %s invoice', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name'))
                     . '</button></a></p>');
 
                 $refunded_payments = array_filter($order->get_refunds(), fn($refund) => $refund->get_refunded_payment());
                 if (count($refunded_payments) > 0) {
-                    print('<p><a href="' . $this->get_twoinc_checkout_host() . "/v1/invoice/{$twoinc_order_id}/pdf?lang="
-                        . WC_Twoinc_Helper::get_locale()
+                    print('<p><a href="' . esc_url($download_url('credit_note'))
                         . '"><button type="button" class="button">'
                         . sprintf(__('Download %s credit note', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name'))
                         . '</button></a><p>');
@@ -1253,6 +1275,261 @@ if (!class_exists('WC_Twoinc')) {
 
                 print('</div>');
             }
+        }
+
+        /**
+         * Timeout (seconds) for the admin invoice-download API calls. The
+         * download is a blocking browser navigation that can chain up to
+         * three serial requests (invoice fetch, order-state fetch, invoice
+         * retry), so it uses a tighter timeout than make_request's default
+         * 30s — scoped to this call site only.
+         */
+        private const INVOICE_DOWNLOAD_TIMEOUT = 10;
+
+        /**
+         * Resolve an admin invoice/credit-note download attempt into a
+         * discriminated result — either the PDF bytes to stream or an admin
+         * notice — implementing the ORDER_NOT_FULFILLED state check
+         * (TWO-25041):
+         *
+         *   - invoice fetch OK → stream the PDF
+         *   - 400 ORDER_NOT_FULFILLED → GET /v1/order/{id} and branch on state:
+         *       FULFILLING → info notice "not ready yet, try again later"
+         *       FULFILLED  → retry the invoice fetch once; error notice if it
+         *                    fails again
+         *       any other  → info notice naming the state
+         *   - any other error → error notice (same terminal path as before
+         *     the state check existed)
+         *
+         * Pure branching over make_request (no echo/exit/headers) so the
+         * unit runner can cover every branch; ajax_download_invoice maps the
+         * result to stream-or-redirect.
+         *
+         * @param $order WC_Order
+         * @param string $variant 'original' | 'credit_note'
+         *
+         * @return array ['action' => 'stream', 'body' => string, 'filename' => string]
+         *             | ['action' => 'notice', 'level' => 'info'|'error', 'message' => string]
+         */
+        public function resolve_invoice_download($order, $variant)
+        {
+            $product_name = WC_Twoinc_Brand::get('product_name');
+
+            $twoinc_order_id = $this->get_twoinc_order_id($order);
+            if (!$twoinc_order_id) {
+                return [
+                    'action' => 'notice',
+                    'level' => 'error',
+                    'message' => sprintf(__('No %s order reference is set for this order.', 'twoinc-payment-gateway'), $product_name),
+                ];
+            }
+
+            $endpoint = "/v1/invoice/{$twoinc_order_id}/pdf";
+            $params = ['lang' => WC_Twoinc_Helper::get_locale()];
+            if ($variant === 'original') {
+                $params['v'] = 'original';
+            }
+
+            $response = $this->make_request($endpoint, [], 'GET', $params, null, self::INVOICE_DOWNLOAD_TIMEOUT);
+
+            if ($this->is_pdf_response($response)) {
+                return $this->invoice_stream_result($response, $variant, $twoinc_order_id, $product_name);
+            }
+
+            if (is_wp_error($response)) {
+                return $this->invoice_unreachable_notice($product_name);
+            }
+
+            $code = (int) wp_remote_retrieve_response_code($response);
+            $body = json_decode(wp_remote_retrieve_body($response), true);
+            $error_code = (is_array($body) && isset($body['error_code']) && is_string($body['error_code'])) ? $body['error_code'] : '';
+
+            if ($code !== 400 || $error_code !== 'ORDER_NOT_FULFILLED') {
+                // Any error other than ORDER_NOT_FULFILLED keeps today's
+                // terminal-error behaviour.
+                return $this->invoice_error_notice($response, $product_name);
+            }
+
+            // Invoice not ready: ask the API what state the order is in.
+            $order_response = $this->make_request("/v1/order/{$twoinc_order_id}", [], 'GET', [], null, self::INVOICE_DOWNLOAD_TIMEOUT);
+            $state = '';
+            if (!is_wp_error($order_response) && (int) wp_remote_retrieve_response_code($order_response) === 200) {
+                $order_body = json_decode(wp_remote_retrieve_body($order_response), true);
+                if (is_array($order_body) && isset($order_body['state']) && is_string($order_body['state'])) {
+                    $state = $order_body['state'];
+                }
+            }
+            if ($state === '') {
+                return $this->invoice_unreachable_notice($product_name);
+            }
+
+            if ($state === 'FULFILLING') {
+                return [
+                    'action' => 'notice',
+                    'level' => 'info',
+                    'message' => sprintf(__('The %s invoice is not ready yet — the order is still being fulfilled. Please try again later.', 'twoinc-payment-gateway'), $product_name),
+                ];
+            }
+
+            if ($state === 'FULFILLED') {
+                // The order claims fulfilled, so the 400 was likely a race —
+                // retry once. No retry on other states (pointless).
+                $retry = $this->make_request($endpoint, [], 'GET', $params, null, self::INVOICE_DOWNLOAD_TIMEOUT);
+                if ($this->is_pdf_response($retry)) {
+                    return $this->invoice_stream_result($retry, $variant, $twoinc_order_id, $product_name);
+                }
+                if (is_wp_error($retry)) {
+                    return $this->invoice_unreachable_notice($product_name);
+                }
+                return $this->invoice_error_notice($retry, $product_name);
+            }
+
+            return [
+                'action' => 'notice',
+                'level' => 'info',
+                'message' => sprintf(__('No %1$s invoice is available because the order is in state: %2$s.', 'twoinc-payment-gateway'), $product_name, $state),
+            ];
+        }
+
+        /**
+         * A response is streamable only if it is a 200 that actually carries
+         * a PDF (content-type or %PDF- magic bytes) — never stream a JSON
+         * error body as a .pdf.
+         */
+        private function is_pdf_response($response)
+        {
+            if (is_wp_error($response) || (int) wp_remote_retrieve_response_code($response) !== 200) {
+                return false;
+            }
+            $content_type = wp_remote_retrieve_header($response, 'content-type');
+            if (is_string($content_type) && stripos($content_type, 'application/pdf') !== false) {
+                return true;
+            }
+            return strpos((string) wp_remote_retrieve_body($response), '%PDF-') === 0;
+        }
+
+        private function invoice_stream_result($response, $variant, $twoinc_order_id, $product_name)
+        {
+            $slug = strtolower(trim(preg_replace('/[^A-Za-z0-9]+/', '-', $product_name), '-'));
+            $kind = $variant === 'credit_note' ? 'credit-note' : 'invoice';
+            return [
+                'action' => 'stream',
+                'body' => wp_remote_retrieve_body($response),
+                'filename' => "{$slug}-{$kind}-{$twoinc_order_id}.pdf",
+            ];
+        }
+
+        private function invoice_unreachable_notice($product_name)
+        {
+            return [
+                'action' => 'notice',
+                'level' => 'error',
+                'message' => sprintf(__('Could not reach %s to retrieve the invoice. Please try again.', 'twoinc-payment-gateway'), $product_name),
+            ];
+        }
+
+        private function invoice_error_notice($response, $product_name)
+        {
+            $message = WC_Twoinc_Helper::get_twoinc_error_msg($response);
+            if (!$message) {
+                $message = sprintf(__('Could not retrieve the %s invoice.', 'twoinc-payment-gateway'), $product_name);
+            }
+            // get_twoinc_error_msg returns the generic "Response code from
+            // X: NNN" for any >= 400 response before it ever reaches its
+            // error_code branch, so surface the API's error_code alongside
+            // it where the body carries one.
+            $body = json_decode((string) wp_remote_retrieve_body($response), true);
+            if (is_array($body) && isset($body['error_code']) && is_string($body['error_code']) && $body['error_code'] !== '' && strpos($message, $body['error_code']) === false) {
+                $message .= ' (' . $body['error_code'] . ')';
+            }
+            return [
+                'action' => 'notice',
+                'level' => 'error',
+                'message' => $message,
+            ];
+        }
+
+        /**
+         * Admin-ajax handler for wp_ajax_twoinc_download_invoice — the
+         * invoice / credit-note buttons on the admin order edit screen.
+         *
+         * This is a browser navigation (link click), not an XHR POST like
+         * twoinc_ajax_verify_api_key / twoinc_ajax_term_fees, so — unlike
+         * those handlers' wp_verify_nonce($_POST['nonce']) pattern — the
+         * nonce travels as the _wpnonce query arg and is verified with
+         * check_admin_referer(). Registered in load_twoinc_classes().
+         */
+        public static function ajax_download_invoice()
+        {
+            check_admin_referer('twoinc_admin_nonce');
+
+            $order_id = isset($_GET['order_id']) ? absint($_GET['order_id']) : 0;
+            $variant = isset($_GET['variant']) ? sanitize_key(wp_unslash($_GET['variant'])) : '';
+
+            // Gate on the order-screen capability, NOT manage_options:
+            // WooCommerce shop managers (edit_shop_orders, no
+            // manage_options) can use the order edit screen and could
+            // follow the previous direct-API link, so they must not be
+            // locked out of the download.
+            if (!$order_id || !current_user_can('edit_shop_orders')) {
+                wp_die(__('You are not allowed to download this invoice.', 'twoinc-payment-gateway'), '', ['response' => 403]);
+            }
+
+            if (!in_array($variant, ['original', 'credit_note'], true)) {
+                wp_die(__('Invalid invoice variant.', 'twoinc-payment-gateway'), '', ['response' => 400]);
+            }
+
+            $order = wc_get_order($order_id);
+            if (!$order || !WC_Twoinc_Helper::is_twoinc_order($order)) {
+                wp_die(__('Order not found.', 'twoinc-payment-gateway'), '', ['response' => 404]);
+            }
+
+            $result = self::get_instance()->resolve_invoice_download($order, $variant);
+
+            if ($result['action'] === 'stream') {
+                nocache_headers();
+                header('Content-Type: application/pdf');
+                header('Content-Disposition: attachment; filename="' . $result['filename'] . '"');
+                header('Content-Length: ' . strlen($result['body']));
+                // Raw PDF bytes — must not be escaped or re-encoded.
+                echo $result['body']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                exit;
+            }
+
+            // Notice outcome: park the message in a short-TTL one-shot
+            // transient and bounce back to the order edit screen, where
+            // render_invoice_download_notice (admin_notices) pops it.
+            set_transient('twoinc_invoice_notice_' . get_current_user_id(), [
+                'level' => $result['level'],
+                'message' => $result['message'],
+            ], 60);
+
+            // get_edit_order_url() is HPOS-aware, unlike get_edit_post_link
+            // (which also HTML-encodes ampersands — wrong for a Location
+            // header); pair it with esc_url_raw, not esc_url, to keep the
+            // redirect URL raw.
+            wp_safe_redirect(esc_url_raw(wp_specialchars_decode($order->get_edit_order_url())));
+            exit;
+        }
+
+        /**
+         * Render (and clear) the one-shot invoice-download notice parked by
+         * ajax_download_invoice for the current user.
+         */
+        public function render_invoice_download_notice()
+        {
+            $key = 'twoinc_invoice_notice_' . get_current_user_id();
+            $notice = get_transient($key);
+            if (!is_array($notice) || !isset($notice['message'])) {
+                return;
+            }
+            delete_transient($key);
+            $class = (isset($notice['level']) && $notice['level'] === 'info') ? 'notice-info' : 'notice-error';
+            printf(
+                '<div class="notice %s is-dismissible"><p>%s</p></div>',
+                esc_attr($class),
+                esc_html($notice['message'])
+            );
         }
 
         /**

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -1254,7 +1254,10 @@ if (!class_exists('WC_Twoinc')) {
                             ],
                             admin_url('admin-ajax.php')
                         ),
-                        'twoinc_admin_nonce'
+                        // Scope the nonce to the exact order + variant this
+                        // link authorizes — not the shared twoinc_admin_nonce
+                        // action the unrelated XHR handlers use.
+                        "twoinc_download_invoice_{$order->get_id()}_{$variant}"
                     );
                 };
 
@@ -1412,10 +1415,14 @@ if (!class_exists('WC_Twoinc')) {
         {
             $slug = strtolower(trim(preg_replace('/[^A-Za-z0-9]+/', '-', $product_name), '-'));
             $kind = $variant === 'credit_note' ? 'credit-note' : 'invoice';
+            // The order id is order meta (normally a UUID, but never
+            // validated) and lands in a quoted Content-Disposition filename
+            // — strip anything that could break out of the quoting.
+            $safe_id = preg_replace('/[^A-Za-z0-9_-]/', '', (string) $twoinc_order_id);
             return [
                 'action' => 'stream',
                 'body' => wp_remote_retrieve_body($response),
-                'filename' => "{$slug}-{$kind}-{$twoinc_order_id}.pdf",
+                'filename' => "{$slug}-{$kind}-{$safe_id}.pdf",
             ];
         }
 
@@ -1461,32 +1468,42 @@ if (!class_exists('WC_Twoinc')) {
          */
         public static function ajax_download_invoice()
         {
-            check_admin_referer('twoinc_admin_nonce');
-
             $order_id = isset($_GET['order_id']) ? absint($_GET['order_id']) : 0;
             $variant = isset($_GET['variant']) ? sanitize_key(wp_unslash($_GET['variant'])) : '';
 
-            // Gate on the order-screen capability, NOT manage_options:
-            // WooCommerce shop managers (edit_shop_orders, no
-            // manage_options) can use the order edit screen and could
-            // follow the previous direct-API link, so they must not be
-            // locked out of the download.
-            if (!$order_id || !current_user_can('edit_shop_orders')) {
-                wp_die(__('You are not allowed to download this invoice.', 'twoinc-payment-gateway'), '', ['response' => 403]);
-            }
+            // The nonce action is scoped to the exact order + variant the
+            // link was minted for (add_invoice_credit_note_urls), so the
+            // request params must be read before the nonce can be checked.
+            check_admin_referer("twoinc_download_invoice_{$order_id}_{$variant}");
 
             if (!in_array($variant, ['original', 'credit_note'], true)) {
                 wp_die(__('Invalid invoice variant.', 'twoinc-payment-gateway'), '', ['response' => 400]);
             }
 
-            $order = wc_get_order($order_id);
+            $order = $order_id ? wc_get_order($order_id) : false;
             if (!$order || !WC_Twoinc_Helper::is_twoinc_order($order)) {
                 wp_die(__('Order not found.', 'twoinc-payment-gateway'), '', ['response' => 404]);
+            }
+
+            // Gate on the per-order meta capability (WC's idiom for
+            // per-order actions), NOT manage_options or the blanket
+            // edit_shop_orders type capability: shop managers must not be
+            // locked out, but plugins that scope order visibility per user
+            // (multi-vendor etc.) hook the meta-cap, so the check must name
+            // the specific order being downloaded.
+            if (!current_user_can('edit_shop_order', $order_id)) {
+                wp_die(__('You are not allowed to download this invoice.', 'twoinc-payment-gateway'), '', ['response' => 403]);
             }
 
             $result = self::get_instance()->resolve_invoice_download($order, $variant);
 
             if ($result['action'] === 'stream') {
+                // Discard anything already buffered (admin-ajax and
+                // third-party plugins are known to leave stray output or
+                // whitespace) — any preceding bytes corrupt the PDF.
+                while (ob_get_level()) {
+                    ob_end_clean();
+                }
                 nocache_headers();
                 header('Content-Type: application/pdf');
                 header('Content-Disposition: attachment; filename="' . $result['filename'] . '"');
@@ -1499,7 +1516,10 @@ if (!class_exists('WC_Twoinc')) {
             // Notice outcome: park the message in a short-TTL one-shot
             // transient and bounce back to the order edit screen, where
             // render_invoice_download_notice (admin_notices) pops it.
-            set_transient('twoinc_invoice_notice_' . get_current_user_id(), [
+            // Keyed by user AND order: two order tabs downloading close
+            // together must not overwrite each other's notice (and a notice
+            // for order A must never render on order B's screen).
+            set_transient('twoinc_invoice_notice_' . get_current_user_id() . '_' . $order_id, [
                 'level' => $result['level'],
                 'message' => $result['message'],
             ], 60);
@@ -1518,7 +1538,23 @@ if (!class_exists('WC_Twoinc')) {
          */
         public function render_invoice_download_notice()
         {
-            $key = 'twoinc_invoice_notice_' . get_current_user_id();
+            // admin_notices fires on every wp-admin page, but the transient
+            // is scoped to one order — only render it on that order's edit
+            // screen. Resolve the order id the way WooCommerce routes the
+            // two order-edit screens: HPOS is admin.php?page=wc-orders&id=N,
+            // legacy is post.php?post=N.
+            if (isset($_GET['page'], $_GET['id']) && sanitize_key(wp_unslash($_GET['page'])) === 'wc-orders') {
+                $order_id = absint($_GET['id']);
+            } elseif (isset($_GET['post'])) {
+                $order_id = absint($_GET['post']);
+            } else {
+                return;
+            }
+            if (!$order_id) {
+                return;
+            }
+
+            $key = 'twoinc_invoice_notice_' . get_current_user_id() . '_' . $order_id;
             $notice = get_transient($key);
             if (!is_array($notice) || !isset($notice['message'])) {
                 return;

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -434,6 +434,45 @@ function wp_remote_retrieve_header($response, $header)
     return '';
 }
 
+// ── Admin-ajax handler stubs (invoice download gate tests) ─────────
+
+function absint($maybeint)
+{
+    return abs((int) $maybeint);
+}
+
+function sanitize_key($key)
+{
+    return preg_replace('/[^a-z0-9_\-]/', '', strtolower((string) $key));
+}
+
+function wp_unslash($value)
+{
+    return is_string($value) ? stripslashes($value) : $value;
+}
+
+function check_admin_referer($action = -1, $query_arg = '_wpnonce')
+{
+    return 1;
+}
+
+// Capability set injected per test via $GLOBALS['__twoinc_test_caps'].
+function current_user_can($capability, ...$args)
+{
+    return in_array($capability, $GLOBALS['__twoinc_test_caps'] ?? [], true);
+}
+
+// wp_die must halt the handler: surface it as an exception the test catches.
+function wp_die($message = '', $title = '', $args = [])
+{
+    throw new RuntimeException(is_string($message) ? $message : 'wp_die');
+}
+
+function wc_get_order($order_id)
+{
+    return $GLOBALS['__twoinc_test_wc_orders'][$order_id] ?? false;
+}
+
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Brand.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Helper.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Payment_Terms.php';

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -377,6 +377,26 @@ class StubOrder
         return 42;
     }
 
+    // Settable per test: '' means "not a Two order" (is_twoinc_order false).
+    public $payment_method = '';
+
+    public function get_payment_method()
+    {
+        return $this->payment_method;
+    }
+
+    public $status = 'completed';
+
+    public function get_status()
+    {
+        return $this->status;
+    }
+
+    public function get_refunds()
+    {
+        return [];
+    }
+
     public function get_cancel_order_url()
     {
         return 'https://shop.example/cancel';
@@ -453,13 +473,83 @@ function wp_unslash($value)
 
 function check_admin_referer($action = -1, $query_arg = '_wpnonce')
 {
+    // Record the action so tests can assert the nonce is scoped to the
+    // resource it authorizes.
+    $GLOBALS['__twoinc_test_referer_actions'][] = $action;
     return 1;
 }
 
 // Capability set injected per test via $GLOBALS['__twoinc_test_caps'].
+// Meta-capability checks against a specific object (e.g.
+// current_user_can('edit_shop_order', $order_id)) resolve against
+// $GLOBALS['__twoinc_test_object_caps'] as "capability:object_id" strings,
+// so tests can distinguish the blanket type capability from the per-object
+// grant.
 function current_user_can($capability, ...$args)
 {
+    if ($args !== []) {
+        return in_array($capability . ':' . $args[0], $GLOBALS['__twoinc_test_object_caps'] ?? [], true);
+    }
     return in_array($capability, $GLOBALS['__twoinc_test_caps'] ?? [], true);
+}
+
+function get_current_user_id()
+{
+    return $GLOBALS['__twoinc_test_user_id'] ?? 1;
+}
+
+// ── Transients (invoice-download one-shot notice) ───────────────────
+
+function set_transient($key, $value, $expiration = 0)
+{
+    $GLOBALS['__twoinc_test_transients'][$key] = $value;
+    return true;
+}
+
+function get_transient($key)
+{
+    return $GLOBALS['__twoinc_test_transients'][$key] ?? false;
+}
+
+function delete_transient($key)
+{
+    unset($GLOBALS['__twoinc_test_transients'][$key]);
+    return true;
+}
+
+// wp_safe_redirect must halt the handler (it is followed by exit, which
+// would kill the test runner): surface it as an exception the test catches.
+function wp_safe_redirect($location, $status = 302)
+{
+    throw new RuntimeException('redirect:' . $location);
+}
+
+function esc_url_raw($url, $protocols = null)
+{
+    return $url;
+}
+
+function esc_url($url, $protocols = null)
+{
+    return $url;
+}
+
+function admin_url($path = '')
+{
+    return 'https://shop.example/wp-admin/' . ltrim($path, '/');
+}
+
+function add_query_arg($args, $url)
+{
+    return $url . (strpos($url, '?') === false ? '?' : '&') . http_build_query($args);
+}
+
+function wp_nonce_url($actionurl, $action = -1, $name = '_wpnonce')
+{
+    // Record the action so tests can assert mint-side scoping matches the
+    // verify-side check_admin_referer action.
+    $GLOBALS['__twoinc_test_nonce_url_actions'][] = $action;
+    return add_query_arg([$name => 'testnonce'], $actionurl);
 }
 
 // wp_die must halt the handler: surface it as an exception the test catches.

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -93,6 +93,16 @@ final class BrandConfigSpec
             'testEnvironmentHostFollowsModeAndBrandTemplate',
             'testCheckoutHostPrefersExplicitModeOverDevSniffing',
             'testCheckoutEnvOptionsPreserveStoredModeWithoutSettingsApi',
+            'testInvoiceDownloadStreamsPdf',
+            'testInvoiceDownloadFulfillingIsInfoNotice',
+            'testInvoiceDownloadFulfilledRetriesOnceThenStreams',
+            'testInvoiceDownloadFulfilledRetryFailureIsError',
+            'testInvoiceDownloadOtherStateNamesState',
+            'testInvoiceDownloadOtherErrorKeepsTodayBehaviour',
+            'testInvoiceDownloadMissingOrderIdIsError',
+            'testInvoiceDownload200NonPdfIsError',
+            'testInvoiceDownloadCreditNoteOmitsVOriginal',
+            'testInvoiceDownloadCapabilityGate',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -2013,6 +2023,218 @@ final class BrandConfigSpec
         // Garbage is NOT perpetuated as a selectable option.
         $GLOBALS['__twoinc_test_options'][$key] = ['checkout_env' => 'evil.example/'];
         TinyAssert::same(['PROD', 'SANDBOX'], array_keys($gateway->get_checkout_env_options()));
+    }
+
+    // ── Invoice download state check (TWO-25041) ────────────────────
+
+    /**
+     * Gateway fake for the invoice-download flow: make_request pops queued
+     * responses per endpoint prefix (so the retry can see a different
+     * response than the first fetch) and logs every call with its params
+     * and timeout.
+     */
+    private static function invoiceGateway(array $responses): WC_Twoinc
+    {
+        return new class ($responses) extends WC_Twoinc {
+            private $responses;
+            public $requests = [];
+
+            public function __construct($responses)
+            {
+                $this->responses = $responses;
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $empty_value ?? '';
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+            {
+                $this->requests[] = ['endpoint' => $endpoint, 'params' => $params, 'timeout' => $timeout];
+                foreach ($this->responses as $prefix => &$queue) {
+                    if (strpos($endpoint, $prefix) === 0) {
+                        return count($queue) > 1 ? array_shift($queue) : $queue[0];
+                    }
+                }
+                return new WP_Error();
+            }
+        };
+    }
+
+    private static function invoiceOrder(): StubOrder
+    {
+        $order = new StubOrder();
+        $order->meta[WC_Twoinc_Brand::prefixed_name('order_id')] = 'two-order-id';
+        return $order;
+    }
+
+    private static function pdfOk(): array
+    {
+        return ['response' => ['code' => 200], 'body' => '%PDF-1.4 test'];
+    }
+
+    private static function notFulfilled(): array
+    {
+        return ['response' => ['code' => 400], 'body' => json_encode(['error_code' => 'ORDER_NOT_FULFILLED'])];
+    }
+
+    private static function orderState(string $state): array
+    {
+        return ['response' => ['code' => 200], 'body' => json_encode(['state' => $state])];
+    }
+
+    private static function invoiceCallCount($gateway): int
+    {
+        return count(array_filter($gateway->requests, static function ($r) {
+            return strpos($r['endpoint'], '/v1/invoice/') === 0;
+        }));
+    }
+
+    private static function testInvoiceDownloadStreamsPdf(): void
+    {
+        $gateway = self::invoiceGateway(['/v1/invoice/' => [self::pdfOk()]]);
+        $result = $gateway->resolve_invoice_download(self::invoiceOrder(), 'original');
+        TinyAssert::same('stream', $result['action']);
+        TinyAssert::same('%PDF-1.4 test', $result['body']);
+        // Straight-through success: one invoice fetch, no order-state fetch.
+        TinyAssert::same(1, count($gateway->requests));
+        TinyAssert::same('original', $gateway->requests[0]['params']['v']);
+        // A blocking browser navigation chaining up to three serial calls:
+        // must run on a tighter timeout than make_request's default 30s.
+        TinyAssert::true($gateway->requests[0]['timeout'] < 30);
+    }
+
+    private static function testInvoiceDownloadFulfillingIsInfoNotice(): void
+    {
+        $gateway = self::invoiceGateway([
+            '/v1/invoice/' => [self::notFulfilled()],
+            '/v1/order/' => [self::orderState('FULFILLING')],
+        ]);
+        $result = $gateway->resolve_invoice_download(self::invoiceOrder(), 'original');
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('info', $result['level']);
+        TinyAssert::true(strpos($result['message'], 'not ready yet') !== false);
+        // No pointless retry while the order is still FULFILLING.
+        TinyAssert::same(1, self::invoiceCallCount($gateway));
+    }
+
+    private static function testInvoiceDownloadFulfilledRetriesOnceThenStreams(): void
+    {
+        $gateway = self::invoiceGateway([
+            '/v1/invoice/' => [self::notFulfilled(), self::pdfOk()],
+            '/v1/order/' => [self::orderState('FULFILLED')],
+        ]);
+        $result = $gateway->resolve_invoice_download(self::invoiceOrder(), 'original');
+        TinyAssert::same('stream', $result['action']);
+        TinyAssert::same(2, self::invoiceCallCount($gateway));
+    }
+
+    private static function testInvoiceDownloadFulfilledRetryFailureIsError(): void
+    {
+        $gateway = self::invoiceGateway([
+            '/v1/invoice/' => [self::notFulfilled(), self::notFulfilled()],
+            '/v1/order/' => [self::orderState('FULFILLED')],
+        ]);
+        $result = $gateway->resolve_invoice_download(self::invoiceOrder(), 'original');
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('error', $result['level']);
+        // The terminal message surfaces the API error_code, not only the
+        // bare HTTP code (get_twoinc_error_msg's generic 400 string).
+        TinyAssert::true(strpos($result['message'], 'ORDER_NOT_FULFILLED') !== false);
+        // Retried exactly once.
+        TinyAssert::same(2, self::invoiceCallCount($gateway));
+    }
+
+    private static function testInvoiceDownloadOtherStateNamesState(): void
+    {
+        $gateway = self::invoiceGateway([
+            '/v1/invoice/' => [self::notFulfilled()],
+            '/v1/order/' => [self::orderState('CANCELLED')],
+        ]);
+        $result = $gateway->resolve_invoice_download(self::invoiceOrder(), 'original');
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('info', $result['level']);
+        TinyAssert::true(strpos($result['message'], 'CANCELLED') !== false);
+        TinyAssert::same(1, self::invoiceCallCount($gateway));
+    }
+
+    private static function testInvoiceDownloadOtherErrorKeepsTodayBehaviour(): void
+    {
+        $gateway = self::invoiceGateway([
+            '/v1/invoice/' => [['response' => ['code' => 403], 'body' => json_encode(['error_code' => 'FORBIDDEN'])]],
+        ]);
+        $result = $gateway->resolve_invoice_download(self::invoiceOrder(), 'original');
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('error', $result['level']);
+        TinyAssert::true(strpos($result['message'], 'FORBIDDEN') !== false);
+        // Errors other than ORDER_NOT_FULFILLED never trigger the
+        // order-state fetch: today's terminal path, unchanged.
+        TinyAssert::same(1, count($gateway->requests));
+    }
+
+    private static function testInvoiceDownloadMissingOrderIdIsError(): void
+    {
+        $gateway = self::invoiceGateway([]);
+        $result = $gateway->resolve_invoice_download(new StubOrder(), 'original');
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('error', $result['level']);
+        // Never call the API with an empty order id.
+        TinyAssert::same(0, count($gateway->requests));
+    }
+
+    private static function testInvoiceDownload200NonPdfIsError(): void
+    {
+        $gateway = self::invoiceGateway([
+            '/v1/invoice/' => [['response' => ['code' => 200], 'body' => json_encode(['unexpected' => 'json'])]],
+        ]);
+        $result = $gateway->resolve_invoice_download(self::invoiceOrder(), 'original');
+        // A 200 that is not a PDF must not be streamed as a .pdf.
+        TinyAssert::same('notice', $result['action']);
+        TinyAssert::same('error', $result['level']);
+    }
+
+    private static function testInvoiceDownloadCreditNoteOmitsVOriginal(): void
+    {
+        $gateway = self::invoiceGateway(['/v1/invoice/' => [self::pdfOk()]]);
+        $result = $gateway->resolve_invoice_download(self::invoiceOrder(), 'credit_note');
+        TinyAssert::same('stream', $result['action']);
+        TinyAssert::same(false, array_key_exists('v', $gateway->requests[0]['params']));
+        TinyAssert::true(strpos($result['filename'], 'credit-note') !== false);
+    }
+
+    private static function testInvoiceDownloadCapabilityGate(): void
+    {
+        $_GET['_wpnonce'] = 'test';
+        $_GET['order_id'] = '42';
+        $_GET['variant'] = 'original';
+
+        // Without the order-screen capability the handler dies (403).
+        $GLOBALS['__twoinc_test_caps'] = [];
+        $message = '';
+        try {
+            WC_Twoinc::ajax_download_invoice();
+        } catch (RuntimeException $e) {
+            $message = $e->getMessage();
+        }
+        TinyAssert::true(strpos($message, 'not allowed') !== false, 'expected capability wp_die without edit_shop_orders');
+
+        // With edit_shop_orders (shop manager — no manage_options needed)
+        // the gate passes; execution proceeds to the order lookup, which
+        // fails differently here (no order registered).
+        $GLOBALS['__twoinc_test_caps'] = ['edit_shop_orders'];
+        $GLOBALS['__twoinc_test_wc_orders'] = [];
+        $message = '';
+        try {
+            WC_Twoinc::ajax_download_invoice();
+        } catch (RuntimeException $e) {
+            $message = $e->getMessage();
+        }
+        TinyAssert::true(strpos($message, 'not allowed') === false, 'edit_shop_orders must pass the capability gate');
+        TinyAssert::true(strpos($message, 'Order not found') !== false);
+
+        unset($_GET['_wpnonce'], $_GET['order_id'], $_GET['variant']);
+        unset($GLOBALS['__twoinc_test_caps'], $GLOBALS['__twoinc_test_wc_orders']);
     }
 }
 

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -103,6 +103,9 @@ final class BrandConfigSpec
             'testInvoiceDownload200NonPdfIsError',
             'testInvoiceDownloadCreditNoteOmitsVOriginal',
             'testInvoiceDownloadCapabilityGate',
+            'testInvoiceDownloadNonceScopedToOrderAndVariant',
+            'testInvoiceDownloadNoticeIsolatedPerOrder',
+            'testInvoiceStreamFilenameSanitizesOrderId',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -2203,38 +2206,155 @@ final class BrandConfigSpec
         TinyAssert::true(strpos($result['filename'], 'credit-note') !== false);
     }
 
+    /**
+     * A StubOrder that is a Two order (payment method matches the brand
+     * gateway id) with a Two order-id meta, registered as wc_get_order(42).
+     */
+    private static function registerTwoOrder(): StubOrder
+    {
+        $order = self::invoiceOrder();
+        $order->payment_method = WC_Twoinc_Brand::get('gateway_id');
+        $GLOBALS['__twoinc_test_wc_orders'] = [42 => $order];
+        return $order;
+    }
+
+    private static function runDownloadHandler(): string
+    {
+        try {
+            WC_Twoinc::ajax_download_invoice();
+        } catch (RuntimeException $e) {
+            return $e->getMessage();
+        }
+        return '';
+    }
+
+    private static function withGatewayInstance(WC_Twoinc $gateway, callable $fn)
+    {
+        $prop = new ReflectionProperty(WC_Twoinc::class, 'instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null, $gateway);
+        try {
+            return $fn();
+        } finally {
+            $prop->setValue(null, null);
+        }
+    }
+
     private static function testInvoiceDownloadCapabilityGate(): void
     {
         $_GET['_wpnonce'] = 'test';
         $_GET['order_id'] = '42';
         $_GET['variant'] = 'original';
 
-        // Without the order-screen capability the handler dies (403).
+        // The order lookup runs before the capability gate: an unknown
+        // order 404s regardless of capabilities.
         $GLOBALS['__twoinc_test_caps'] = [];
-        $message = '';
-        try {
-            WC_Twoinc::ajax_download_invoice();
-        } catch (RuntimeException $e) {
-            $message = $e->getMessage();
-        }
-        TinyAssert::true(strpos($message, 'not allowed') !== false, 'expected capability wp_die without edit_shop_orders');
-
-        // With edit_shop_orders (shop manager — no manage_options needed)
-        // the gate passes; execution proceeds to the order lookup, which
-        // fails differently here (no order registered).
-        $GLOBALS['__twoinc_test_caps'] = ['edit_shop_orders'];
+        $GLOBALS['__twoinc_test_object_caps'] = [];
         $GLOBALS['__twoinc_test_wc_orders'] = [];
-        $message = '';
-        try {
-            WC_Twoinc::ajax_download_invoice();
-        } catch (RuntimeException $e) {
-            $message = $e->getMessage();
-        }
-        TinyAssert::true(strpos($message, 'not allowed') === false, 'edit_shop_orders must pass the capability gate');
-        TinyAssert::true(strpos($message, 'Order not found') !== false);
+        TinyAssert::true(strpos(self::runDownloadHandler(), 'Order not found') !== false);
+
+        // The gate is the per-order meta capability: holding the blanket
+        // edit_shop_orders type capability but NOT edit_shop_order on this
+        // specific order (multi-vendor / restricted-visibility plugins hook
+        // the meta-cap) must be denied.
+        self::registerTwoOrder();
+        $GLOBALS['__twoinc_test_caps'] = ['edit_shop_orders'];
+        $GLOBALS['__twoinc_test_object_caps'] = ['edit_shop_order:41'];
+        $message = self::runDownloadHandler();
+        TinyAssert::true(strpos($message, 'not allowed') !== false, 'expected wp_die without per-order edit_shop_order');
+
+        // With the per-order grant the gate passes: the handler proceeds to
+        // the API call (WP_Error here → error notice) and redirects back to
+        // the order edit screen with the notice parked in a transient.
+        $GLOBALS['__twoinc_test_object_caps'] = ['edit_shop_order:42'];
+        $GLOBALS['__twoinc_test_transients'] = [];
+        $message = self::withGatewayInstance(self::invoiceGateway([]), function () {
+            return self::runDownloadHandler();
+        });
+        TinyAssert::true(strpos($message, 'redirect:') === 0, 'per-order grant must pass the gate and redirect');
+        TinyAssert::true(isset($GLOBALS['__twoinc_test_transients']['twoinc_invoice_notice_1_42']), 'notice transient must be keyed by user AND order');
 
         unset($_GET['_wpnonce'], $_GET['order_id'], $_GET['variant']);
-        unset($GLOBALS['__twoinc_test_caps'], $GLOBALS['__twoinc_test_wc_orders']);
+        unset($GLOBALS['__twoinc_test_caps'], $GLOBALS['__twoinc_test_object_caps'], $GLOBALS['__twoinc_test_wc_orders'], $GLOBALS['__twoinc_test_transients']);
+    }
+
+    private static function testInvoiceDownloadNonceScopedToOrderAndVariant(): void
+    {
+        // Mint side: the order-screen download button.
+        $order = self::registerTwoOrder();
+        $GLOBALS['__twoinc_test_nonce_url_actions'] = [];
+        ob_start();
+        self::invoiceGateway([])->add_invoice_credit_note_urls($order);
+        ob_end_clean();
+        TinyAssert::same(['twoinc_download_invoice_42_original'], $GLOBALS['__twoinc_test_nonce_url_actions']);
+
+        // Verify side: the ajax handler checks the SAME order+variant-scoped
+        // action — not the shared twoinc_admin_nonce the XHR handlers use.
+        $_GET['_wpnonce'] = 'test';
+        $_GET['order_id'] = '42';
+        $_GET['variant'] = 'original';
+        $GLOBALS['__twoinc_test_caps'] = [];
+        $GLOBALS['__twoinc_test_object_caps'] = [];
+        $GLOBALS['__twoinc_test_referer_actions'] = [];
+        self::runDownloadHandler();
+        TinyAssert::same(['twoinc_download_invoice_42_original'], $GLOBALS['__twoinc_test_referer_actions']);
+
+        unset($_GET['_wpnonce'], $_GET['order_id'], $_GET['variant']);
+        unset($GLOBALS['__twoinc_test_caps'], $GLOBALS['__twoinc_test_object_caps'], $GLOBALS['__twoinc_test_wc_orders']);
+        unset($GLOBALS['__twoinc_test_nonce_url_actions'], $GLOBALS['__twoinc_test_referer_actions']);
+    }
+
+    private static function testInvoiceDownloadNoticeIsolatedPerOrder(): void
+    {
+        $gateway = self::invoiceGateway([]);
+        $GLOBALS['__twoinc_test_transients'] = [
+            'twoinc_invoice_notice_1_42' => ['level' => 'info', 'message' => 'notice for order 42'],
+            'twoinc_invoice_notice_1_43' => ['level' => 'error', 'message' => 'notice for order 43'],
+        ];
+
+        $render = static function () use ($gateway) {
+            ob_start();
+            $gateway->render_invoice_download_notice();
+            return ob_get_clean();
+        };
+
+        // No resolvable order id on the current screen: render nothing,
+        // consume nothing (no leaking onto unrelated wp-admin pages).
+        TinyAssert::same('', $render());
+        TinyAssert::same(2, count($GLOBALS['__twoinc_test_transients']));
+
+        // HPOS order edit screen for order 42: only order 42's notice
+        // renders and only its transient is consumed.
+        $_GET['page'] = 'wc-orders';
+        $_GET['id'] = '42';
+        $out = $render();
+        TinyAssert::true(strpos($out, 'notice for order 42') !== false);
+        TinyAssert::true(strpos($out, 'notice for order 43') === false, 'order B notice must not leak to order A screen');
+        TinyAssert::true(!isset($GLOBALS['__twoinc_test_transients']['twoinc_invoice_notice_1_42']));
+        TinyAssert::true(isset($GLOBALS['__twoinc_test_transients']['twoinc_invoice_notice_1_43']));
+        unset($_GET['page'], $_GET['id']);
+
+        // Legacy (post.php?post=N) order edit screen for order 43.
+        $_GET['post'] = '43';
+        $out = $render();
+        TinyAssert::true(strpos($out, 'notice for order 43') !== false);
+        TinyAssert::same(0, count($GLOBALS['__twoinc_test_transients']));
+        unset($_GET['post']);
+
+        unset($GLOBALS['__twoinc_test_transients']);
+    }
+
+    private static function testInvoiceStreamFilenameSanitizesOrderId(): void
+    {
+        $gateway = self::invoiceGateway(['/v1/invoice/' => [self::pdfOk()]]);
+        $order = new StubOrder();
+        $order->meta[WC_Twoinc_Brand::prefixed_name('order_id')] = 'ab"c;d e/f.pdf';
+        $result = $gateway->resolve_invoice_download($order, 'original');
+        TinyAssert::same('stream', $result['action']);
+        // Raw meta lands in a quoted Content-Disposition filename: anything
+        // outside [A-Za-z0-9_-] must be stripped.
+        TinyAssert::true(strpos($result['filename'], 'abcdefpdf.pdf') !== false);
+        TinyAssert::same(false, strpbrk($result['filename'], '";/ ') !== false, 'filename must not carry quote/semicolon/slash/space');
     }
 }
 

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -103,6 +103,13 @@ function load_twoinc_classes()
     add_action('wc_ajax_two_sole_trader_availability', ['WC_Twoinc_Sole_Trader', 'ajax_availability']);
     add_action('wc_ajax_two_sole_trader_tokens', ['WC_Twoinc_Sole_Trader', 'ajax_tokens']);
 
+    // Admin invoice / credit-note PDF download from the order edit screen:
+    // streams the PDF, or redirects back with a notice after the
+    // ORDER_NOT_FULFILLED state check (TWO-25041). A static handler
+    // registered here at plugins_loaded like the wc-ajax endpoints above,
+    // since an admin-ajax request does not construct the payment gateway.
+    add_action('wp_ajax_twoinc_download_invoice', ['WC_Twoinc', 'ajax_download_invoice']);
+
     // Confirm order after returning from twoinc checkout-page, DO NOT CHANGE HOOKS
     add_action('template_redirect', 'WC_Twoinc::process_confirmation_header_redirect');
     // add_action('template_redirect', 'WC_Twoinc::before_process_confirmation');


### PR DESCRIPTION
Implements [TWO-25041](https://linear.app/two-inc/issue/TWO-25041) (WooCommerce child of [TWO-25040](https://linear.app/two-inc/issue/TWO-25040)).

## Problem

The admin order page linked the invoice / credit-note buttons straight at the API PDF endpoint. When the order is still `FULFILLING`, the API answers `400 {"error_code": "ORDER_NOT_FULFILLED"}` and the merchant gets raw JSON in the browser — reads as a failure when it just means "not ready yet".

## Change

Route both buttons through a new plugin-owned admin-ajax handler (`wp_ajax_twoinc_download_invoice`) that fetches the PDF server-side via the existing `make_request` plumbing and implements the parent spec's state check:

- **Invoice fetch OK** → stream the PDF (content-type / `%PDF-` magic validated — never streams a JSON error body as a `.pdf`).
- **400 `ORDER_NOT_FULFILLED`** → `GET /v1/order/{id}` and branch on `state`:
  - `FULFILLING` → **info** notice: invoice not ready yet, try again later.
  - `FULFILLED` → retry the invoice fetch once; if it fails again, error notice as today.
  - any other state → **info** notice naming the state.
- **Any other error** → today's terminal-error behaviour, enriched with the API `error_code` where the response body carries one (`get_twoinc_error_msg` alone yields only the generic "code: 400" string for 4xx).

Non-stream outcomes park a one-shot transient notice and redirect back to the order edit screen (`$order->get_edit_order_url()` — HPOS-aware, unlike `get_edit_post_link` — passed through `esc_url_raw`), where an `admin_notices` hook renders it.

### Security / correctness details

- Capability gate is `edit_shop_orders` (the order-screen capability), **not** `manage_options` — shop managers can use this button today and must not be locked out.
- Nonce via `check_admin_referer('twoinc_admin_nonce')` on the `_wpnonce` query arg. Note: this is a deliberate departure from the existing handlers' `wp_verify_nonce($_POST['nonce'])` pattern, because this endpoint is a link-click navigation, not an XHR POST — called out in code comments.
- Two order id resolved server-side from order meta (legacy `tillit_order_id` fallback preserved); `variant` whitelisted to `original` | `credit_note`; `is_twoinc_order` re-asserted in the handler.
- The flow can chain up to three serial API calls on a blocking navigation, so these calls use a 10s timeout (scoped to this call site via `make_request`'s existing `$timeout` parameter; the 30s default is untouched for other call sites).

## Testing

`php tests/unit/run.php` — 77/77 pass (67 existing + 10 new specs): stream-through, FULFILLING info, FULFILLED retry-then-stream, FULFILLED retry-fail error (with `error_code` surfaced), other-state naming, non-ORDER_NOT_FULFILLED passthrough (no order-state fetch), missing order ref, 200-non-PDF guard, credit-note variant param, and the capability gate (deny without `edit_shop_orders`, pass with it).

---
*Implemented by Claude on Doug's behalf. Design + design review on the Linear ticket.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn