### PR TITLE
TWO-25049/fix: overlay-agnostic plugin-list whitelabel + notice/subtitle seams

### DIFF
--- a/brands/two.php
+++ b/brands/two.php
@@ -63,4 +63,9 @@ return [
     // obtaining production keys. WC_Twoinc::init_form_fields is the only
     // reader. A brand overlay substitutes its own support address.
     'production_key_contact_email' => 'integration@two.inc',
+    // Buyer-facing notice shown once order intent is approved, pending
+    // final checks. sprintf'd with the brand product_name (one %s). ''
+    // renders nothing. WC_Twoinc::get_pay_box_description is the only
+    // reader.
+    'intent_approved_notice' => 'Your invoice purchase with %s is likely to be accepted subject to additional checks.',
 ];

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -456,6 +456,20 @@ if (!class_exists('WC_Twoinc')) {
         }
 
         /**
+         * Buyer-facing notice shown once order intent is approved, pending
+         * final checks. A brand overlay may set 'intent_approved_notice'
+         * to '' to suppress it entirely.
+         */
+        private function get_intent_approved_notice(): string
+        {
+            $template = WC_Twoinc_Brand::get('intent_approved_notice');
+            if ($template === '') {
+                return '';
+            }
+            return sprintf(__($template, 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name'));
+        }
+
+        /**
          * Get payment box description
          */
         private function get_pay_box_description()
@@ -492,7 +506,7 @@ if (!class_exists('WC_Twoinc')) {
                 </div>',
                 sprintf(__('%s lets your business pay later for the goods you purchase online.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')),
                 $term_input,
-                sprintf(__('Your invoice purchase with %s is likely to be accepted subject to additional checks.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')),
+                $this->get_intent_approved_notice(),
                 sprintf(__('Invoice purchase with %s is not available for this order.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')),
                 __('Phone number is invalid.', 'twoinc-payment-gateway')
             );
@@ -910,10 +924,12 @@ if (!class_exists('WC_Twoinc')) {
         public function get_pay_subtitle()
         {
             $subtitle = WC_Twoinc_Brand::get('checkout_subtitle');
+            // wp_kses_post, not esc_html: a brand's subtitle may carry an
+            // inline link (e.g. ABN's "lees meer") — esc_html stripped it.
             $subtitle_html = $subtitle
                 ? sprintf(
                     '<div class="twoinc-payment-subtitle">%s</div>',
-                    esc_html(__($subtitle, 'twoinc-payment-gateway'))
+                    wp_kses_post(__($subtitle, 'twoinc-payment-gateway'))
                 )
                 : '';
 

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -479,7 +479,7 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
                 return $days !== null ? str_replace('%s', (string) $days, $template) : $template;
             }
             $label = WC_Twoinc_Brand::get('fee_line_label');
-            return $label ?: __('Service charge', 'twoinc-payment-gateway');
+            return $label ? __($label, 'twoinc-payment-gateway') : __('Service charge', 'twoinc-payment-gateway');
         }
 
         /**

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -36,6 +36,7 @@ add_action('plugins_loaded', 'load_twoinc_classes');
 
 if (is_admin() && !defined('DOING_AJAX')) {
     add_filter("plugin_action_links_" . plugin_basename(__FILE__), 'twoinc_settings_link');
+    add_filter('all_plugins', 'twoinc_rebrand_plugin_row');
 }
 
 if (!is_admin() && !defined('DOING_AJAX')) {
@@ -146,9 +147,36 @@ function wc_twoinc_enqueue_scripts()
  */
 function twoinc_settings_link($links)
 {
+    // A brand overlay re-skins this same gateway under its own row — the
+    // base plugin's own row is just the required library, so it carries
+    // no independent Settings link when an overlay is active.
+    if (apply_filters('twoinc_brand_file', null) !== null) {
+        return $links;
+    }
     $settings_link = '<a href="admin.php?page=wc-settings&tab=checkout&section=' . WC_Twoinc_Brand::get('gateway_id') . '">Settings</a>';
     array_unshift($links, $settings_link);
     return $links;
+}
+
+/**
+ * Rebrand the base plugin's own Plugins-list row when a brand overlay is
+ * active, using the overlay's own provider name — overlay-agnostic, so
+ * every overlay gets this via the twoinc_brand_file seam they already
+ * implement, with no per-overlay duplication. Standalone installs (no
+ * overlay) keep the base plugin's own caption untouched.
+ */
+function twoinc_rebrand_plugin_row($plugins)
+{
+    if (apply_filters('twoinc_brand_file', null) === null) {
+        return $plugins;
+    }
+    $base = plugin_basename(__FILE__);
+    if (isset($plugins[$base])) {
+        $provider = WC_Twoinc_Brand::get('provider');
+        $plugins[$base]['Name'] = $provider . ' Payment Gateway Provider';
+        $plugins[$base]['Description'] = 'Common libraries for the ' . $provider . ' payment gateway';
+    }
+    return $plugins;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Plugins-list row for this base plugin now rebrands itself (Name/Description) and drops its Settings link when a brand overlay is active — gated on the existing `twoinc_brand_file` seam, so every current/future overlay gets this for free with no per-overlay duplication. Standalone (no overlay) installs are untouched.
- Fixed `get_pay_subtitle()`: `esc_html()` was silently stripping any inline link a brand's `checkout_subtitle` carried. Switched to `wp_kses_post()`.
- New `intent_approved_notice` brand-config key so an overlay can suppress the order-intent-approved pending-checks notice (default preserves current English string/behavior for the base "Two" brand).
- `get_fee_label()` now wraps a brand-declared `fee_line_label` in `__()` for i18n-catalog consistency with the generic fallback.

## Test plan
- [x] `make test-unit` — all pass, no regressions
- [x] `php -l` on all touched files
- [ ] Manual staging check: ABN plugin-list row shows rebranded caption + no Settings link once the companion ABN PR lands

By Claude.