### PR TITLE
TWO-25049/fix: plugin-row polish — drop "the", strip PluginURI link

### DIFF
--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -199,8 +199,12 @@ function twoinc_rebrand_plugin_row($plugins)
         $provider = WC_Twoinc_Brand::get('provider');
         // "Utility library for..." — sorts well below the brand's own row
         // in the (alphabetical) Plugins list, never above it.
-        $plugins[$base]['Name'] = 'Utility library for the ' . $provider;
+        $plugins[$base]['Name'] = 'Utility library for ' . $provider;
         $plugins[$base]['Description'] = 'Common libraries for the ' . $provider . ' payment gateway';
+        // PluginURI drives the "Version x.y.z" link WP renders in the row
+        // meta line — clear it so the rebranded row carries no lingering
+        // link back to two.inc.
+        $plugins[$base]['PluginURI'] = '';
     }
     return $plugins;
 }


### PR DESCRIPTION
## Summary
- "Utility library for the <brand>" -> "Utility library for <brand>".
- Cleared `PluginURI` on the rebranded row — it was rendering a "Version x.y.z" link back to two.inc in the row-meta line.

## Note on the third reported issue
The ABN overlay's "Requires: Two - BNPL for business" note (WP core's plugin-dependency admin UI) was showing the pre-rebrand name. Root cause: `WP_Plugin_Dependencies` caches the dependency's display name in a **12-hour site transient** (`wp_plugin_dependencies_plugin_data`), populated the first time the dependency notice rendered — before the rebrand PR (#354) had landed. It's not reading a live value each time; it's serving that stale cache. No code fix applies here (the transient already recomputes correctly from the current `all_plugins` filter output on any cache miss) — flushed manually on both live ABN shops (`woocom-abn-staging`, `woocom-abn-dev-staging`) to confirm and unblock immediate verification.

## Test plan
- [x] `make test-unit` — all pass
- [x] `php -l`

By Claude.