### PR TITLE
TWO-25070: configurable surcharge tax treatment

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -406,6 +406,21 @@ jQuery(function ($) {
       $(".twoinc-surcharge-grid-field").toggle(type !== "none");
     }
 
+    // ── Surcharge tax treatment/class visibility ─────────────────────
+    // Both rows follow the surcharge method (no surcharge → no tax
+    // question); the class dropdown additionally follows the treatment
+    // (only "Specific tax class" needs it). Selection changes mirror
+    // without a save; the stored values are untouched until Save.
+    const $taxTreatment = $("#" + prefix + "surcharge_tax_treatment");
+    const $taxClass = $("#" + prefix + "surcharge_tax_class");
+
+    function updateTaxFields() {
+      const type = $surchargeType.val() || "none";
+      const treatment = $taxTreatment.val() || "standard";
+      $taxTreatment.closest("tr").toggle(type !== "none");
+      $taxClass.closest("tr").toggle(type !== "none" && treatment === "custom_class");
+    }
+
     function onTermsChanged() {
       rebuildDefaultTerm();
       loadFees();
@@ -415,9 +430,12 @@ jQuery(function ($) {
     $checkboxes.on("change", onTermsChanged);
     $customDays.on("change keyup", onTermsChanged);
     $surchargeType.on("change", updateGridColumns);
+    $surchargeType.on("change", updateTaxFields);
+    $taxTreatment.on("change", updateTaxFields);
 
     rebuildDefaultTerm();
     loadFees();
     updateGridRows();
+    updateTaxFields();
   })();
 });

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -801,7 +801,14 @@ if (!class_exists('WC_Twoinc')) {
                 if ($name === '') {
                     continue;
                 }
-                $options[sanitize_title($name)] = $name;
+                $slug = sanitize_title($name);
+                if ($slug === '') {
+                    // A pathological class name (e.g. all punctuation) can
+                    // sanitize to '' — skip it rather than overwrite the
+                    // placeholder option keyed by ''.
+                    continue;
+                }
+                $options[$slug] = $name;
             }
             return $options;
         }
