### PR TITLE
TWO-25049/fix: whitelabel dependency-note name in Plugins API result

### DIFF
--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -54,6 +54,7 @@ function twoinc_on_deactivate_plugin()
 if (is_admin() && !defined('DOING_AJAX')) {
     add_filter("plugin_action_links_" . plugin_basename(__FILE__), 'twoinc_settings_link');
     add_filter('all_plugins', 'twoinc_rebrand_plugin_row');
+    add_filter('plugins_api_result', 'twoinc_rebrand_dependency_api_name', 10, 3);
 }
 
 if (!is_admin() && !defined('DOING_AJAX')) {
@@ -207,6 +208,33 @@ function twoinc_rebrand_plugin_row($plugins)
         $plugins[$base]['PluginURI'] = '';
     }
     return $plugins;
+}
+
+/**
+ * Whitelabel this plugin's name in Plugins API results when a brand overlay
+ * is active. WP_Plugin_Dependencies renders the overlay row's "Requires:"
+ * note from plugins_api('plugin_information') data for the dependency slug
+ * — real wp.org data that bypasses the all_plugins rebrand above — so the
+ * note would otherwise leak the base plugin's real name. Filtering the API
+ * result keeps the note consistent with the rebranded row. The filtered
+ * name is what WP caches (12h transient), so it sticks.
+ */
+function twoinc_rebrand_dependency_api_name($res, $action, $args)
+{
+    if ($action !== 'plugin_information') {
+        return $res;
+    }
+    $slug = dirname(plugin_basename(__FILE__));
+    if (!isset($args->slug) || $args->slug !== $slug) {
+        return $res;
+    }
+    if (apply_filters('twoinc_brand_file', null) === null) {
+        return $res;
+    }
+    if (is_object($res) && isset($res->name)) {
+        $res->name = 'Utility library for ' . WC_Twoinc_Brand::get('provider');
+    }
+    return $res;
 }
 
 /**


### PR DESCRIPTION
## What

WordPress's `WP_Plugin_Dependencies` renders a "Requires: Two - BNPL for businesses" note on a brand overlay's plugin-list row. That note is built from `plugins_api('plugin_information')` data for the dependency slug — real wp.org Plugin API data, cached for 12h — so it bypasses our existing `all_plugins` rebrand of the base plugin's own row.

## Fix

Register a `plugins_api_result` filter (admin, non-AJAX, alongside the existing row-rebrand registrations) that rewrites `$res->name` to "Utility library for {provider}" when:
- the action is `plugin_information`,
- the requested slug is this plugin's own directory slug, and
- a brand overlay is active (`twoinc_brand_file` seam).

The filter runs inside `plugins_api()` before `WP_Plugin_Dependencies` casts the result to an array and caches it, so the whitelabeled name is what lands in the 12h transient and the dependency note. Verified against vendored core: the filter signature is `($res, $action, $args)` and core reads `['name']` after an `(array)` cast of the result object.

Standalone installs (no overlay) are untouched.

## Testing

- `php -l` clean
- `make test-unit`: all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn