### PR TITLE
TWO-25050/fix: surcharge fee not toggling on payment-method switch

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -2036,6 +2036,23 @@ let instance = null;
 let isTwoincSelected = null;
 jQuery(function () {
   if (window.twoinc) {
+    // WooCommerce core's own radio-click handler for payment method
+    // selection (checkout.js payment_method_selected) calls
+    // e.stopPropagation() and only fires a bare `payment_method_selected`
+    // event on document.body — it never triggers `update_checkout`. This
+    // gateway's buyer surcharge fee (apply_cart_fee) is conditional on
+    // which payment method is currently chosen, so without an explicit
+    // recalculation trigger here the fee neither appears when switching
+    // TO this gateway nor disappears when switching AWAY from it, until
+    // something unrelated (e.g. a term-chip click) happens to fire
+    // update_checkout first. Bound once at page load; WC fires
+    // payment_method_selected only when the checked radio actually
+    // changes, so this does not cause extra recalculations on unrelated
+    // re-renders.
+    jQuery(document.body).on("payment_method_selected", function () {
+      jQuery(document.body).trigger("update_checkout");
+    });
+
     if (window.twoinc.enable_order_intent === "yes") {
       const initIfGatewayPresent = function () {
         if (jQuery("#payment_method_" + window.twoinc.gateway_id).length > 0) {


### PR DESCRIPTION
## Summary
- Root cause: WooCommerce core's `payment_method_selected` click handler (checkout.js) calls `e.stopPropagation()` and only fires a bare `payment_method_selected` event on `document.body` — it never triggers `update_checkout`. Nothing in this plugin's JS filled that gap either; the **only** place that fires `update_checkout` is a term-chip click (`twoincTermChips.select`).
- Since the buyer surcharge fee (`apply_cart_fee`, hooked on `woocommerce_cart_calculate_fees`) is gated purely on the currently-selected payment method, and WC rebuilds cart fees from scratch on every `calculate_totals()` call, the fee only ever (re)computes when `update_checkout` fires. With no trigger on plain payment-method selection, selecting Two/ABN doesn't show the fee until a chip is clicked, and switching away doesn't clear it until something else happens to trigger a recalc.
- Ruled out: session lag (`WC()->session->set('chosen_payment_method', ...)` is set in `class-wc-ajax.php::update_order_review` *before* `calculate_totals()` runs, so `apply_cart_fee`'s gate always sees the fresh value); and fee-removal correctness (`WC_Cart::calculate_totals()` calls `fees_api()->remove_all_fees()` before re-firing `woocommerce_cart_calculate_fees`, so simply not calling `add_fee()` is sufficient once a recalc happens).
- Fix: bind once at page load to WC's `payment_method_selected` body event and forward it into `update_checkout`, so a real payment-method change always recalculates totals immediately.

No ticket assigned yet — this is a distinct bug from TWO-25049 (which covers unrelated plugin-list rebranding work in this repo); happy to open/attach one, just say the word.

## Test plan
- [ ] `make test-unit` passes (all 38 existing PHP unit tests green; this fix is JS-only — the repo has no JS test harness, and the PHP harness (`tests/unit/run.php`) only exercises pure functions like `build_buyer_fee_share`, not the `woocommerce_cart_calculate_fees` hook firing sequence or DOM events, so no new automated test was added for the regression itself)
- [ ] Manual: select Two/ABN at checkout — fee should appear immediately without clicking a term chip
- [ ] Manual: switch to a different payment method — fee should disappear immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn