### PR TITLE
TWO-25049/fix: suppress the about-link when a brand declares no about_url

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -603,8 +603,11 @@ if (!class_exists('WC_Twoinc')) {
          */
         private function get_abt_twoinc_html()
         {
-            if ($this->get_option('show_abt_link') === 'yes') {
-                $abt_url = WC_Twoinc_Brand::get('about_url');
+            $abt_url = WC_Twoinc_Brand::get('about_url');
+            // A brand with no about page ('' — e.g. ABN, whose subtitle
+            // already carries its own "lees meer" link) renders nothing
+            // here, regardless of the merchant's show_abt_link setting.
+            if ($this->get_option('show_abt_link') === 'yes' && $abt_url !== '') {
                 $product_name = WC_Twoinc_Brand::get('product_name');
                 $link = '<a href="' . esc_url($abt_url) . '" target="_blank">' . sprintf(__('What is %s?', 'twoinc-payment-gateway'), $product_name) . '</a>';
                 $text = sprintf(


### PR DESCRIPTION
## Summary
ABN's Two-branded "What is X?" about-link was still rendering (with an empty `href`) even though ABN already sets `about_url` to `''` — `show_abt_link` (merchant preference) was the only gate, brand intent wasn't checked. Now the link only renders when both the merchant enables it AND the active brand actually has an about page. ABN's own subtitle already carries a "lees meer" link, so this removes the redundant/broken second link for that brand.

## Test plan
- [x] `make test-unit` — all pass
- [x] `php -l`

By Claude.