### PR TITLE
feat: animated loading-dots on checkout term chips while fee quote is in flight

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -227,6 +227,37 @@
   color: inherit;
   opacity: 0.85;
 }
+/*
+ * Loading dots shown while the fee quote is in flight. Timing mirrors the
+ * Magento checkout (.two-term-chip__loading): 1.4s staggered opacity pulse.
+ */
+.twoinc-term-chip__loading {
+  display: inline-block;
+  letter-spacing: 2px;
+  font-size: 12px;
+  font-weight: 700;
+  color: inherit;
+}
+.twoinc-term-chip__loading > span {
+  display: inline-block;
+  animation: twoinc-term-chip-dot 1.4s infinite ease-in-out both;
+}
+.twoinc-term-chip__loading > span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.twoinc-term-chip__loading > span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+@keyframes twoinc-term-chip-dot {
+  0%,
+  80%,
+  100% {
+    opacity: 0.2;
+  }
+  40% {
+    opacity: 1;
+  }
+}
 
 /* Sole trader toggle (TWO-24754) */
 /*

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -885,6 +885,7 @@ let twoincDomHelper = {
  */
 let twoincTermChips = {
   fees: {},
+  feesLoaded: false,
 
   config: function () {
     return (window.twoinc && window.twoinc.payment_terms) || { enabled: false };
@@ -901,19 +902,31 @@ let twoincTermChips = {
       return;
     }
     $container.removeClass("hidden");
+
+    const willFetchFees = Boolean(cfg.offset_pricing_enabled && cfg.fees_url);
+    // A checkout update invalidates the previous quotes, so show the
+    // loading dots again until the fresh quotes arrive. When no fetch
+    // will happen, skip straight to the settled (no-fee) state.
+    twoincTermChips.feesLoaded = !willFetchFees;
     twoincTermChips.render(cfg.terms, cfg.selected);
 
-    if (cfg.offset_pricing_enabled && cfg.fees_url) {
+    if (willFetchFees) {
       jQuery
         .post(cfg.fees_url, { nonce: cfg.nonce })
         .done(function (response) {
+          twoincTermChips.feesLoaded = true;
           if (response && response.success && response.data) {
             twoincTermChips.fees = response.data.fees || {};
             twoincTermChips.render(response.data.terms, response.data.selected);
+          } else {
+            twoincTermChips.render(cfg.terms, cfg.selected);
           }
         })
         .fail(function () {
           // Fee labels are decorative: chips stay usable without them.
+          // Re-render to settle the loading dots into the no-fee state.
+          twoincTermChips.feesLoaded = true;
+          twoincTermChips.render(cfg.terms, cfg.selected);
         });
     }
   },
@@ -940,14 +953,28 @@ let twoincTermChips = {
       const daysLabel = (twoincTermChips.config().days_label || "%s days").replace("%s", days);
       $chip.append(jQuery("<span>", { class: "twoinc-term-chip__days", text: daysLabel }));
 
-      const fee = twoincTermChips.fees[days];
-      if (fee && parseFloat(fee.buyer_fee_share) > 0) {
-        $chip.append(
-          jQuery("<span>", {
-            class: "twoinc-term-chip__fee",
-            text: "+" + fee.buyer_fee_share + " " + fee.currency
-          })
-        );
+      if (!twoincTermChips.feesLoaded) {
+        // Fee quote in flight: show animated loading dots instead of a
+        // blank chip. Never render the configured rate — only the real
+        // quoted amount once it arrives.
+        const $loading = jQuery("<span>", {
+          class: "twoinc-term-chip__loading",
+          "aria-hidden": "true"
+        });
+        for (let i = 0; i < 3; i++) {
+          $loading.append(jQuery("<span>", { text: "." }));
+        }
+        $chip.append($loading);
+      } else {
+        const fee = twoincTermChips.fees[days];
+        if (fee && parseFloat(fee.buyer_fee_share) > 0) {
+          $chip.append(
+            jQuery("<span>", {
+              class: "twoinc-term-chip__fee",
+              text: "+" + fee.buyer_fee_share + " " + fee.currency
+            })
+          );
+        }
       }
       if (!single) {
         $chip.on("click", function () {


### PR DESCRIPTION
## Context
Matches PrestaShop's chip behavior fix (same product decision): the checkout term chips must never leak the merchant's configured surcharge rate to the buyer — only the real quoted amount, or a loading indicator while the quote is pending. This repo's chips already did the safe thing by accident (blank until the fee-quote POST resolves) but had no loading indicator, unlike magento-plugin's animated three-dot chip loader.

## Fix
- \`twoincTermChips\` gains a \`feesLoaded\` flag. \`render()\` shows an animated three-dot \`.twoinc-term-chip__loading\` span per chip while unresolved, swapping to the real fee (or nothing, if ~0) once loaded — same as before, just no more bare-blank interim state.
- \`refresh()\`: dots reset on every checkout update (cart totals invalidate old quotes), settle on success, failure, or malformed response — never left spinning indefinitely, never falls back to a rate.
- When offset pricing is disabled / no fees URL configured, skips straight to the settled state (no dots that would never resolve).
- CSS timing copied from Magento's \`.two-term-chip__loading\` (1.4s staggered opacity pulse), adapted to this file's \`twoinc-\` naming and color conventions.

## Testing
\`node --check\` clean. No JS test harness in this repo — verified by manual trace of all four settle paths (success, malformed success, fail, no-fetch-configured).

---
*Reviewed by Claude prior to opening this PR — self-review-lane process.*