### PR TITLE
fix: require explicit surcharge tax treatment selection

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -872,8 +872,11 @@ if (!class_exists('WC_Twoinc')) {
         public function validate_surcharge_type_field($key, $value)
         {
             $value = trim((string) $value);
+            // Same enabled-set the runtime uses (get_surcharge_settings
+            // coerces anything else to 'none'), so the gate matches what
+            // will actually surcharge.
             if (
-                $value !== 'none' && $value !== ''
+                in_array($value, ['percentage', 'fixed', 'fixed_and_percentage'], true)
                 && !in_array(
                     $this->get_sibling_field_save_value('surcharge_tax_treatment'),
                     ['standard', 'custom_class', 'always_zero'],
@@ -898,8 +901,8 @@ if (!class_exists('WC_Twoinc')) {
             $value = trim((string) $value);
             if ($value === '') {
                 $type = $this->get_sibling_field_save_value('surcharge_type');
-                if ($type !== 'none' && $type !== '') {
-                    throw new Exception(__('Select a surcharge tax treatment before enabling surcharges.', 'twoinc-payment-gateway'));
+                if (in_array($type, ['percentage', 'fixed', 'fixed_and_percentage'], true)) {
+                    throw new Exception(__('Select a surcharge tax treatment — surcharges cannot be used without one.', 'twoinc-payment-gateway'));
                 }
                 return '';
             }

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -842,13 +842,67 @@ if (!class_exists('WC_Twoinc')) {
         }
 
         /**
+         * A sibling field's value as it will stand AFTER this save: the
+         * posted value when the field is in the submission, else the stored
+         * option. Lets one field's validator enforce a cross-field invariant
+         * against the state actually being saved, not the stale stored one
+         * (e.g. enabling surcharges and picking a tax treatment in the same
+         * save must pass).
+         */
+        private function get_sibling_field_save_value(string $key): string
+        {
+            $post_data = $this->get_post_data();
+            $field_key = $this->get_field_key($key);
+            if (is_array($post_data) && array_key_exists($field_key, $post_data)) {
+                return trim((string) $post_data[$field_key]);
+            }
+            return trim((string) $this->get_option($key));
+        }
+
+        /**
+         * Block ENABLING surcharges while no valid surcharge tax treatment
+         * is selected (server-side — the treatment field has no default, so
+         * a never-configured shop posts the '' placeholder). Enforced on
+         * this field, not just the treatment field, because WooCommerce's
+         * per-field validation only skips the failing field: without this
+         * check a save could enable surcharges while the treatment error
+         * merely left the treatment unset. Disabling ('none') never needs a
+         * treatment.
+         */
+        public function validate_surcharge_type_field($key, $value)
+        {
+            $value = trim((string) $value);
+            if (
+                $value !== 'none' && $value !== ''
+                && !in_array(
+                    $this->get_sibling_field_save_value('surcharge_tax_treatment'),
+                    ['standard', 'custom_class', 'always_zero'],
+                    true
+                )
+            ) {
+                throw new Exception(__('Select a surcharge tax treatment before enabling surcharges.', 'twoinc-payment-gateway'));
+            }
+            return $value;
+        }
+
+        /**
          * Enforce that a saved surcharge tax treatment is one of the three
          * supported modes (WooCommerce's default select validation sanitises
-         * but does not enforce option-list membership).
+         * but does not enforce option-list membership). The '' placeholder
+         * is only storable while surcharges are (staying) disabled — with
+         * surcharges enabled a real treatment must be selected; there is no
+         * silent fall-back to Standard at save time.
          */
         public function validate_surcharge_tax_treatment_field($key, $value)
         {
             $value = trim((string) $value);
+            if ($value === '') {
+                $type = $this->get_sibling_field_save_value('surcharge_type');
+                if ($type !== 'none' && $type !== '') {
+                    throw new Exception(__('Select a surcharge tax treatment before enabling surcharges.', 'twoinc-payment-gateway'));
+                }
+                return '';
+            }
             if (!in_array($value, ['standard', 'custom_class', 'always_zero'], true)) {
                 throw new Exception(__('Surcharge tax treatment must be one of the offered modes.', 'twoinc-payment-gateway'));
             }
@@ -3183,11 +3237,23 @@ if (!class_exists('WC_Twoinc')) {
                     'desc_tip'    => true,
                     'type'        => 'select',
                     'options'     => [
+                        ''             => __('-- Select surcharge tax treatment --', 'twoinc-payment-gateway'),
                         'standard'     => __('Standard (store default tax rules)', 'twoinc-payment-gateway'),
                         'custom_class' => __('Specific tax class', 'twoinc-payment-gateway'),
                         'always_zero'  => __('Never taxed', 'twoinc-payment-gateway'),
                     ],
-                    'default'     => 'standard'
+                    // Deliberately NO pre-selected default (unified rule
+                    // across the WC/PS/Magento plugins): how a fee is taxed
+                    // must be an explicit merchant decision, so the field
+                    // starts on the placeholder until the merchant picks a
+                    // mode. This default only feeds get_option() for shops
+                    // that have NEVER saved this field — a persisted
+                    // settings-row value (including 'standard' accepted
+                    // under the old default) is returned as-is and is never
+                    // migrated or reset by this change. Save-time
+                    // enforcement lives in validate_surcharge_type_field /
+                    // validate_surcharge_tax_treatment_field.
+                    'default'     => ''
                 ],
                 'surcharge_tax_class' => [
                     'title'       => __('Surcharge Tax Class', 'twoinc-payment-gateway'),

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -854,9 +854,13 @@ if (!class_exists('WC_Twoinc')) {
             $post_data = $this->get_post_data();
             $field_key = $this->get_field_key($key);
             if (is_array($post_data) && array_key_exists($field_key, $post_data)) {
-                return trim((string) $post_data[$field_key]);
+                // Non-scalar values (e.g. a tampered field[]= submission)
+                // are meaningless for these scalar selects — treat as unset
+                // rather than tripping PHP's array-to-string warning.
+                return is_scalar($post_data[$field_key]) ? trim((string) $post_data[$field_key]) : '';
             }
-            return trim((string) $this->get_option($key));
+            $stored = $this->get_option($key);
+            return is_scalar($stored) ? trim((string) $stored) : '';
         }
 
         /**
@@ -871,7 +875,7 @@ if (!class_exists('WC_Twoinc')) {
          */
         public function validate_surcharge_type_field($key, $value)
         {
-            $value = trim((string) $value);
+            $value = is_scalar($value) ? trim((string) $value) : '';
             // Same enabled-set the runtime uses (get_surcharge_settings
             // coerces anything else to 'none'), so the gate matches what
             // will actually surcharge.
@@ -898,7 +902,7 @@ if (!class_exists('WC_Twoinc')) {
          */
         public function validate_surcharge_tax_treatment_field($key, $value)
         {
-            $value = trim((string) $value);
+            $value = is_scalar($value) ? trim((string) $value) : '';
             if ($value === '') {
                 $type = $this->get_sibling_field_save_value('surcharge_type');
                 if (in_array($type, ['percentage', 'fixed', 'fixed_and_percentage'], true)) {

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -196,6 +196,14 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
          * honest and lets the settings page surface the stale selection
          * (WC_Twoinc::init_form_fields carries the matching admin warning).
          *
+         * '' (the treatment field has no default and starts unselected)
+         * also degrades to 'standard' here: save-validation blocks enabling
+         * surcharges without a treatment, so an enabled-but-unset
+         * combination can only mean a shop that enabled surcharges before
+         * the treatment field existed (or a direct DB edit) — 'standard' is
+         * byte-for-byte the pre-feature fee behaviour those shops were
+         * already getting.
+         *
          * @return array{treatment: string, tax_class: string}
          */
         public static function resolve_surcharge_tax_treatment($gateway): array

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -327,6 +327,15 @@ class WC_Payment_Gateway
 
     public $plugin_id = 'woocommerce_';
 
+    // Mirrors WC_Settings_API::get_post_data (the submitted settings form),
+    // injectable per test for cross-field save validation.
+    public $test_post_data = [];
+
+    public function get_post_data()
+    {
+        return $this->test_post_data;
+    }
+
     public function get_option($key, $empty_value = null)
     {
         return $empty_value ?? '';

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -81,6 +81,7 @@ final class BrandConfigSpec
             'testSurchargeFeeAlwaysZeroNeverTaxed',
             'testSurchargeFeeCustomClassFallsBackWhenClassDeleted',
             'testSurchargeTaxSettingsValidationAndStaleNotice',
+            'testSurchargeTaxTreatmentRequiresExplicitSelection',
             'testPaymentTermsValidationRequiresSelection',
             'testDefaultTermCoercedToOfferedSet',
             'testOrderPayloadCarriesSelectedAndAvailableTerms',
@@ -1911,6 +1912,82 @@ final class BrandConfigSpec
             'surcharge_tax_class' => 'deleted-class',
         ]);
         TinyAssert::same('', $standard->get_surcharge_tax_class_stale_notice(), 'no notice outside custom_class mode');
+    }
+
+    private static function testSurchargeTaxTreatmentRequiresExplicitSelection(): void
+    {
+        $GLOBALS['__twoinc_test_tax_classes'] = ['B2B Levy'];
+
+        // Field definition: placeholder option first, NO pre-selected
+        // default — a never-configured shop starts unselected.
+        $gateway = self::surchargeFeeGateway([]);
+        $gateway->init_form_fields();
+        $field = $gateway->form_fields['surcharge_tax_treatment'];
+        TinyAssert::same('', $field['default'], 'treatment must not default to any mode');
+        TinyAssert::same(['', 'standard', 'custom_class', 'always_zero'], array_keys($field['options']));
+        TinyAssert::same('-- Select surcharge tax treatment --', $field['options']['']);
+
+        // The '' placeholder is storable while surcharges stay disabled.
+        $off = self::surchargeFeeGateway(['surcharge_type' => 'none']);
+        TinyAssert::same('', $off->validate_surcharge_tax_treatment_field('surcharge_tax_treatment', ''));
+
+        // ...but rejected when the SAME save enables surcharges (the
+        // posted sibling value wins over the stored one).
+        $off->test_post_data = [$off->get_field_key('surcharge_type') => 'percentage'];
+        $threw = false;
+        try {
+            $off->validate_surcharge_tax_treatment_field('surcharge_tax_treatment', '');
+        } catch (Exception $e) {
+            $threw = true;
+        }
+        TinyAssert::true($threw, 'empty treatment must be rejected while enabling surcharges');
+
+        // ...and when surcharges are already enabled in stored settings —
+        // no silent save-as-standard.
+        $on = self::surchargeFeeGateway(['surcharge_type' => 'fixed']);
+        $threw = false;
+        try {
+            $on->validate_surcharge_tax_treatment_field('surcharge_tax_treatment', '');
+        } catch (Exception $e) {
+            $threw = true;
+        }
+        TinyAssert::true($threw, 'empty treatment must be rejected while surcharges are enabled');
+
+        // ENABLING surcharges is itself blocked while no treatment is
+        // selected: WooCommerce's per-field validation only skips the
+        // failing field, so without this a save could still flip the type
+        // on while the treatment error merely left the treatment unset.
+        $fresh = self::surchargeFeeGateway([]);
+        $threw = false;
+        try {
+            $fresh->validate_surcharge_type_field('surcharge_type', 'percentage');
+        } catch (Exception $e) {
+            $threw = true;
+        }
+        TinyAssert::true($threw, 'enabling surcharges with no treatment must be blocked');
+
+        // Enabling and picking a treatment in the same save passes.
+        $fresh->test_post_data = [$fresh->get_field_key('surcharge_tax_treatment') => 'always_zero'];
+        TinyAssert::same('percentage', $fresh->validate_surcharge_type_field('surcharge_type', 'percentage'));
+
+        // Disabling never needs a treatment.
+        TinyAssert::same('none', self::surchargeFeeGateway([])->validate_surcharge_type_field('surcharge_type', 'none'));
+
+        // Persisted-value nuance: a merchant whose STORED treatment is
+        // 'standard' (accepted under the old default) is untouched — the
+        // value round-trips through save-validation and the runtime
+        // resolver reads it as-is.
+        $legacy = self::surchargeFeeGateway(['surcharge_type' => 'percentage', 'surcharge_tax_treatment' => 'standard']);
+        TinyAssert::same('standard', $legacy->validate_surcharge_tax_treatment_field('surcharge_tax_treatment', 'standard'));
+        TinyAssert::same('percentage', $legacy->validate_surcharge_type_field('surcharge_type', 'percentage'));
+        TinyAssert::same('standard', WC_Twoinc_Payment_Terms::resolve_surcharge_tax_treatment($legacy)['treatment']);
+
+        // A shop that enabled surcharges BEFORE the treatment field existed
+        // (enabled type, no stored treatment) keeps the pre-feature runtime
+        // behaviour: the resolver degrades '' to 'standard' — checkout is
+        // never blocked by the new admin rule.
+        $prefeature = self::surchargeFeeGateway(['surcharge_type' => 'percentage']);
+        TinyAssert::same('standard', WC_Twoinc_Payment_Terms::resolve_surcharge_tax_treatment($prefeature)['treatment']);
     }
 
     private static function testPaymentTermsValidationRequiresSelection(): void


### PR DESCRIPTION
## What

Removes the pre-selected `standard` default from the **Surcharge Tax Treatment** dropdown (unified never-auto-default rule across the WC/PS/Magento plugins, follow-up to #363):

- The field now starts on a `-- Select surcharge tax treatment --` placeholder with **no default** — the merchant must explicitly pick a mode.
- **Server-side save validation** blocks saving the placeholder while surcharges are enabled or being enabled. Enforced on BOTH fields (`surcharge_type` and `surcharge_tax_treatment`), because WooCommerce's per-field validation only skips the failing field — gating only the treatment field would still let the same save flip surcharges on. There is no silent save-as-standard.
- Cross-field checks read the **posted** sibling value (falling back to stored), so enabling surcharges and picking a treatment in the same save passes.

## Existing merchants are untouched

- Nothing writes, migrates, or resets persisted settings-row values. A merchant whose stored treatment is `standard` (accepted under the old default) keeps it — the default only feeds `get_option()` for shops that have **never** saved this field.
- Shops that enabled surcharges before the treatment field existed (settings row predates #363) render as unselected in admin, and the runtime resolver keeps degrading `''` → `standard` — byte-for-byte the pre-feature fee behaviour. Checkout is never affected by the new admin rule; only their next settings save asks them to pick a mode explicitly.

## Tests

New `testSurchargeTaxTreatmentRequiresExplicitSelection` covers: no-default field definition + placeholder, '' storable while disabled, rejection when enabling / already enabled (both fields), same-save enable+pick passing, disable never requiring a treatment, persisted-`standard` round-trip, and pre-feature-shop runtime degradation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)