### PR TITLE
TWO-25049/fix: rebranded plugin row sorts below the brand's own row

### DIFF
--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -197,7 +197,9 @@ function twoinc_rebrand_plugin_row($plugins)
     $base = plugin_basename(__FILE__);
     if (isset($plugins[$base])) {
         $provider = WC_Twoinc_Brand::get('provider');
-        $plugins[$base]['Name'] = $provider . ' Payment Gateway Provider';
+        // "Utility library for..." — sorts well below the brand's own row
+        // in the (alphabetical) Plugins list, never above it.
+        $plugins[$base]['Name'] = 'Utility library for the ' . $provider;
         $plugins[$base]['Description'] = 'Common libraries for the ' . $provider . ' payment gateway';
     }
     return $plugins;


### PR DESCRIPTION
## Summary
The base plugin's rebranded Plugins-list row read "<brand> Payment Gateway Provider" — alphabetically that can sort ahead of or right next to the brand overlay's own row. Renamed to "Utility library for the <brand>" so it sorts near the bottom of the (alphabetical) Plugins list, unambiguously below the brand's own entry.

## Test plan
- [x] `make test-unit` — all pass
- [x] `php -l`

By Claude.