@@ -827,7 +834,10 @@ if (!class_exists('WC_Twoinc')) {
             }
             return sprintf(
                 __('⚠ The previously selected tax class ("%s") no longer exists. The surcharge is currently taxed under the Standard treatment — select an existing tax class or change the tax treatment above.', 'twoinc-payment-gateway'),
-                $stored
+                // The notice is rendered as raw HTML in the settings field
+                // description, so escape the stored value (it may have been
+                // written outside the dropdown, e.g. direct DB/API edits).
+                esc_html($stored)
             );
         }
 

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -780,6 +780,91 @@ if (!class_exists('WC_Twoinc')) {
         }
 
         /**
+         * Admin option list for the surcharge tax class: the store's LIVE
+         * additional tax classes (WC_Tax::get_tax_classes), keyed by slug —
+         * the value WC_Cart_Fees::add_fee() resolves rates by. Built fresh
+         * on every settings render, never hardcoded, so it always mirrors
+         * WooCommerce → Settings → Tax. Mirrors core's
+         * wc_get_product_tax_class_options() slug mapping (minus the
+         * implicit Standard entry, which is the 'standard' treatment mode).
+         *
+         * @return array<string, string> slug => display name
+         */
+        public function get_surcharge_tax_class_options(): array
+        {
+            $options = ['' => __('— select a tax class —', 'twoinc-payment-gateway')];
+            if (!class_exists('WC_Tax')) {
+                return $options;
+            }
+            foreach ((array) WC_Tax::get_tax_classes() as $name) {
+                $name = (string) $name;
+                if ($name === '') {
+                    continue;
+                }
+                $options[sanitize_title($name)] = $name;
+            }
+            return $options;
+        }
+
+        /**
+         * Visible warning for the surcharge tax class field when the stored
+         * selection no longer matches a live tax class (the merchant deleted
+         * it). Without this the failure is silent twice over: core's
+         * add_fee() would quietly tax the fee as Standard, and the effective-
+         * treatment resolver (WC_Twoinc_Payment_Terms::
+         * resolve_surcharge_tax_treatment) therefore deliberately degrades
+         * to standard mode — this notice is what makes that degradation
+         * visible to the merchant.
+         */
+        public function get_surcharge_tax_class_stale_notice(): string
+        {
+            if ($this->get_option('surcharge_tax_treatment') !== 'custom_class') {
+                return '';
+            }
+            $stored = trim((string) $this->get_option('surcharge_tax_class'));
+            if ($stored === '' || array_key_exists($stored, $this->get_surcharge_tax_class_options())) {
+                return '';
+            }
+            return sprintf(
+                __('⚠ The previously selected tax class ("%s") no longer exists. The surcharge is currently taxed under the Standard treatment — select an existing tax class or change the tax treatment above.', 'twoinc-payment-gateway'),
+                $stored
+            );
+        }
+
+        /**
+         * Enforce that a saved surcharge tax treatment is one of the three
+         * supported modes (WooCommerce's default select validation sanitises
+         * but does not enforce option-list membership).
+         */
+        public function validate_surcharge_tax_treatment_field($key, $value)
+        {
+            $value = trim((string) $value);
+            if (!in_array($value, ['standard', 'custom_class', 'always_zero'], true)) {
+                throw new Exception(__('Surcharge tax treatment must be one of the offered modes.', 'twoinc-payment-gateway'));
+            }
+            return $value;
+        }
+
+        /**
+         * Enforce that a saved surcharge tax class is one of the store's
+         * live tax classes ('' = none selected is allowed; the effective
+         * treatment then degrades to standard). Guards against a tampered
+         * or stale POST persisting a slug that WC_Cart_Fees::add_fee()
+         * would silently tax as Standard.
+         */
+        public function validate_surcharge_tax_class_field($key, $value)
+        {
+            $value = trim((string) $value);
+            if ($value === '') {
+                return '';
+            }
+            if (!array_key_exists($value, $this->get_surcharge_tax_class_options())) {
+                throw new Exception(__('Surcharge tax class must be one of the store\'s existing tax classes.', 'twoinc-payment-gateway'));
+            }
+            return $value;
+        }
+
+        /**
          * Render the per-term surcharge grid (WC Settings API custom field
          * `two_surcharge_grid`). One row per offered term, columns
          * fixed/percentage/cap, mirroring the Magento surcharge grid. Values
@@ -3080,6 +3165,29 @@ if (!class_exists('WC_Twoinc')) {
                     'description' => __('Buyer-facing label for the surcharge line. Use %s for the term length in days. Leave blank to use the brand default.', 'twoinc-payment-gateway'),
                     'desc_tip'    => true,
                     'type'        => 'text',
+                    'default'     => ''
+                ],
+                'surcharge_tax_treatment' => [
+                    'title'       => __('Surcharge Tax Treatment', 'twoinc-payment-gateway'),
+                    'description' => __('How the surcharge line is taxed. Standard applies your store\'s default tax rules to the fee. Specific tax class taxes the fee under a WooCommerce tax class you select below. Never taxed adds the fee as non-taxable, regardless of the customer\'s destination.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'type'        => 'select',
+                    'options'     => [
+                        'standard'     => __('Standard (store default tax rules)', 'twoinc-payment-gateway'),
+                        'custom_class' => __('Specific tax class', 'twoinc-payment-gateway'),
+                        'always_zero'  => __('Never taxed', 'twoinc-payment-gateway'),
+                    ],
+                    'default'     => 'standard'
+                ],
+                'surcharge_tax_class' => [
+                    'title'       => __('Surcharge Tax Class', 'twoinc-payment-gateway'),
+                    'desc_tip'    => __('The WooCommerce tax class applied to the surcharge when the tax treatment is "Specific tax class". Manage tax classes under WooCommerce → Settings → Tax.', 'twoinc-payment-gateway'),
+                    // Visible (non-tooltip) description: carries the stale-
+                    // selection warning when the stored class has been
+                    // deleted, empty otherwise.
+                    'description' => $this->get_surcharge_tax_class_stale_notice(),
+                    'type'        => 'select',
+                    'options'     => $this->get_surcharge_tax_class_options(),
                     'default'     => ''
                 ],
                 'surcharge_grid' => [

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -64,8 +64,12 @@ if (!class_exists('WC_Twoinc_Checkout')) {
         public function move_country_field($fields)
         {
 
-            // Change the priority for the country field
-            $fields['billing']['billing_country']['priority'] = $fields['billing']['billing_company']['priority'] - 1;
+            // Change the priority for the country field. billing_company may
+            // be absent (e.g. WooCommerce's own "Company name" field toggle
+            // disabled) — fall back to core's default priority (30) rather
+            // than warning on an undefined array key.
+            $company_priority = $fields['billing']['billing_company']['priority'] ?? 30;
+            $fields['billing']['billing_country']['priority'] = $company_priority - 1;
 
             // Return the fields list
             return $fields;
@@ -82,7 +86,8 @@ if (!class_exists('WC_Twoinc_Checkout')) {
         public function update_company_fields($fields)
         {
 
-            $company_name_priority = $fields['billing']['billing_company']['priority'];
+            // billing_company may be absent (see move_country_field above).
+            $company_name_priority = $fields['billing']['billing_company']['priority'] ?? 30;
 
             if ($this->wc_twoinc->get_enable_company_search() === 'yes') {
 

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -161,7 +161,7 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
          * Magento surcharge model: a type gate, a per-term grid of
          * {fixed, percentage, limit}, a differential toggle and rounding.
          *
-         * @return array{type: string, enabled: bool, differential: bool, grid: array<int,array>, rounding_basis: string, rounding_step: float|null}
+         * @return array{type: string, enabled: bool, differential: bool, grid: array<int,array>, rounding_basis: string, rounding_step: float|null, tax_treatment: string, tax_class: string}
          */
         public static function get_surcharge_settings($gateway): array
         {
@@ -172,6 +172,7 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
             $grid = $gateway->get_option('surcharge_grid');
             $grid = is_array($grid) ? $grid : [];
             $rounding_step = (float) $gateway->get_option('surcharge_rounding_step');
+            $tax = self::resolve_surcharge_tax_treatment($gateway);
             return [
                 'type' => $type,
                 'enabled' => $type !== 'none',
@@ -179,7 +180,53 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
                 'grid' => $grid,
                 'rounding_basis' => (string) $gateway->get_option('surcharge_rounding_basis'),
                 'rounding_step' => $rounding_step > 0 ? $rounding_step : null,
+                'tax_treatment' => $tax['treatment'],
+                'tax_class' => $tax['tax_class'],
             ];
+        }
+
+        /**
+         * The EFFECTIVE surcharge tax treatment: the stored mode, degraded
+         * to 'standard' when it cannot be honoured. In custom_class mode the
+         * stored slug is re-validated against the LIVE tax-class list on
+         * every read: WC_Cart_Fees::add_fee() silently reverts an unknown
+         * tax class to Standard rather than erroring, so if the merchant
+         * deleted the selected class the surcharge would quietly change tax
+         * behaviour anyway — degrading explicitly here keeps the runtime
+         * honest and lets the settings page surface the stale selection
+         * (WC_Twoinc::init_form_fields carries the matching admin warning).
+         *
+         * @return array{treatment: string, tax_class: string}
+         */
+        public static function resolve_surcharge_tax_treatment($gateway): array
+        {
+            $treatment = (string) $gateway->get_option('surcharge_tax_treatment');
+            if (!in_array($treatment, ['standard', 'custom_class', 'always_zero'], true)) {
+                $treatment = 'standard';
+            }
+            if ($treatment !== 'custom_class') {
+                return ['treatment' => $treatment, 'tax_class' => ''];
+            }
+            $slug = trim((string) $gateway->get_option('surcharge_tax_class'));
+            if ($slug === '' || !in_array($slug, self::live_tax_class_slugs(), true)) {
+                return ['treatment' => 'standard', 'tax_class' => ''];
+            }
+            return ['treatment' => 'custom_class', 'tax_class' => $slug];
+        }
+
+        /**
+         * The store's current additional tax-class slugs (Standard is the
+         * implicit '' class and is never in this list). Guarded so the
+         * resolver stays callable outside a full WooCommerce bootstrap.
+         *
+         * @return string[]
+         */
+        private static function live_tax_class_slugs(): array
+        {
+            if (!class_exists('WC_Tax') || !method_exists('WC_Tax', 'get_tax_class_slugs')) {
+                return [];
+            }
+            return array_values(array_map('strval', (array) WC_Tax::get_tax_class_slugs()));
         }
 
         /**
@@ -461,7 +508,34 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
                 return;
             }
 
-            $cart->add_fee(self::get_fee_label(), (float) $fee['buyer_fee_share'], true);
+            $label = self::get_fee_label();
+            $amount = (float) $fee['buyer_fee_share'];
+            switch ($settings['tax_treatment']) {
+                case 'always_zero':
+                    // Unconditionally non-taxable via add_fee's $taxable
+                    // flag — deliberately NOT bound to WC's "Zero rate" tax
+                    // class. "Zero rate" is only an empty class by naming
+                    // convention (core creates it with no rate rows and no
+                    // special semantics); a merchant could later add rate
+                    // rows to it and silently break the guarantee, whereas
+                    // taxable=false is destination-independent by
+                    // construction.
+                    $cart->add_fee($label, $amount, false);
+                    break;
+                case 'custom_class':
+                    // The slug is pre-validated against the live class list
+                    // (resolve_surcharge_tax_treatment) — an unknown class
+                    // never reaches here, because WC_Cart_Fees::add_fee()
+                    // would silently tax it as Standard. WC's own tax engine
+                    // (WC_Tax::get_matched_tax_rates) handles the rest:
+                    // additive multi-rate jurisdictions and zero when no
+                    // rate matches the destination.
+                    $cart->add_fee($label, $amount, true, $settings['tax_class']);
+                    break;
+                default:
+                    // 'standard' — pre-feature behaviour, byte-for-byte.
+                    $cart->add_fee($label, $amount, true);
+            }
         }
 
         /**

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -156,6 +156,7 @@ function WC()
             public $countries;
             public $cart;
             public $customer;
+            public $session;
 
             public function __construct()
             {
@@ -192,6 +193,116 @@ class StubCart
     public function is_empty()
     {
         return $this->is_empty;
+    }
+}
+
+class StubSession
+{
+    private $data = [];
+
+    public function get($key, $default = null)
+    {
+        return $this->data[$key] ?? $default;
+    }
+
+    public function set($key, $value)
+    {
+        $this->data[$key] = $value;
+    }
+}
+
+/**
+ * WC_Tax stub: additional tax classes from
+ * $GLOBALS['__twoinc_test_tax_classes'] (display names, as core stores
+ * them); destination-matched rate rows per class slug from
+ * $GLOBALS['__twoinc_test_tax_rates'] ('' = Standard). The rate rows
+ * model what core's WC_Tax::get_matched_tax_rates() returns for the
+ * current destination: a LIST of percentages (multi-rate jurisdictions
+ * have several rows, applied additively), empty when nothing matches.
+ */
+class WC_Tax
+{
+    public static function get_tax_classes()
+    {
+        return $GLOBALS['__twoinc_test_tax_classes'] ?? [];
+    }
+
+    public static function get_tax_class_slugs()
+    {
+        return array_filter(array_map('sanitize_title', self::get_tax_classes()));
+    }
+
+    /** @return float[] matched rate percentages for a class slug */
+    public static function get_rates_for_class($slug)
+    {
+        return $GLOBALS['__twoinc_test_tax_rates'][$slug] ?? [];
+    }
+}
+
+function sanitize_title($title)
+{
+    $title = strtolower(trim((string) $title));
+    $title = preg_replace('/[^a-z0-9]+/', '-', $title);
+    return trim($title, '-');
+}
+
+/**
+ * Cart stub for the surcharge cart-fee hook. add_fee() records its exact
+ * arguments (argc included, so tests can pin the 3-arg pre-feature call
+ * shape) and computes the fee tax the way core does:
+ *
+ *  - $taxable false → no tax, unconditionally (never consults rates).
+ *  - a $tax_class that doesn't match a live class silently reverts to
+ *    Standard (the WC_Cart_Fees::add_fee / WC_Tax::get_rates gotcha the
+ *    plugin-side validation defends against — mirrored here faithfully
+ *    so a regression in that validation shows up as the WRONG TAX, not
+ *    as a stub error).
+ *  - matched rate rows apply additively (US state+local, CA GST+PST).
+ */
+class StubFeeCart
+{
+    public $fees = [];
+
+    public function get_cart_contents_total()
+    {
+        return 100.0;
+    }
+
+    public function get_cart_contents_tax()
+    {
+        return 25.0;
+    }
+
+    public function get_shipping_total()
+    {
+        return 10.0;
+    }
+
+    public function get_shipping_tax()
+    {
+        return 2.5;
+    }
+
+    public function add_fee($name, $amount, $taxable = false, $tax_class = '')
+    {
+        $tax = 0.0;
+        if ($taxable) {
+            $class = (string) $tax_class;
+            if ($class !== '' && !in_array($class, WC_Tax::get_tax_class_slugs(), true)) {
+                $class = ''; // core's silent revert-to-Standard
+            }
+            foreach (WC_Tax::get_rates_for_class($class) as $percent) {
+                $tax += (float) $amount * (float) $percent / 100;
+            }
+        }
+        $this->fees[] = [
+            'name' => $name,
+            'amount' => $amount,
+            'taxable' => $taxable,
+            'tax_class' => $tax_class,
+            'argc' => func_num_args(),
+            'tax' => $tax,
+        ];
     }
 }
 

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -1853,6 +1853,14 @@ final class BrandConfigSpec
         TinyAssert::same(['', 'b2b-levy'], array_keys($options));
         TinyAssert::same('B2B Levy', $options['b2b-levy']);
 
