### PR TITLE
TWO-25046/fix: drop hardcoded 'Fee - ' prefix from API fee line-item name

### DIFF
--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -337,7 +337,11 @@ if (!class_exists('WC_Twoinc_Helper')) {
                 }
                 $tax_rate = WC_Twoinc_Helper::get_item_tax_rate($fee, $order);
                 $fee_line = [
-                    'name' => 'Fee - ' . $fee->get_name(),
+                    // The fee name is already the resolved, translated,
+                    // brand-correct label (get_fee_label()); no hardcoded
+                    // prefix — Magento's ComposeOrder never prefixes either,
+                    // and 'type' => 'SERVICE' carries the semantic.
+                    'name' => $fee->get_name(),
                     'description' => '',
                     'gross_amount' => strval(WC_Twoinc_Helper::round_amt($fee->get_total() + $fee->get_total_tax())),
                     'net_amount' => strval(WC_Twoinc_Helper::round_amt($fee->get_total())),

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -35,6 +35,7 @@ final class BrandConfigSpec
             'testConfirmationUrlHookReceivesUrlAndOrderId',
             'testOrderPayloadHookAugmentsBody',
             'testPaymentTermsLineHookAdjustsLineItems',
+            'testFeeLineItemNameUsesResolvedLabelWithoutPrefix',
             'testEditOrderAppliesSameBrandHooks',
             'testShippingDetailsOmitTrackingWithoutMeta',
             'testShippingDetailsFromShipmentTrackingMeta',
@@ -301,6 +302,45 @@ final class BrandConfigSpec
 
         TinyAssert::same(1, count($body['line_items']));
         TinyAssert::same('Surcharge for NOK', $body['line_items'][0]['name']);
+    }
+
+    private static function testFeeLineItemNameUsesResolvedLabelWithoutPrefix(): void
+    {
+        // TWO-25046: the API line-item name for a cart fee must be the
+        // fee's own (already resolved, translated, brand-correct) name —
+        // no hardcoded 'Fee - ' prefix. Magento's ComposeOrder is the
+        // reference: it never prefixes the surcharge description.
+        $fee = new class {
+            public function get_name()
+            {
+                return 'Servicekosten';
+            }
+
+            public function get_total()
+            {
+                return 10.0;
+            }
+
+            public function get_total_tax()
+            {
+                return 2.5;
+            }
+
+            public function get_taxes()
+            {
+                return ['total' => []];
+            }
+        };
+
+        $items = WC_Twoinc_Helper::get_line_items([], [], [$fee], new StubOrder());
+
+        TinyAssert::same(1, count($items));
+        TinyAssert::same('Servicekosten', $items[0]['name']);
+        TinyAssert::same('SERVICE', $items[0]['type']);
+        TinyAssert::true(
+            strpos($items[0]['name'], 'Fee - ') === false,
+            'Fee line-item name must not carry a hardcoded prefix'
+        );
     }
 
     private static function testEditOrderAppliesSameBrandHooks(): void


### PR DESCRIPTION
Base-plugin half of [TWO-25046](https://linear.app/two-inc/issue/TWO-25046) (companion to two-inc/woocommerce-abn-plugin#19), per the design + review posted on the ticket.

## The bug

`WC_Twoinc_Helper::get_line_items()` built every cart fee's API line-item name as `'Fee - ' . $fee->get_name()` — an untranslated, hardcoded English literal prepended unconditionally. The fee name is already the resolved, translated, brand-correct label from `WC_Twoinc_Payment_Terms::get_fee_label()` (merchant `surcharge_line_description` → brand `fee_line_label` → `__('Service charge')`), so on Dutch ABN shops the surcharge line rendered as **"Fee - Servicekosten"** — one English word glued to a translated string, impossible to localise or suppress per brand.

## The fix

Use `$fee->get_name()` as-is. Magento — the branding reference — never prefixes its surcharge description (`ComposeOrder` sends the raw description; `Block/Sales/Total/Surcharge` falls back to `__('Two Surcharge')`), and `'type' => 'SERVICE'` already carries the semantic for the API consumer. Brand-agnostic: every brand benefits.

## Servicekosten provenance (review CONCERN, resolved)

The review flagged that no `Service charge` → `Servicekosten` mapping existed in the repo. It does now: TWO-25035 (commit 4ab8734, merged to staging earlier today) added it to `twoinc-payment-gateway-nl_NL.po` and recompiled the `.mo` — the design/review grepped a pre-25035 checkout. Verified present in both `.po` (line 873) and compiled `.mo` on this branch, so **no i18n change is needed here**; the observed "Servicekosten" is the bundled translation of the base default, and the only bug was the prefix.

## Tests

New `testFeeLineItemNameUsesResolvedLabelWithoutPrefix` asserts the fee line-item name is exactly the fee's own name (`SERVICE` type, no `'Fee - '` prefix). `php tests/unit/run.php`: **81/81 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn