### PR TITLE
TWO-25041/fix: show invoice-not-ready notice instead of silent no-op

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -131,9 +131,13 @@ if (!class_exists('WC_Twoinc')) {
                 // Add HTML in order edit page
                 add_action('woocommerce_admin_order_data_after_order_details', [$this, 'add_invoice_credit_note_urls']);
 
-                // One-shot notice from the invoice/credit-note download
-                // handler (ajax_download_invoice redirects back here)
-                add_action('admin_notices', [$this, 'render_invoice_download_notice']);
+                // NOTE: render_invoice_download_notice is registered on
+                // admin_notices in load_twoinc_classes() (plugins_loaded),
+                // NOT here: on the order edit screen WooCommerce constructs
+                // the gateway lazily during the order-data metabox render,
+                // which is AFTER admin_notices has already fired — a
+                // constructor registration is silently too late and the
+                // parked notice never renders (TWO-25041 follow-up).
 
                 // Advanced Custom Fields plugin hides custom fields, we must display them
                 add_filter('acf/settings/remove_wp_meta_box', '__return_false');
@@ -1554,8 +1558,15 @@ if (!class_exists('WC_Twoinc')) {
         /**
          * Render (and clear) the one-shot invoice-download notice parked by
          * ajax_download_invoice for the current user.
+         *
+         * Static and registered on admin_notices in load_twoinc_classes()
+         * (plugins_loaded), not in the gateway constructor: on the order
+         * edit screen the gateway is only constructed during the order-data
+         * metabox render, after admin_notices has fired, so a
+         * constructor-registered callback never runs on the very request
+         * that should display the notice.
          */
-        public function render_invoice_download_notice()
+        public static function render_invoice_download_notice()
         {
             // admin_notices fires on every wp-admin page, but the transient
             // is scoped to one order — only render it on that order's edit

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -2346,15 +2346,25 @@ final class BrandConfigSpec
 
     private static function testInvoiceDownloadNoticeIsolatedPerOrder(): void
     {
-        $gateway = self::invoiceGateway([]);
+        // The renderer must be STATIC: it is registered on admin_notices in
+        // load_twoinc_classes() (plugins_loaded), not the gateway
+        // constructor — on the order edit screen the gateway is only
+        // constructed during the metabox render, AFTER admin_notices has
+        // fired, so a constructor registration silently never renders the
+        // notice (the TWO-25041 "button does nothing" bug).
+        TinyAssert::true(
+            (new ReflectionMethod(WC_Twoinc::class, 'render_invoice_download_notice'))->isStatic(),
+            'render_invoice_download_notice must be static so plugins_loaded can register it without a gateway instance'
+        );
+
         $GLOBALS['__twoinc_test_transients'] = [
             'twoinc_invoice_notice_1_42' => ['level' => 'info', 'message' => 'notice for order 42'],
             'twoinc_invoice_notice_1_43' => ['level' => 'error', 'message' => 'notice for order 43'],
         ];
 
-        $render = static function () use ($gateway) {
+        $render = static function () {
             ob_start();
-            $gateway->render_invoice_download_notice();
+            WC_Twoinc::render_invoice_download_notice();
             return ob_get_clean();
         };
 

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -111,6 +111,14 @@ function load_twoinc_classes()
     // since an admin-ajax request does not construct the payment gateway.
     add_action('wp_ajax_twoinc_download_invoice', ['WC_Twoinc', 'ajax_download_invoice']);
 
+    // The one-shot notice that handler parks must also be registered here,
+    // not in the gateway constructor: on the order edit screen WooCommerce
+    // constructs the gateway lazily during the order-data metabox render,
+    // AFTER admin_notices has already fired — a constructor registration is
+    // silently too late and the "invoice not ready yet" notice never
+    // renders, so the button click looks like a no-op (TWO-25041 follow-up).
+    add_action('admin_notices', ['WC_Twoinc', 'render_invoice_download_notice']);
+
     // Confirm order after returning from twoinc checkout-page, DO NOT CHANGE HOOKS
     add_action('template_redirect', 'WC_Twoinc::process_confirmation_header_redirect');
     // add_action('template_redirect', 'WC_Twoinc::before_process_confirmation');


### PR DESCRIPTION
## Problem

Follow-up to #352: clicking the invoice/credit-note download button on an order still in Two's FULFILLING state redirected back to the order screen with **no notice at all** — a silent no-op instead of the intended "invoice not ready yet" info notice.

## Root cause

`render_invoice_download_notice` (which pops the one-shot transient parked by `ajax_download_invoice`) was registered on `admin_notices` from the **gateway constructor** (`class/WC_Twoinc.php:136`). But on the order edit screen WooCommerce constructs payment gateways lazily during the order-data metabox render (`WC_Meta_Box_Order_Data::output` → `WC()->payment_gateways()`), which happens **after** `admin_notices` has already fired in `admin-header.php`. The registration was silently too late on exactly the request that should display the notice.

The same file already documents this class of bug for the ajax handler and the cart-fee hook ("a constructor-registered hook is missed") — this hook needed the same treatment.

## Fix (minimal)

- Register `render_invoice_download_notice` on `admin_notices` in `load_twoinc_classes()` (plugins_loaded), matching the adjacent `wp_ajax_twoinc_download_invoice` registration.
- Make the method `static` (it uses no instance state).
- Remove the too-late constructor registration; leave a comment explaining why it must not come back.
- Pin the timing contract in the existing notice test with a `ReflectionMethod::isStatic()` assertion.

No changes to the notice text, transient mechanism, or download/stream flow — those were correct; they just never got a chance to render.

## Testing

- `php -l` clean on all three files
- `make test-unit`: all 84 tests pass (existing notice-isolation test now exercises the static call path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QPUWVU327UaA1dsgxpQn