+        // A pathological class name whose slug sanitises to '' is skipped —
+        // it must not overwrite the '' placeholder option.
+        $GLOBALS['__twoinc_test_tax_classes'] = ['!!!', 'B2B Levy'];
+        $options = $gateway->get_surcharge_tax_class_options();
+        TinyAssert::same(['', 'b2b-levy'], array_keys($options), 'empty-slug class must not clobber the placeholder');
+        TinyAssert::same('— select a tax class —', $options['']);
+        $GLOBALS['__twoinc_test_tax_classes'] = ['B2B Levy'];
+
         // Save-validation: live slug and '' pass, a dead slug is rejected
         // (WC's select validation does not enforce option membership).
         TinyAssert::same('b2b-levy', $gateway->validate_surcharge_tax_class_field('surcharge_tax_class', 'b2b-levy'));
@@ -1882,6 +1890,17 @@ final class BrandConfigSpec
             'surcharge_tax_class' => 'deleted-class',
         ]);
         TinyAssert::true(strpos($stale->get_surcharge_tax_class_stale_notice(), 'no longer exists') !== false);
+
+        // The stored slug is echoed into the settings description (raw HTML
+        // context) — a crafted value must come out HTML-escaped.
+        $crafted = self::surchargeFeeGateway([
+            'surcharge_tax_treatment' => 'custom_class',
+            'surcharge_tax_class' => '<script>alert(1)</script>',
+        ]);
+        $notice = $crafted->get_surcharge_tax_class_stale_notice();
+        TinyAssert::true(strpos($notice, '<script>') === false, 'stale notice must HTML-escape the stored slug');
+        TinyAssert::true(strpos($notice, '&lt;script&gt;') !== false);
+
         $healthy = self::surchargeFeeGateway([
             'surcharge_tax_treatment' => 'custom_class',
             'surcharge_tax_class' => 'b2b-levy',

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -76,6 +76,11 @@ final class BrandConfigSpec
             'testSurchargeGridEnforcesMerchantFixedCap',
             'testSurchargeCapZeroAmountFromApiMeansNoLimit',
             'testSurchargeGridHelpTextOmitsMaxOnCurrencyMismatch',
+            'testSurchargeFeeStandardModeUnchanged',
+            'testSurchargeFeeCustomClassTaxedAtSelectedClassRates',
+            'testSurchargeFeeAlwaysZeroNeverTaxed',
+            'testSurchargeFeeCustomClassFallsBackWhenClassDeleted',
+            'testSurchargeTaxSettingsValidationAndStaleNotice',
             'testPaymentTermsValidationRequiresSelection',
             'testDefaultTermCoercedToOfferedSet',
             'testOrderPayloadCarriesSelectedAndAvailableTerms',
@@ -128,6 +133,8 @@ final class BrandConfigSpec
         WC_Twoinc::reset_merchant_record_memo();
         WC()->cart = null;
         WC()->customer = null;
+        WC()->session = null;
+        unset($GLOBALS['__twoinc_test_tax_classes'], $GLOBALS['__twoinc_test_tax_rates']);
         foreach (['twoinc_brand_file', 'twoinc_checkout_fields', 'twoinc_confirmation_url', 'twoinc_order_payload', 'twoinc_payment_terms_line', 'two_order_create', 'twoinc_payment_validation_error', 'twoinc_sole_trader_signup_url', 'twoinc_shipping_details'] as $tag) {
             remove_all_filters($tag);
         }
@@ -1677,6 +1684,214 @@ final class BrandConfigSpec
         TinyAssert::true(strpos($html, 'Max') === false, 'Max sentence must be omitted on currency mismatch');
         unset($GLOBALS['__twoinc_test_currency']);
         unset($GLOBALS['test_home_url']);
+    }
+
+    // ── Surcharge tax treatment (TWO-25070) ────────────────────────────
+
+    /**
+     * Gateway fake for the surcharge cart-fee path: options injected, one
+     * merchant term offered, and the pricing endpoint canned to quote a
+     * 12.50 buyer fee share.
+     */
+    private static function surchargeFeeGateway(array $options): WC_Twoinc
+    {
+        return new class ($options) extends WC_Twoinc {
+            private $options;
+
+            public function __construct($options = [])
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+                $this->options = $options;
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $this->options[$key] ?? $empty_value ?? '';
+            }
+
+            public function get_merchant_available_terms(bool $refresh = false): array
+            {
+                return [30, 60];
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+            {
+                if (strpos($endpoint, '/v1/pricing/order/fee') === 0) {
+                    return [
+                        'response' => ['code' => 200],
+                        'body' => json_encode(['buyer_fee_share' => '12.50', 'currency' => 'EUR']),
+                    ];
+                }
+                return new WP_Error();
+            }
+        };
+    }
+
+    /**
+     * Drive the woocommerce_cart_calculate_fees handler end-to-end (session
+     * gateway match, term resolution, fee quote, add_fee) against a
+     * StubFeeCart, and return the cart for assertions on the recorded
+     * add_fee call. $options rides on top of a minimal enabled-surcharge
+     * configuration.
+     */
+    private static function runApplyCartFee(array $options): StubFeeCart
+    {
+        $gateway = self::surchargeFeeGateway(array_merge([
+            'surcharge_type' => 'percentage',
+            'payment_terms_days' => [30],
+            'surcharge_grid' => [30 => ['percentage' => 2.0]],
+        ], $options));
+        return self::withGatewayInstance($gateway, static function () use ($gateway) {
+            WC_Twoinc_Payment_Terms::reset_fee_cache();
+            WC()->session = new StubSession();
+            WC()->session->set('chosen_payment_method', $gateway->id);
+            WC()->customer = new StubCustomer('US');
+            $cart = new StubFeeCart();
+            WC_Twoinc_Payment_Terms::apply_cart_fee($cart);
+            TinyAssert::same(1, count($cart->fees), 'expected exactly one surcharge fee line');
+            return $cart;
+        });
+    }
+
+    private static function testSurchargeFeeStandardModeUnchanged(): void
+    {
+        // Regression pin: no tax-treatment option stored (pre-feature
+        // install) → the pre-feature 3-arg taxable call, byte-for-byte, so
+        // WC taxes the fee under Standard exactly as today.
+        $GLOBALS['__twoinc_test_tax_classes'] = ['Reduced rate'];
+        $GLOBALS['__twoinc_test_tax_rates'] = ['' => [25.0], 'reduced-rate' => [5.0]];
+
+        $fee = self::runApplyCartFee([])->fees[0];
+        TinyAssert::same(3, $fee['argc'], 'standard mode must keep the pre-feature 3-arg add_fee call');
+        TinyAssert::same(true, $fee['taxable']);
+        TinyAssert::same(12.5, $fee['amount']);
+        TinyAssert::same(12.5 * 0.25, $fee['tax'], 'standard mode taxes at the Standard rate');
+
+        // An explicit 'standard' selection is identical.
+        $fee = self::runApplyCartFee(['surcharge_tax_treatment' => 'standard'])->fees[0];
+        TinyAssert::same(3, $fee['argc']);
+        TinyAssert::same(true, $fee['taxable']);
+    }
+
+    private static function testSurchargeFeeCustomClassTaxedAtSelectedClassRates(): void
+    {
+        // 'B2B Levy' carries TWO simultaneous destination-matched rate rows
+        // (the US state+local / CA GST+PST shape): WC's engine applies them
+        // additively, and the fee must be taxed at 5% + 2%, not at the 25%
+        // Standard rate.
+        $GLOBALS['__twoinc_test_tax_classes'] = ['B2B Levy', 'Reduced rate'];
+        $GLOBALS['__twoinc_test_tax_rates'] = [
+            '' => [25.0],
+            'b2b-levy' => [5.0, 2.0],
+            'reduced-rate' => [10.0],
+        ];
+
+        $fee = self::runApplyCartFee([
+            'surcharge_tax_treatment' => 'custom_class',
+            'surcharge_tax_class' => 'b2b-levy',
+        ])->fees[0];
+        TinyAssert::same(4, $fee['argc'], 'custom_class mode must pass the tax_class argument');
+        TinyAssert::same(true, $fee['taxable']);
+        TinyAssert::same('b2b-levy', $fee['tax_class']);
+        // 5% + 2% of 12.50 = 0.875 (exact in binary floating point).
+        TinyAssert::same(0.875, $fee['tax'], 'multi-rate rows for the selected class stack additively');
+    }
+
+    private static function testSurchargeFeeAlwaysZeroNeverTaxed(): void
+    {
+        // Fat Standard rate and a "Zero rate" class that a merchant has
+        // (mis)filled with rate rows: always_zero must not consult either —
+        // it is add_fee(…, taxable: false), not a binding to any class, so
+        // the guarantee is destination-independent by construction.
+        $GLOBALS['__twoinc_test_tax_classes'] = ['Zero rate'];
+        $GLOBALS['__twoinc_test_tax_rates'] = ['' => [25.0], 'zero-rate' => [19.0]];
+
+        $fee = self::runApplyCartFee(['surcharge_tax_treatment' => 'always_zero'])->fees[0];
+        TinyAssert::same(3, $fee['argc'], 'always_zero must not pass a tax class');
+        TinyAssert::same(false, $fee['taxable']);
+        TinyAssert::same(0.0, $fee['tax']);
+    }
+
+    private static function testSurchargeFeeCustomClassFallsBackWhenClassDeleted(): void
+    {
+        // The stored class was deleted from WooCommerce → Settings → Tax.
+        // Core's add_fee would silently tax it as Standard; the resolver
+        // must degrade to EXPLICIT standard treatment instead (same tax
+        // outcome, but visible in settings and never passing a dead slug).
+        $GLOBALS['__twoinc_test_tax_classes'] = ['Reduced rate'];
+        $GLOBALS['__twoinc_test_tax_rates'] = ['' => [25.0], 'reduced-rate' => [5.0]];
+
+        $options = [
+            'surcharge_tax_treatment' => 'custom_class',
+            'surcharge_tax_class' => 'deleted-class',
+        ];
+        $settings = WC_Twoinc_Payment_Terms::get_surcharge_settings(
+            self::surchargeFeeGateway(array_merge(['surcharge_type' => 'percentage'], $options))
+        );
+        TinyAssert::same('standard', $settings['tax_treatment'], 'a dead slug must degrade to standard treatment');
+        TinyAssert::same('', $settings['tax_class']);
+
+        $fee = self::runApplyCartFee($options)->fees[0];
+        TinyAssert::same(3, $fee['argc'], 'fallback must use the plain 3-arg call, never a dead slug');
+        TinyAssert::same(true, $fee['taxable']);
+        TinyAssert::same(12.5 * 0.25, $fee['tax'], 'fallback taxes at the Standard rate');
+
+        // An empty stored class in custom_class mode degrades the same way.
+        $settings = WC_Twoinc_Payment_Terms::get_surcharge_settings(
+            self::surchargeFeeGateway(['surcharge_type' => 'percentage', 'surcharge_tax_treatment' => 'custom_class'])
+        );
+        TinyAssert::same('standard', $settings['tax_treatment']);
+    }
+
+    private static function testSurchargeTaxSettingsValidationAndStaleNotice(): void
+    {
+        $GLOBALS['__twoinc_test_tax_classes'] = ['B2B Levy'];
+
+        // Options are built live from WC_Tax, keyed by slug.
+        $gateway = self::surchargeFeeGateway([]);
+        $options = $gateway->get_surcharge_tax_class_options();
+        TinyAssert::same(['', 'b2b-levy'], array_keys($options));
+        TinyAssert::same('B2B Levy', $options['b2b-levy']);
+
+        // Save-validation: live slug and '' pass, a dead slug is rejected
+        // (WC's select validation does not enforce option membership).
+        TinyAssert::same('b2b-levy', $gateway->validate_surcharge_tax_class_field('surcharge_tax_class', 'b2b-levy'));
+        TinyAssert::same('', $gateway->validate_surcharge_tax_class_field('surcharge_tax_class', ''));
+        $threw = false;
+        try {
+            $gateway->validate_surcharge_tax_class_field('surcharge_tax_class', 'deleted-class');
+        } catch (Exception $e) {
+            $threw = true;
+        }
+        TinyAssert::true($threw, 'a non-live tax class must be rejected at save');
+
+        // Treatment validation enforces the three modes.
+        TinyAssert::same('always_zero', $gateway->validate_surcharge_tax_treatment_field('surcharge_tax_treatment', 'always_zero'));
+        $threw = false;
+        try {
+            $gateway->validate_surcharge_tax_treatment_field('surcharge_tax_treatment', 'zero_rate_class');
+        } catch (Exception $e) {
+            $threw = true;
+        }
+        TinyAssert::true($threw);
+
+        // Stale-selection notice: shown only when custom_class is selected
+        // AND the stored slug no longer matches a live class.
+        $stale = self::surchargeFeeGateway([
+            'surcharge_tax_treatment' => 'custom_class',
+            'surcharge_tax_class' => 'deleted-class',
+        ]);
+        TinyAssert::true(strpos($stale->get_surcharge_tax_class_stale_notice(), 'no longer exists') !== false);
+        $healthy = self::surchargeFeeGateway([
+            'surcharge_tax_treatment' => 'custom_class',
+            'surcharge_tax_class' => 'b2b-levy',
+        ]);
+        TinyAssert::same('', $healthy->get_surcharge_tax_class_stale_notice());
+        $standard = self::surchargeFeeGateway([
+            'surcharge_tax_treatment' => 'standard',
+            'surcharge_tax_class' => 'deleted-class',
+        ]);
+        TinyAssert::same('', $standard->get_surcharge_tax_class_stale_notice(), 'no notice outside custom_class mode');
     }
 
     private static function testPaymentTermsValidationRequiresSelection(): void


### PR DESCRIPTION
## Summary
Adds a merchant-configurable surcharge tax treatment: Standard (default, unchanged), Specific tax class, or Never taxed. Closes the gap where the surcharge fee was hardcoded to WC's Standard tax class regardless of merchant intent (TWO-25069).

- New admin settings: `surcharge_tax_treatment` (standard/custom_class/always_zero), `surcharge_tax_class` (live-populated from `WC_Tax::get_tax_classes()`)
- `always_zero` uses `add_fee(..., taxable: false)`, not a binding to WC's "Zero rate" class (that class has no special semantics — a merchant could add rate rows to it later and silently break the guarantee)
- Deleted/stale tax class selection degrades explicitly to Standard (WC's `add_fee()` would otherwise silently revert to Standard with no signal) — surfaced via a visible admin notice
- Save-time validation enforces membership against the live class list

## Test plan
- [x] 86/86 unit tests pass (81 pre-existing regression, 5 new)
- [x] `php -l` / `node --check` clean
- [ ] Staging checkout spot-check with a multi-rate tax class (unit suite is stub-based, no live WC install in this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)