### PR TITLE
TWO-25097/fix: fail loud on negative discount amounts

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -3597,18 +3597,39 @@ if (!class_exists('WC_Twoinc')) {
                 return false;
             }
 
-            $twoinc_order_hash = $order->get_meta(WC_Twoinc_Brand::meta_key('req_body_hash'));
-            $twoinc_updated_order_hash = WC_Twoinc_Helper::hash_order($order, $twoinc_meta);
-            $updated = true;
-            if (!$twoinc_order_hash || $twoinc_order_hash != $twoinc_updated_order_hash) {
-                $updated = $this->update_twoinc_order($order, $twoinc_meta);
-                if ($updated) {
-                    $order->update_meta_data(WC_Twoinc_Brand::meta_key('req_body_hash'), $twoinc_updated_order_hash);
-                    $order->save();
+            // Compose-time validation (e.g. the negative-discount guard,
+            // TWO-25097) throws to fail checkout loud. This path is fired
+            // from non-checkout hooks (admin order save, status
+            // transitions, fulfilment sync) — contain the failure to the
+            // Two sync: note + log it and abort the update, but do not
+            // crash the surrounding save/transition.
+            try {
+                $twoinc_order_hash = $order->get_meta(WC_Twoinc_Brand::meta_key('req_body_hash'));
+                $twoinc_updated_order_hash = WC_Twoinc_Helper::hash_order($order, $twoinc_meta);
+                $updated = true;
+                if (!$twoinc_order_hash || $twoinc_order_hash != $twoinc_updated_order_hash) {
+                    $updated = $this->update_twoinc_order($order, $twoinc_meta);
+                    if ($updated) {
+                        $order->update_meta_data(WC_Twoinc_Brand::meta_key('req_body_hash'), $twoinc_updated_order_hash);
+                        $order->save();
+                    }
+                    if ($forced_reload) {
+                        WC_Twoinc_Helper::append_admin_force_reload();
+                    }
                 }
-                if ($forced_reload) {
-                    WC_Twoinc_Helper::append_admin_force_reload();
+            } catch (Exception $e) {
+                $order->add_order_note(sprintf(
+                    __('Could not update the order with %s. Reason: %s', 'twoinc-payment-gateway'),
+                    WC_Twoinc_Brand::get('product_name'),
+                    $e->getMessage()
+                ));
+                if (function_exists('wc_get_logger')) {
+                    wc_get_logger()->error(
+                        'Order update sync failed for order ' . $order->get_id() . ': ' . $e->getMessage(),
+                        ['source' => 'twoinc-payment-gateway']
+                    );
                 }
+                return false;
             }
             return $updated;
         }

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -31,6 +31,58 @@ if (!class_exists('WC_Twoinc_Helper')) {
         }
 
         /**
+         * Round a computed discount once at the payload boundary and fail
+         * loud if it is genuinely negative (TWO-25097, mirrors the
+         * PrestaShop guard shipped in TWO-24741).
+         *
+         * The discount MUST be derived at native precision and rounded
+         * exactly once, here. Rounding the operands first (e.g. a 2dp unit
+         * price before differencing totals) manufactures phantom +/-0.01
+         * discounts whenever the operands round in opposite directions —
+         * the PrestaShop round-1 self-review finding. For the same reason
+         * the sign check runs on the once-rounded value: sub-cent float
+         * residue in the platform's native totals is not a data error and
+         * must not fail an otherwise healthy checkout.
+         *
+         * A genuinely negative discount is a data inconsistency from an
+         * upstream cart-rule/coupon bug. It is surfaced, never silently
+         * clamped to zero: the exception fails checkout loud instead of
+         * posting a bad payload to the Two API.
+         *
+         * @param float  $discount_amount discount at native precision
+         * @param string $context         diagnostic: surface, ids, operands
+         *
+         * @return string the once-rounded, non-negative discount amount
+         * @throws Exception when the rounded discount is negative
+         */
+        public static function guard_negative_discount($discount_amount, $context)
+        {
+            $rounded = WC_Twoinc_Helper::round_amt($discount_amount);
+            if ((float) $rounded < 0) {
+                if (function_exists('wc_get_logger')) {
+                    wc_get_logger()->error(
+                        'Negative discount amount calculated for ' . $context
+                            . ' (native ' . var_export($discount_amount, true)
+                            . ', rounded ' . $rounded . ')',
+                        ['source' => 'twoinc-payment-gateway']
+                    );
+                }
+                throw new Exception(
+                    sprintf(
+                        __('Negative discount amount calculated for %s.', 'twoinc-payment-gateway'),
+                        $context
+                    )
+                );
+            }
+            // Strip negative zero ("-0.00") left by sub-cent float residue
+            // so the payload always carries a plain non-negative amount.
+            if ((float) $rounded == 0.0) {
+                $rounded = WC_Twoinc_Helper::round_amt(0);
+            }
+            return $rounded;
+        }
+
+        /**
          * Get error message from twoinc response
          *
          * @param $response
@@ -269,12 +321,26 @@ if (!class_exists('WC_Twoinc_Helper')) {
                     $categories = wp_get_post_terms($product_simple->get_id(), 'product_cat');
                 }
 
+                // Derive the line discount at native precision; the guard
+                // rounds once at the payload boundary and fails loud on a
+                // genuinely negative discount (TWO-25097).
+                $discount_amount = WC_Twoinc_Helper::guard_negative_discount(
+                    $line_item['line_subtotal'] - $line_item['line_total'],
+                    sprintf(
+                        'product "%s" on order %s (line_subtotal %s - line_total %s)',
+                        $name,
+                        $order->get_id(),
+                        var_export($line_item['line_subtotal'], true),
+                        var_export($line_item['line_total'], true)
+                    )
+                );
+
                 $product = [
                     'name' => $name,
                     'description' => $description,
                     'gross_amount' => strval(WC_Twoinc_Helper::round_amt($line_item['line_total'] + $line_item['line_tax'])),
                     'net_amount' => strval(WC_Twoinc_Helper::round_amt($line_item['line_total'])),
-                    'discount_amount' => strval(WC_Twoinc_Helper::round_amt($line_item['line_subtotal'] - $line_item['line_total'])),
+                    'discount_amount' => $discount_amount,
                     'tax_amount' => strval(WC_Twoinc_Helper::round_amt($line_item['line_tax'])),
                     'tax_class_name' => $tax_rate['name'],
                     'tax_rate' => strval(WC_Twoinc_Helper::round_rate($tax_rate['rate'])),
@@ -626,7 +692,16 @@ if (!class_exists('WC_Twoinc_Helper')) {
                 'gross_amount' => strval(WC_Twoinc_Helper::round_amt($order->get_total())),
                 'net_amount' => strval(WC_Twoinc_Helper::round_amt($order->get_total() - $order->get_total_tax())),
                 'tax_amount' => strval(WC_Twoinc_Helper::round_amt($order->get_total_tax())),
-                'discount_amount' => strval(WC_Twoinc_Helper::round_amt($order->get_total_discount())),
+                // Native-precision total discount; guard rounds once at the
+                // payload boundary and fails loud on a negative (TWO-25097).
+                'discount_amount' => WC_Twoinc_Helper::guard_negative_discount(
+                    $order->get_total_discount(),
+                    sprintf(
+                        'order %s (total discount %s)',
+                        $order->get_id(),
+                        var_export($order->get_total_discount(), true)
+                    )
+                ),
                 'discount_rate' => '0',
                 'invoice_type' => 'FUNDED_INVOICE',
                 'invoice_details' => $invoice_details,
@@ -792,7 +867,16 @@ if (!class_exists('WC_Twoinc_Helper')) {
                 'gross_amount' => strval(WC_Twoinc_Helper::round_amt($order->get_total())),
                 'net_amount' => strval(WC_Twoinc_Helper::round_amt($order->get_total() - $order->get_total_tax())),
                 'tax_amount' => strval(WC_Twoinc_Helper::round_amt($order->get_total_tax())),
-                'discount_amount' => strval(WC_Twoinc_Helper::round_amt($order->get_total_discount())),
+                // Native-precision total discount; guard rounds once at the
+                // payload boundary and fails loud on a negative (TWO-25097).
+                'discount_amount' => WC_Twoinc_Helper::guard_negative_discount(
+                    $order->get_total_discount(),
+                    sprintf(
+                        'order %s (total discount %s)',
+                        $order->get_id(),
+                        var_export($order->get_total_discount(), true)
+                    )
+                ),
                 'discount_rate' => '0',
                 'invoice_type' => 'FUNDED_INVOICE',
                 'buyer_department' => $department,

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -50,18 +50,23 @@ if (!class_exists('WC_Twoinc_Helper')) {
          * posting a bad payload to the Two API.
          *
          * @param float  $discount_amount discount at native precision
-         * @param string $context         diagnostic: surface, ids, operands
+         * @param string $subject         short surface identifier for the
+         *                                exception (safe to surface to the
+         *                                shopper as a checkout notice)
+         * @param string $log_context     full diagnostic for the log only:
+         *                                ids and raw operands
          *
          * @return string the once-rounded, non-negative discount amount
          * @throws Exception when the rounded discount is negative
          */
-        public static function guard_negative_discount($discount_amount, $context)
+        public static function guard_negative_discount($discount_amount, $subject, $log_context)
         {
             $rounded = WC_Twoinc_Helper::round_amt($discount_amount);
             if ((float) $rounded < 0) {
                 if (function_exists('wc_get_logger')) {
                     wc_get_logger()->error(
-                        'Negative discount amount calculated for ' . $context
+                        'Negative discount amount calculated for ' . $subject
+                            . ': ' . $log_context
                             . ' (native ' . var_export($discount_amount, true)
                             . ', rounded ' . $rounded . ')',
                         ['source' => 'twoinc-payment-gateway']
@@ -70,7 +75,7 @@ if (!class_exists('WC_Twoinc_Helper')) {
                 throw new Exception(
                     sprintf(
                         __('Negative discount amount calculated for %s.', 'twoinc-payment-gateway'),
-                        $context
+                        $subject
                     )
                 );
             }
@@ -286,9 +291,15 @@ if (!class_exists('WC_Twoinc_Helper')) {
         /**
          * Compose the cart items
          *
+         * @param bool $is_refund true when composing a refund body: refund
+         *                        line items carry negated amounts, so the
+         *                        negative-discount guard does not apply
+         *                        (a refunded discounted line legitimately
+         *                        yields a negative subtotal-total diff).
+         *
          * @return array
          */
-        public static function get_line_items($line_items, $shippings, $fees, $order)
+        public static function get_line_items($line_items, $shippings, $fees, $order, $is_refund = false)
         {
 
             $items = [];
@@ -323,17 +334,23 @@ if (!class_exists('WC_Twoinc_Helper')) {
 
                 // Derive the line discount at native precision; the guard
                 // rounds once at the payload boundary and fails loud on a
-                // genuinely negative discount (TWO-25097).
-                $discount_amount = WC_Twoinc_Helper::guard_negative_discount(
-                    $line_item['line_subtotal'] - $line_item['line_total'],
-                    sprintf(
-                        'product "%s" on order %s (line_subtotal %s - line_total %s)',
-                        $name,
-                        $order->get_id(),
-                        var_export($line_item['line_subtotal'], true),
-                        var_export($line_item['line_total'], true)
-                    )
-                );
+                // genuinely negative discount (TWO-25097). Refund bodies
+                // carry negated line amounts, so the sign check is skipped
+                // there (legacy behaviour preserved).
+                if ($is_refund) {
+                    $discount_amount = WC_Twoinc_Helper::round_amt($line_item['line_subtotal'] - $line_item['line_total']);
+                } else {
+                    $discount_amount = WC_Twoinc_Helper::guard_negative_discount(
+                        $line_item['line_subtotal'] - $line_item['line_total'],
+                        sprintf('product "%s"', $name),
+                        sprintf(
+                            'order %s, line_subtotal %s - line_total %s',
+                            $order->get_id(),
+                            var_export($line_item['line_subtotal'], true),
+                            var_export($line_item['line_total'], true)
+                        )
+                    );
+                }
 
                 $product = [
                     'name' => $name,
@@ -696,11 +713,8 @@ if (!class_exists('WC_Twoinc_Helper')) {
                 // payload boundary and fails loud on a negative (TWO-25097).
                 'discount_amount' => WC_Twoinc_Helper::guard_negative_discount(
                     $order->get_total_discount(),
-                    sprintf(
-                        'order %s (total discount %s)',
-                        $order->get_id(),
-                        var_export($order->get_total_discount(), true)
-                    )
+                    sprintf('order %s', $order->get_id()),
+                    sprintf('total discount %s', var_export($order->get_total_discount(), true))
                 ),
                 'discount_rate' => '0',
                 'invoice_type' => 'FUNDED_INVOICE',
@@ -871,11 +885,8 @@ if (!class_exists('WC_Twoinc_Helper')) {
                 // payload boundary and fails loud on a negative (TWO-25097).
                 'discount_amount' => WC_Twoinc_Helper::guard_negative_discount(
                     $order->get_total_discount(),
-                    sprintf(
-                        'order %s (total discount %s)',
-                        $order->get_id(),
-                        var_export($order->get_total_discount(), true)
-                    )
+                    sprintf('order %s', $order->get_id()),
+                    sprintf('total discount %s', var_export($order->get_total_discount(), true))
                 ),
                 'discount_rate' => '0',
                 'invoice_type' => 'FUNDED_INVOICE',
@@ -933,7 +944,7 @@ if (!class_exists('WC_Twoinc_Helper')) {
             $req_body = [
                 'amount' => strval(WC_Twoinc_Helper::round_amt($amount)),
                 'currency' => $currency,
-                'line_items' => WC_Twoinc_Helper::get_line_items($order_refund->get_items(), $order_refund->get_items('shipping'), $order_refund->get_items('fee'), $order_refund)
+                'line_items' => WC_Twoinc_Helper::get_line_items($order_refund->get_items(), $order_refund->get_items('shipping'), $order_refund->get_items('fee'), $order_refund, true)
             ];
 
             return $req_body;

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -362,10 +362,69 @@ class WC_HTTPS
 
 // ── Order stub for compose_twoinc_order ─────────────────────────────
 
+/**
+ * Product line item stub: WC_Order_Item_Product is ArrayAccess-backed,
+ * and get_line_items() reads it both ways (['line_subtotal'] and
+ * ->get_taxes()). Only what the exercised code paths touch is stubbed.
+ */
+class StubProductLineItem implements ArrayAccess
+{
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = array_merge(
+            ['line_tax' => 0.0, 'quantity' => 1, 'data' => null],
+            $data
+        );
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetExists($offset)
+    {
+        return isset($this->data[$offset]);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+        return $this->data[$offset] ?? null;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetSet($offset, $value)
+    {
+        $this->data[$offset] = $value;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($offset)
+    {
+        unset($this->data[$offset]);
+    }
+
+    public function get_name()
+    {
+        return $this->data['name'] ?? 'Stub product';
+    }
+
+    public function get_taxes()
+    {
+        return ['total' => []];
+    }
+}
+
 class StubOrder
 {
     // Meta store mirroring WC_Order::get_meta single-value behaviour.
     public $meta = [];
+
+    public function get_item_subtotal($item, $inc_tax = false, $round = true)
+    {
+        $qty = max(1, (int) $item['quantity']);
+        $subtotal = $item['line_subtotal'] / $qty;
+        return $round ? round($subtotal, 2) : $subtotal;
+    }
 
     public function get_meta($key, $single = true)
     {

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -117,6 +117,7 @@ final class BrandConfigSpec
             'testNegativeDiscountGuardThrowsOnNegativeLineDiscount',
             'testNegativeDiscountGuardThrowsOnNegativeOrderDiscount',
             'testNegativeDiscountGuardNoFalsePositiveFromEarlyRounding',
+            'testNegativeDiscountGuardSkipsRefundLineItems',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -2744,6 +2745,19 @@ final class BrandConfigSpec
         // Order-level surface: zero discount composes as plain '0.00'.
         $body = self::composeOrder();
         TinyAssert::same('0.00', $body['discount_amount']);
+
+        // Order-level surface: a positive total discount passes untouched
+        // through both compose bodies.
+        $order = new class extends StubOrder {
+            public function get_total_discount()
+            {
+                return 12.5;
+            }
+        };
+        $body = WC_Twoinc_Helper::compose_twoinc_order($order, 'test-order-reference', '912345678', 'IT', 'Project X', '', []);
+        TinyAssert::same('12.50', $body['discount_amount']);
+        $body = WC_Twoinc_Helper::compose_twoinc_edit_order($order, 'IT', 'Project X', '', '');
+        TinyAssert::same('12.50', $body['discount_amount']);
     }
 
     private static function testNegativeDiscountGuardThrowsOnNegativeLineDiscount(): void
@@ -2839,6 +2853,25 @@ final class BrandConfigSpec
         };
         $body = WC_Twoinc_Helper::compose_twoinc_order($order, 'test-order-reference', '912345678', 'IT', 'Project X', '', []);
         TinyAssert::same('0.00', $body['discount_amount']);
+    }
+
+    private static function testNegativeDiscountGuardSkipsRefundLineItems(): void
+    {
+        // Refund bodies carry NEGATED line amounts: refunding a discounted
+        // line gives e.g. -100 - (-90) = -10, a legitimately negative
+        // discount diff. The guard must not fire there — refund behaviour
+        // is unchanged (compose_twoinc_refund passes is_refund = true).
+        $line_item = new StubProductLineItem([
+            'name' => 'Refunded widget',
+            'line_subtotal' => -100.0,
+            'line_total' => -90.0,
+            'line_tax' => -22.5,
+        ]);
+
+        $items = WC_Twoinc_Helper::get_line_items([$line_item], [], [], new StubOrder(), true);
+
+        TinyAssert::same(1, count($items));
+        TinyAssert::same('-10.00', $items[0]['discount_amount']);
     }
 }
 

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -113,6 +113,10 @@ final class BrandConfigSpec
             'testInvoiceDownloadNonceScopedToOrderAndVariant',
             'testInvoiceDownloadNoticeIsolatedPerOrder',
             'testInvoiceStreamFilenameSanitizesOrderId',
+            'testNegativeDiscountGuardPassesLegitimateDiscount',
+            'testNegativeDiscountGuardThrowsOnNegativeLineDiscount',
+            'testNegativeDiscountGuardThrowsOnNegativeOrderDiscount',
+            'testNegativeDiscountGuardNoFalsePositiveFromEarlyRounding',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -2716,6 +2720,125 @@ final class BrandConfigSpec
         // outside [A-Za-z0-9_-] must be stripped.
         TinyAssert::true(strpos($result['filename'], 'abcdefpdf.pdf') !== false);
         TinyAssert::same(false, strpbrk($result['filename'], '";/ ') !== false, 'filename must not carry quote/semicolon/slash/space');
+    }
+
+    // ── Negative-discount guard (TWO-25097) ─────────────────────────
+
+    private static function testNegativeDiscountGuardPassesLegitimateDiscount(): void
+    {
+        // (a) A legitimate positive discount passes through untouched.
+        $line_item = new StubProductLineItem([
+            'name' => 'Discounted widget',
+            'line_subtotal' => 100.0,
+            'line_total' => 90.0,
+            'line_tax' => 22.5,
+            'quantity' => 2,
+        ]);
+
+        $items = WC_Twoinc_Helper::get_line_items([$line_item], [], [], new StubOrder());
+
+        TinyAssert::same(1, count($items));
+        TinyAssert::same('10.00', $items[0]['discount_amount']);
+        TinyAssert::same('90.00', $items[0]['net_amount']);
+
+        // Order-level surface: zero discount composes as plain '0.00'.
+        $body = self::composeOrder();
+        TinyAssert::same('0.00', $body['discount_amount']);
+    }
+
+    private static function testNegativeDiscountGuardThrowsOnNegativeLineDiscount(): void
+    {
+        // (b) A genuinely negative line discount fails loud with a clear
+        // message — never silently clamped to zero.
+        $line_item = new StubProductLineItem([
+            'name' => 'Broken widget',
+            'line_subtotal' => 90.0,
+            'line_total' => 100.0,
+        ]);
+
+        $thrown = null;
+        try {
+            WC_Twoinc_Helper::get_line_items([$line_item], [], [], new StubOrder());
+        } catch (Exception $e) {
+            $thrown = $e;
+        }
+
+        TinyAssert::true($thrown instanceof Exception, 'negative line discount must throw');
+        TinyAssert::true(
+            strpos($thrown->getMessage(), 'Negative discount amount calculated') !== false,
+            'exception must name the negative-discount failure'
+        );
+        TinyAssert::true(
+            strpos($thrown->getMessage(), 'Broken widget') !== false,
+            'exception must identify the offending product'
+        );
+    }
+
+    private static function testNegativeDiscountGuardThrowsOnNegativeOrderDiscount(): void
+    {
+        // (b) Order-level surfaces: both compose bodies guard
+        // get_total_discount().
+        $order = new class extends StubOrder {
+            public function get_total_discount()
+            {
+                return -5.0;
+            }
+        };
+
+        $thrown = null;
+        try {
+            WC_Twoinc_Helper::compose_twoinc_order($order, 'test-order-reference', '912345678', 'IT', 'Project X', '', []);
+        } catch (Exception $e) {
+            $thrown = $e;
+        }
+        TinyAssert::true($thrown instanceof Exception, 'negative order discount must fail order create');
+        TinyAssert::true(
+            strpos($thrown->getMessage(), 'Negative discount amount calculated') !== false,
+            'create exception must name the negative-discount failure'
+        );
+
+        $thrown = null;
+        try {
+            WC_Twoinc_Helper::compose_twoinc_edit_order($order, 'IT', 'Project X', '', '');
+        } catch (Exception $e) {
+            $thrown = $e;
+        }
+        TinyAssert::true($thrown instanceof Exception, 'negative order discount must fail order edit');
+    }
+
+    private static function testNegativeDiscountGuardNoFalsePositiveFromEarlyRounding(): void
+    {
+        // (c) Rounding-order regression (the PrestaShop TWO-24741 round-1
+        // finding): a native-precision difference that only goes negative
+        // if the operands are rounded early must NOT false-positive.
+        //
+        // 25.024 - 25.026 = -0.002 at native precision, which rounds to
+        // zero at the payload boundary. Rounding the operands first gives
+        // 25.02 - 25.03 = -0.01, a phantom negative that would fire the
+        // fail-loud throw on a legitimate cart.
+        $line_item = new StubProductLineItem([
+            'name' => 'Residue widget',
+            'line_subtotal' => 25.024,
+            'line_total' => 25.026,
+        ]);
+
+        $items = WC_Twoinc_Helper::get_line_items([$line_item], [], [], new StubOrder());
+
+        TinyAssert::same(1, count($items));
+        // Once-rounded sub-cent residue is zero — and plain '0.00', never
+        // a negative-zero '-0.00' artefact in the payload.
+        TinyAssert::same('0.00', $items[0]['discount_amount']);
+
+        // Same shape at the order level: sub-cent float residue in
+        // get_total_discount() must not fail checkout.
+        $order = new class extends StubOrder {
+            public function get_total_discount()
+            {
+                return -0.002;
+            }
+        };
+        $body = WC_Twoinc_Helper::compose_twoinc_order($order, 'test-order-reference', '912345678', 'IT', 'Project X', '', []);
+        TinyAssert::same('0.00', $body['discount_amount']);
     }
 }
 


### PR DESCRIPTION
## Summary

A negative line/order discount could reach the Two API silently — no sign check existed on any discount surface. This adds a fail-loud guard at all three discount surfaces in `class/WC_Twoinc_Helper.php`, mirroring the PrestaShop guard shipped under TWO-24741:

- **Per-line discount** in `get_line_items()` (`line_subtotal - line_total`)
- **Order-level discount** in `compose_twoinc_order()` (`get_total_discount()`)
- **Order-level discount** in `compose_twoinc_edit_order()` (same surface, edit PUT body)

New helper `guard_negative_discount()`: derives the discount at **native precision**, rounds **once** at the payload boundary, and on a genuinely negative value logs a diagnostic (surface, ids, operands) and throws — checkout fails loud, never silently clamps to 0.

## Rounding-order gotcha (from the PS round-1 self-review)

The sign check runs on the once-rounded value, never on early-rounded operands: rounding operands to 2dp before differencing manufactures phantom ±0.01 discounts and would fire the throw on legitimate carts. Sub-cent float residue in native totals rounds to zero and passes; negative-zero `-0.00` residue is normalised to `0.00` in the payload.

## Tests

Unit tests (custom runner, `make test-unit`) covering the ticket's (a)/(b)/(c):

- (a) legitimate positive discount passes through untouched (line + order surfaces)
- (b) genuinely negative discount throws with a clear message naming the product/order (all three surfaces)
- (c) rounding-order regression: `25.024 - 25.026` (native −0.002, early-rounded −0.01) does NOT false-positive and emits plain `0.00`

Test scaffolding: `StubProductLineItem` (ArrayAccess + `get_taxes()`, matching how `get_line_items()` reads WC_Order_Item_Product both ways) and `StubOrder::get_item_subtotal()`.

Ticket: [TWO-25097](https://linear.app/two-inc/issue/TWO-25097)

🤖 Generated with [Claude Code](https://claude.com/claude-code)