### PR TITLE
TWO-25104: FX conversion layer on /refdata/v1/fx-rates

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -2287,26 +2287,36 @@ if (!class_exists('WC_Twoinc')) {
             $basket_is_judgeable = !WC()->cart->is_empty()
                 && !(function_exists('is_wc_endpoint_url') && is_wc_endpoint_url('order-pay'));
 
+            // A basket in another currency is judged by converting its
+            // value into the minimum's currency via the Two FX layer
+            // (TWO-25104): last-known-good rates, so a transient rates-API
+            // failure never flaps the gateway. Null (no rate ever fetched,
+            // or an unsupported currency) fails CLOSED — a basket that
+            // cannot be proven to satisfy a minimum is not offered the
+            // gateway; the API still enforces the platform minimum at
+            // order creation. Same-currency baskets never touch the FX
+            // layer.
+            $meets_minimum = function (array $minimum) use ($basket_value): bool {
+                $value = $basket_value($minimum['basis']);
+                $basket_currency = get_woocommerce_currency();
+                if ($basket_currency !== $minimum['currency']) {
+                    $value = WC_Twoinc_FX::convert($this, $value, $basket_currency, $minimum['currency']);
+                    if ($value === null) {
+                        return false;
+                    }
+                }
+                return $value >= $minimum['amount'];
+            };
+
             $satisfied = true;
             if ($platform_minimum && $basket_is_judgeable) {
-                // Fail closed on a basket in another currency: with no FX
-                // source in WooCommerce it cannot be proven to satisfy the
-                // funding partner's minimum.
-                $satisfied = get_woocommerce_currency() === $platform_minimum['currency']
-                    && $basket_value($platform_minimum['basis']) >= $platform_minimum['amount'];
+                $satisfied = $meets_minimum($platform_minimum);
             }
             if ($satisfied && $gate) {
                 $satisfied = in_array(WC()->customer->get_billing_country(), $gate['billing_countries'], true);
             }
             if ($satisfied && $merchant_minimum && $basket_is_judgeable) {
-                $satisfied = get_woocommerce_currency() === $merchant_minimum['currency']
-                    ? $basket_value($merchant_minimum['basis']) >= $merchant_minimum['amount']
-                    // The merchant minimum is store-currency scoped; a
-                    // basket in another currency cannot be judged against
-                    // it (no FX source in WooCommerce) — fail open on the
-                    // merchant's own optional bar, the platform minimum
-                    // above still applies.
-                    : $satisfied;
+                $satisfied = $meets_minimum($merchant_minimum);
             }
             if (!$satisfied) {
                 unset($available_gateways[$this->id]);
@@ -2343,9 +2353,10 @@ if (!class_exists('WC_Twoinc')) {
          * Dynamic description for the Minimum Order Value setting: shows
          * the platform minimum the merchant's value must exceed. The
          * field is interpreted in the STORE currency; when that differs
-         * from the platform minimum's currency the floor is shown in its
-         * native currency only — WooCommerce has no FX rate source until
-         * TWO-24776, so no converted figure can honestly be displayed.
+         * from the platform minimum's currency an approximate store-
+         * currency figure converted via the Two FX layer is appended
+         * (display conversion — fail soft: without a rate the floor is
+         * shown in its native currency only).
          *
          * @return string
          */
@@ -2362,6 +2373,20 @@ if (!class_exists('WC_Twoinc')) {
                     return sprintf(
                         __('Platform minimum %1$s, %2$s tax. A value here is interpreted in the store currency on the tax basis selected below and must exceed it.', 'twoinc-payment-gateway'),
                         $native_display,
+                        $basis_label
+                    );
+                }
+                $converted = WC_Twoinc_FX::convert(
+                    $this,
+                    (float) $platform_minimum['amount'],
+                    (string) $platform_minimum['currency'],
+                    strval(get_option('woocommerce_currency'))
+                );
+                if ($converted !== null) {
+                    return sprintf(
+                        __('Platform minimum %1$s (approximately %2$s at the current exchange rate), %3$s tax. A value here is interpreted in the store currency on the tax basis selected below — both minimums are enforced independently.', 'twoinc-payment-gateway'),
+                        $native_display,
+                        get_woocommerce_currency_symbol(get_option('woocommerce_currency')) . number_format($converted, 2),
                         $basis_label
                     );
                 }
@@ -2406,10 +2431,11 @@ if (!class_exists('WC_Twoinc')) {
          * Validate the merchant minimum on settings save: numeric and
          * non-negative always; strictly above the platform minimum when
          * the brand declares one IN THE STORE CURRENCY. A platform
-         * minimum in another currency cannot be compared (no FX source
-         * in WooCommerce until TWO-24776) — the numeric floor check is
-         * skipped and both minimums are enforced independently at
-         * checkout.
+         * minimum in another currency is deliberately not floor-checked
+         * even though an FX rate may be available (TWO-25104): a save
+         * that is valid one day would fail the next as rates drift, so
+         * both minimums are enforced independently at checkout instead
+         * (the availability gate converts there).
          *
          * @param string $key
          * @param string $value
@@ -3863,6 +3889,12 @@ if (!class_exists('WC_Twoinc')) {
          */
         public function on_deactivate_plugin()
         {
+            // The recurring FX refresh must not keep firing (listener-less)
+            // while the plugin is deactivated; it is re-registered on init
+            // when the plugin comes back (WC_Twoinc_FX::maybe_schedule_refresh).
+            if (class_exists('WC_Twoinc_FX') && function_exists('as_unschedule_all_actions')) {
+                as_unschedule_all_actions(WC_Twoinc_FX::refresh_hook());
+            }
             if ($this->get_option('clear_options_on_deactivation') === 'yes') {
                 delete_option('woocommerce_' . $this->id . '_settings');
                 // The merchant-record caches (terms, days-on-invoice,
@@ -3870,6 +3902,9 @@ if (!class_exists('WC_Twoinc')) {
                 // dedicated wp_options — clear them too, or "clear options
                 // on deactivation" leaves orphaned rows behind.
                 $this->invalidate_merchant_record_caches();
+                if (class_exists('WC_Twoinc_FX')) {
+                    WC_Twoinc_FX::purge();
+                }
             }
         }
 

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -2384,6 +2384,7 @@ if (!class_exists('WC_Twoinc')) {
                 );
                 if ($converted !== null) {
                     return sprintf(
+                        /* translators: 1: platform minimum in its native currency, e.g. "EUR 250.00", 2: the same minimum converted into the store currency at the current FX rate, e.g. "NOK 2,941.18", 3: tax basis label, "including" or "excluding" */
                         __('Platform minimum %1$s (approximately %2$s at the current exchange rate), %3$s tax. A value here is interpreted in the store currency on the tax basis selected below — both minimums are enforced independently.', 'twoinc-payment-gateway'),
                         $native_display,
                         get_woocommerce_currency_symbol(get_option('woocommerce_currency')) . number_format($converted, 2),

--- a/class/WC_Twoinc_FX.php
+++ b/class/WC_Twoinc_FX.php
@@ -15,19 +15,29 @@
  *
  * Cache model (three layers):
  *  - Request memo: one table read/parse per PHP request.
- *  - Freshness transient (6h): while present, the stored table is trusted
- *    and no HTTP happens. A recurring Action Scheduler job re-fetches on
- *    the same cadence so checkout traffic normally never pays for a fetch.
+ *  - Freshness transient (6h + a grace margin): while present, the stored
+ *    table is trusted and no HTTP happens. A recurring Action Scheduler job
+ *    re-fetches on the 6h cadence; the grace margin absorbs Action
+ *    Scheduler's best-effort timing (it runs on traffic/cron, not a
+ *    guaranteed clock) so a late job normally still beats the transient's
+ *    expiry and checkout traffic never pays for a fetch.
  *  - Last-known-good option (durable, non-autoloaded): survives transient
  *    expiry and fetch failures. Rates move a few times a day at most, so a
  *    stale table is a far better basis for a gate decision than no table.
+ *    Values are re-validated on every read (not just on fetch): a table can
+ *    reach wp_options via a route other than fetch_table (a DB import, an
+ *    older/newer plugin version, manual editing) and a poisoned entry must
+ *    not reach the division in get_rate().
  *
- * On-demand path: a checkout in a currency the cached table does not carry
- * triggers one synchronous re-fetch (tight timeout) — the endpoint returns
- * the full table, so a successful fetch caches every currency at once, and
- * a currency still absent afterwards is genuinely unsupported. A failed
- * fetch arms a short retry-throttle transient so a flapping API cannot be
- * hammered once per conversion.
+ * On-demand path: a checkout in a currency the FRESH cached table does not
+ * carry triggers one synchronous re-fetch (tight timeout) — a fresh table
+ * is, by construction, the endpoint's complete table, so a currency absent
+ * from it is conclusively unsupported and re-fetching would only repeat
+ * that same conclusion on every request (an unbounded fetch loop, not a
+ * cache). A STALE table's absence is inconclusive (a fresher table might
+ * carry the currency), so that case still re-fetches. A failed fetch arms
+ * a short retry-throttle transient so a flapping API cannot be hammered
+ * once per conversion.
  *
  * Fail semantics (per TWO-25104):
  *  - Gate conversions (minimum-order availability) use last-known-good and
@@ -46,8 +56,18 @@
 if (!class_exists('WC_Twoinc_FX')) {
     class WC_Twoinc_FX
     {
-        /** Background refresh cadence and freshness window (seconds). */
+        /** Background refresh cadence (seconds). */
         public const REFRESH_INTERVAL = 6 * 3600;
+
+        /**
+         * Extra slack added to the freshness transient beyond
+         * REFRESH_INTERVAL. Action Scheduler is best-effort (it runs on
+         * traffic/WP-cron, not a guaranteed clock), so the transient must
+         * outlive the nominal interval or checkout traffic pays for a
+         * fetch every cycle at the boundary, right when the previous
+         * fetch is due anyway.
+         */
+        public const FRESHNESS_GRACE = 3600;
 
         /** Retry throttle after a failed fetch (seconds). */
         public const FAILURE_RETRY_WINDOW = 300;
@@ -116,12 +136,20 @@ if (!class_exists('WC_Twoinc_FX')) {
                 $scheduled = as_next_scheduled_action(self::refresh_hook()) !== false;
             }
             if (!$scheduled) {
+                // $unique = true: two concurrent requests in the cold
+                // state (first install, or right after a
+                // deactivate/reactivate cleared the job) both observe
+                // "not scheduled" — the has-scheduled-action check above
+                // is not atomic with the schedule call. Without $unique
+                // both would schedule, and a duplicate recurring series
+                // self-perpetuates forever.
                 as_schedule_recurring_action(
                     time() + self::REFRESH_INTERVAL,
                     self::REFRESH_INTERVAL,
                     self::refresh_hook(),
                     [],
-                    'twoinc-payment-gateway'
+                    'twoinc-payment-gateway',
+                    true
                 );
             }
         }
@@ -154,7 +182,7 @@ if (!class_exists('WC_Twoinc_FX')) {
                 return false;
             }
             update_option(self::option_key(), wp_json_encode($table), false);
-            set_transient(self::fresh_transient_key(), $table['fetched_at'], self::REFRESH_INTERVAL);
+            set_transient(self::fresh_transient_key(), $table['fetched_at'], self::REFRESH_INTERVAL + self::FRESHNESS_GRACE);
             delete_transient(self::retry_transient_key());
             self::$table_memo = $table;
             return true;
@@ -179,24 +207,43 @@ if (!class_exists('WC_Twoinc_FX')) {
                 return null;
             }
             $body = json_decode(wp_remote_retrieve_body($response), true);
-            if (!is_array($body) || !isset($body['base'], $body['rates']) || !is_array($body['rates'])) {
+            if (!is_array($body) || !isset($body['base'], $body['rates']) || !is_array($body['rates']) || !is_string($body['base'])) {
                 return null;
             }
-            $rates = [];
-            foreach ($body['rates'] as $currency => $rate) {
-                if (is_string($currency) && $currency !== '' && is_numeric($rate) && (float) $rate > 0) {
-                    $rates[strtoupper($currency)] = (float) $rate;
-                }
-            }
-            if (count($rates) === 0) {
+            $rates = self::sanitize_rates($body['rates']);
+            if ($rates === null) {
                 return null;
             }
             return [
-                'base' => strtoupper(strval($body['base'])),
+                'base' => strtoupper($body['base']),
                 'rates' => $rates,
                 'as_of' => isset($body['as_of']) && is_string($body['as_of']) ? $body['as_of'] : null,
                 'fetched_at' => time(),
             ];
+        }
+
+        /**
+         * Filter a raw rates map down to positive-numeric entries keyed by
+         * uppercase currency code, or null when nothing usable remains.
+         * Shared by the fetch path and the stored-table read path: a
+         * table can reach wp_options by a route other than fetch_table
+         * (a DB import, a different plugin version's shape, manual
+         * editing), so a poisoned entry (zero, negative, non-numeric)
+         * must be caught on every read, not only at fetch time — a stray
+         * zero or string reaching the division in get_rate() is a fatal,
+         * not a bad conversion.
+         *
+         * @return array<string, float>|null
+         */
+        private static function sanitize_rates(array $raw): ?array
+        {
+            $rates = [];
+            foreach ($raw as $currency => $rate) {
+                if (is_string($currency) && $currency !== '' && is_numeric($rate) && (float) $rate > 0) {
+                    $rates[strtoupper($currency)] = (float) $rate;
+                }
+            }
+            return count($rates) > 0 ? $rates : null;
         }
 
         /**
@@ -213,7 +260,16 @@ if (!class_exists('WC_Twoinc_FX')) {
                 return self::$table_memo;
             }
             $stored = self::read_stored_table();
-            $fresh = get_transient(self::fresh_transient_key()) !== false;
+            // The transient is the primary freshness signal, but an
+            // object cache (Redis/memcached) can evict it under memory
+            // pressure well before its TTL — typically the first thing to
+            // go, often right when the site is busiest. Falling back to
+            // the durable fetched_at (stored in the same DB row as the
+            // table) means an eviction degrades to "one extra freshness
+            // check", not "every request re-fetches".
+            $fresh = get_transient(self::fresh_transient_key()) !== false
+                || ($stored !== null && isset($stored['fetched_at'])
+                    && (time() - (int) $stored['fetched_at']) < (self::REFRESH_INTERVAL + self::FRESHNESS_GRACE));
             if ($stored !== null && $fresh) {
                 return self::$table_memo = $stored;
             }
@@ -239,9 +295,15 @@ if (!class_exists('WC_Twoinc_FX')) {
                 return null;
             }
             $table = json_decode($raw, true);
-            if (!is_array($table) || !isset($table['base'], $table['rates']) || !is_array($table['rates']) || count($table['rates']) === 0) {
+            if (!is_array($table) || !isset($table['base'], $table['rates']) || !is_array($table['rates']) || !is_string($table['base'])) {
                 return null;
             }
+            $rates = self::sanitize_rates($table['rates']);
+            if ($rates === null) {
+                return null;
+            }
+            $table['rates'] = $rates;
+            $table['base'] = strtoupper($table['base']);
             return $table;
         }
 
@@ -288,10 +350,17 @@ if (!class_exists('WC_Twoinc_FX')) {
             if (($from_value === null || $to_value === null)
                 && $gateway
                 && !self::$fetched_this_request
+                && !self::is_fresh($table)
                 && get_transient(self::retry_transient_key()) === false
             ) {
-                // Uncached currency at checkout: one live re-fetch, then
-                // re-resolve from whatever table that produced.
+                // Uncached currency, but the table we have is STALE: it
+                // may not be the endpoint's current full table, so one
+                // live re-fetch is worth it before concluding the
+                // currency is unsupported. A currency missing from a
+                // FRESH table is conclusive — the endpoint always returns
+                // its complete table, so re-fetching would only repeat
+                // the same "still absent" result on every request (an
+                // unbounded synchronous-fetch loop, not a cache).
                 self::refresh($gateway);
                 $table = self::get_table($gateway);
                 if ($table === null) {
@@ -304,6 +373,16 @@ if (!class_exists('WC_Twoinc_FX')) {
                 return null;
             }
             return $from_value / $to_value;
+        }
+
+        /**
+         * Whether $table is within the freshness window by either signal
+         * (transient or durable fetched_at — see get_table()).
+         */
+        private static function is_fresh(array $table): bool
+        {
+            return get_transient(self::fresh_transient_key()) !== false
+                || (isset($table['fetched_at']) && (time() - (int) $table['fetched_at']) < (self::REFRESH_INTERVAL + self::FRESHNESS_GRACE));
         }
 
         /**

--- a/class/WC_Twoinc_FX.php
+++ b/class/WC_Twoinc_FX.php
@@ -1,0 +1,352 @@
+<?php
+
+/**
+ * FX conversion layer over GET /refdata/v1/fx-rates (TWO-25104).
+ *
+ * WooCommerce has no native exchange-rate table (the parity gap vs Magento,
+ * whose plugin reads the store's own rates). This class is the single FX
+ * source for the plugin: it fetches Two's EUR-pivot spot table from the
+ * checkout API with the merchant's API key (server-side only — the key and
+ * the rates never reach browser JS), caches it, and computes cross rates
+ * exactly as the endpoint does (rate = eur_value(from) / eur_value(to)).
+ * Converting with the same table Two uses server-side keeps plugin-side
+ * figures (fixed surcharge, surcharge cap, minimum-order gates) consistent
+ * with what the API will compute at order time.
+ *
+ * Cache model (three layers):
+ *  - Request memo: one table read/parse per PHP request.
+ *  - Freshness transient (6h): while present, the stored table is trusted
+ *    and no HTTP happens. A recurring Action Scheduler job re-fetches on
+ *    the same cadence so checkout traffic normally never pays for a fetch.
+ *  - Last-known-good option (durable, non-autoloaded): survives transient
+ *    expiry and fetch failures. Rates move a few times a day at most, so a
+ *    stale table is a far better basis for a gate decision than no table.
+ *
+ * On-demand path: a checkout in a currency the cached table does not carry
+ * triggers one synchronous re-fetch (tight timeout) — the endpoint returns
+ * the full table, so a successful fetch caches every currency at once, and
+ * a currency still absent afterwards is genuinely unsupported. A failed
+ * fetch arms a short retry-throttle transient so a flapping API cannot be
+ * hammered once per conversion.
+ *
+ * Fail semantics (per TWO-25104):
+ *  - Gate conversions (minimum-order availability) use last-known-good and
+ *    fail CLOSED only when no table has ever been fetched: get_rate()
+ *    returns null and the caller must treat null as "cannot be proven".
+ *  - Display conversions fail SOFT: callers fall back to the native value.
+ *  - Charge conversions (fixed surcharge/cap) fail SOFT to *no* surcharge:
+ *    a wrong-currency amount must never be sent to the pricing API.
+ *
+ * The response's as_of date (the staleness floor of the rates used) is
+ * stored alongside the table for observability and tests; freshness is
+ * governed by fetch time, matching the endpoint's guidance that plugins
+ * keep their own ~6h cache over its short Cache-Control window.
+ */
+
+if (!class_exists('WC_Twoinc_FX')) {
+    class WC_Twoinc_FX
+    {
+        /** Background refresh cadence and freshness window (seconds). */
+        public const REFRESH_INTERVAL = 6 * 3600;
+
+        /** Retry throttle after a failed fetch (seconds). */
+        public const FAILURE_RETRY_WINDOW = 300;
+
+        /**
+         * Timeout for the on-demand fetch on the checkout path. The gate
+         * and fee-quote paths must not stall checkout on a slow refdata
+         * call; the background job re-fetches on its own schedule.
+         */
+        public const FETCH_TIMEOUT = 5;
+
+        /** @var array|null request-scoped memo of the stored table */
+        private static $table_memo = null;
+
+        /** @var bool one live fetch attempt per request at most */
+        private static $fetched_this_request = false;
+
+        /**
+         * The brand-prefixed option key holding the last-known-good table:
+         * ['base' => 'EUR', 'rates' => [CCY => float], 'as_of' => 'Y-m-d'|null,
+         *  'fetched_at' => int].
+         */
+        public static function option_key(): string
+        {
+            return WC_Twoinc_Brand::prefixed_name('fx_rates');
+        }
+
+        /** The brand-prefixed transient key marking the table fresh. */
+        public static function fresh_transient_key(): string
+        {
+            return WC_Twoinc_Brand::prefixed_name('fx_rates_fresh');
+        }
+
+        /** The brand-prefixed transient key throttling failed-fetch retries. */
+        public static function retry_transient_key(): string
+        {
+            return WC_Twoinc_Brand::prefixed_name('fx_rates_retry_after');
+        }
+
+        /**
+         * The brand-prefixed recurring-refresh hook. Prefixed so a Two and
+         * a partner-brand plugin on the same site each refresh their own
+         * cache under their own merchant API key.
+         */
+        public static function refresh_hook(): string
+        {
+            return WC_Twoinc_Brand::prefixed_name('fx_refresh');
+        }
+
+        /**
+         * Register the recurring background refresh with WooCommerce's
+         * Action Scheduler (bundled with WC core). Hooked on init; a no-op
+         * when the job already exists or Action Scheduler is unavailable
+         * (e.g. unit tests) — the on-demand path still keeps the cache
+         * serviceable without it.
+         */
+        public static function maybe_schedule_refresh(): void
+        {
+            if (!function_exists('as_schedule_recurring_action')) {
+                return;
+            }
+            $scheduled = false;
+            if (function_exists('as_has_scheduled_action')) {
+                $scheduled = as_has_scheduled_action(self::refresh_hook());
+            } elseif (function_exists('as_next_scheduled_action')) {
+                $scheduled = as_next_scheduled_action(self::refresh_hook()) !== false;
+            }
+            if (!$scheduled) {
+                as_schedule_recurring_action(
+                    time() + self::REFRESH_INTERVAL,
+                    self::REFRESH_INTERVAL,
+                    self::refresh_hook(),
+                    [],
+                    'twoinc-payment-gateway'
+                );
+            }
+        }
+
+        /**
+         * The scheduled-refresh callback. Static and self-bootstrapping:
+         * Action Scheduler runs it outside any gateway context.
+         */
+        public static function run_scheduled_refresh(): void
+        {
+            $gateway = WC_Twoinc::get_instance();
+            if ($gateway) {
+                self::refresh($gateway);
+            }
+        }
+
+        /**
+         * Fetch the full spot table and store it as last-known-good.
+         * Success re-arms the 6h freshness window; failure keeps the
+         * previous table untouched and arms the retry throttle instead.
+         *
+         * @return bool whether a valid table was fetched and stored
+         */
+        public static function refresh($gateway): bool
+        {
+            self::$fetched_this_request = true;
+            $table = self::fetch_table($gateway);
+            if ($table === null) {
+                set_transient(self::retry_transient_key(), time(), self::FAILURE_RETRY_WINDOW);
+                return false;
+            }
+            update_option(self::option_key(), wp_json_encode($table), false);
+            set_transient(self::fresh_transient_key(), $table['fetched_at'], self::REFRESH_INTERVAL);
+            delete_transient(self::retry_transient_key());
+            self::$table_memo = $table;
+            return true;
+        }
+
+        /**
+         * One GET /refdata/v1/fx-rates call, parsed and validated, or null.
+         * The endpoint is merchant-API-key authed; make_request signs with
+         * the configured key. Only positive numeric rates are kept — a
+         * malformed entry is dropped rather than poisoning conversions.
+         *
+         * @return array{base: string, rates: array<string, float>, as_of: string|null, fetched_at: int}|null
+         */
+        private static function fetch_table($gateway): ?array
+        {
+            $response = $gateway->make_request('/refdata/v1/fx-rates', [], 'GET', [], null, self::FETCH_TIMEOUT);
+            if (is_wp_error($response)) {
+                return null;
+            }
+            $code = (int) wp_remote_retrieve_response_code($response);
+            if ($code < 200 || $code >= 300) {
+                return null;
+            }
+            $body = json_decode(wp_remote_retrieve_body($response), true);
+            if (!is_array($body) || !isset($body['base'], $body['rates']) || !is_array($body['rates'])) {
+                return null;
+            }
+            $rates = [];
+            foreach ($body['rates'] as $currency => $rate) {
+                if (is_string($currency) && $currency !== '' && is_numeric($rate) && (float) $rate > 0) {
+                    $rates[strtoupper($currency)] = (float) $rate;
+                }
+            }
+            if (count($rates) === 0) {
+                return null;
+            }
+            return [
+                'base' => strtoupper(strval($body['base'])),
+                'rates' => $rates,
+                'as_of' => isset($body['as_of']) && is_string($body['as_of']) ? $body['as_of'] : null,
+                'fetched_at' => time(),
+            ];
+        }
+
+        /**
+         * The working table: request memo → stored table, refreshed first
+         * when the freshness window has lapsed (and the retry throttle is
+         * not armed). A failed refresh falls back to last-known-good; null
+         * only when no table has ever been stored.
+         *
+         * @return array{base: string, rates: array<string, float>, as_of: string|null, fetched_at: int}|null
+         */
+        private static function get_table($gateway): ?array
+        {
+            if (self::$table_memo !== null) {
+                return self::$table_memo;
+            }
+            $stored = self::read_stored_table();
+            $fresh = get_transient(self::fresh_transient_key()) !== false;
+            if ($stored !== null && $fresh) {
+                return self::$table_memo = $stored;
+            }
+            if ($gateway && !self::$fetched_this_request && get_transient(self::retry_transient_key()) === false) {
+                self::refresh($gateway);
+                if (self::$table_memo !== null) {
+                    return self::$table_memo;
+                }
+            }
+            if ($stored !== null) {
+                self::$table_memo = $stored;
+            }
+            return $stored;
+        }
+
+        /**
+         * @return array|null the stored last-known-good table, or null
+         */
+        private static function read_stored_table(): ?array
+        {
+            $raw = get_option(self::option_key());
+            if (!is_string($raw) || $raw === '') {
+                return null;
+            }
+            $table = json_decode($raw, true);
+            if (!is_array($table) || !isset($table['base'], $table['rates']) || !is_array($table['rates']) || count($table['rates']) === 0) {
+                return null;
+            }
+            return $table;
+        }
+
+        /**
+         * The value of one unit of $currency in the table's base (EUR).
+         * The base itself may be absent from the rates map (it is 1 by
+         * definition).
+         */
+        private static function base_value(array $table, string $currency): ?float
+        {
+            if ($currency === $table['base']) {
+                return 1.0;
+            }
+            return isset($table['rates'][$currency]) ? (float) $table['rates'][$currency] : null;
+        }
+
+        /**
+         * Units of $to per one unit of $from, or null when no rate can be
+         * produced. Same-currency short-circuits to 1.0 without touching
+         * the cache or the network. A currency missing from the cached
+         * table triggers one on-demand full-table re-fetch (the "checkout
+         * in an uncached currency" path) before concluding it is
+         * unsupported.
+         *
+         * Null means "cannot convert": gate callers must fail closed on
+         * it, display and charge callers fail soft (see the class header).
+         */
+        public static function get_rate($gateway, string $from, string $to): ?float
+        {
+            $from = strtoupper(trim($from));
+            $to = strtoupper(trim($to));
+            if ($from === '' || $to === '') {
+                return null;
+            }
+            if ($from === $to) {
+                return 1.0;
+            }
+            $table = self::get_table($gateway);
+            if ($table === null) {
+                return null;
+            }
+            $from_value = self::base_value($table, $from);
+            $to_value = self::base_value($table, $to);
+            if (($from_value === null || $to_value === null)
+                && $gateway
+                && !self::$fetched_this_request
+                && get_transient(self::retry_transient_key()) === false
+            ) {
+                // Uncached currency at checkout: one live re-fetch, then
+                // re-resolve from whatever table that produced.
+                self::refresh($gateway);
+                $table = self::get_table($gateway);
+                if ($table === null) {
+                    return null;
+                }
+                $from_value = self::base_value($table, $from);
+                $to_value = self::base_value($table, $to);
+            }
+            if ($from_value === null || $to_value === null) {
+                return null;
+            }
+            return $from_value / $to_value;
+        }
+
+        /**
+         * $amount converted from $from to $to, unrounded, or null when no
+         * rate is available (callers apply their own fail semantics and
+         * rounding — a gate comparison must not round, a charged amount
+         * rounds via WC_Twoinc_Helper::round_amt).
+         */
+        public static function convert($gateway, float $amount, string $from, string $to): ?float
+        {
+            $rate = self::get_rate($gateway, $from, $to);
+            return $rate === null ? null : $amount * $rate;
+        }
+
+        /**
+         * The as_of date of the working table (the oldest rate it relies
+         * on, per the endpoint), or null when no table is stored. Exposed
+         * for logging/diagnostics; freshness is governed by fetch time.
+         */
+        public static function get_as_of($gateway): ?string
+        {
+            $table = self::get_table($gateway);
+            return $table !== null ? ($table['as_of'] ?? null) : null;
+        }
+
+        /**
+         * Drop the durable cache (uninstall/cleanup path).
+         */
+        public static function purge(): void
+        {
+            delete_option(self::option_key());
+            delete_transient(self::fresh_transient_key());
+            delete_transient(self::retry_transient_key());
+            self::reset_request_cache();
+        }
+
+        /**
+         * Reset request-scoped state (tests).
+         */
+        public static function reset_request_cache(): void
+        {
+            self::$table_memo = null;
+            self::$fetched_this_request = false;
+        }
+    }
+}

--- a/class/WC_Twoinc_FX.php
+++ b/class/WC_Twoinc_FX.php
@@ -29,15 +29,21 @@
  *    older/newer plugin version, manual editing) and a poisoned entry must
  *    not reach the division in get_rate().
  *
- * On-demand path: a checkout in a currency the FRESH cached table does not
- * carry triggers one synchronous re-fetch (tight timeout) — a fresh table
- * is, by construction, the endpoint's complete table, so a currency absent
- * from it is conclusively unsupported and re-fetching would only repeat
- * that same conclusion on every request (an unbounded fetch loop, not a
- * cache). A STALE table's absence is inconclusive (a fresher table might
- * carry the currency), so that case still re-fetches. A failed fetch arms
- * a short retry-throttle transient so a flapping API cannot be hammered
- * once per conversion.
+ * On-demand path: a checkout in a currency the cached table does not carry
+ * triggers one synchronous re-fetch (tight timeout) whenever the table is
+ * STALE — a stale table's absence is inconclusive (a fresher fetch might
+ * carry the currency). In practice get_table() already re-fetches on ANY
+ * stale read, regardless of which currency is being looked up, so that is
+ * usually what performs this refetch; the currency-specific check in
+ * get_rate() is defense-in-depth for the case get_table()'s own attempt
+ * still left the table without a fetched_at fresh enough (e.g. its fetch
+ * failed and returned last-known-good). A currency absent from a FRESH
+ * table is never re-fetched: a fresh table is, by construction, the
+ * endpoint's complete table, so the currency is conclusively unsupported
+ * and re-fetching would only repeat that same conclusion on every request
+ * (an unbounded fetch loop, not a cache — this was TWO-25104's round-1
+ * bug). A failed fetch arms a short retry-throttle transient so a
+ * flapping API cannot be hammered once per conversion.
  *
  * Fail semantics (per TWO-25104):
  *  - Gate conversions (minimum-order availability) use last-known-good and

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -297,13 +297,21 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
                         }
                         return null;
                     }
-                    $fixed = $fixed !== null ? (float) WC_Twoinc_Helper::round_amt($fixed * $rate) : null;
-                    $cap = $cap !== null ? (float) WC_Twoinc_Helper::round_amt($cap * $rate) : null;
+                    $converted_fixed = $fixed !== null ? (float) WC_Twoinc_Helper::round_amt($fixed * $rate) : null;
+                    $converted_cap = $cap !== null ? (float) WC_Twoinc_Helper::round_amt($cap * $rate) : null;
                     // A tiny configured amount can round to 0.00 in a much
-                    // stronger currency; the > 0 rule above still applies
-                    // to the converted values (a 0 cap would zero the fee).
-                    $fixed = $fixed !== null && $fixed > 0 ? $fixed : null;
-                    $cap = $cap !== null && $cap > 0 ? $cap : null;
+                    // stronger currency. Dropping only the cap while
+                    // leaving the percentage component in place would
+                    // send an UNCAPPED fee — the opposite of what the
+                    // merchant configured — so a component that rounds
+                    // away withholds the whole surcharge, same as no rate
+                    // being available at all, rather than silently
+                    // changing what is charged.
+                    if (($fixed !== null && $converted_fixed <= 0) || ($cap !== null && $converted_cap <= 0)) {
+                        return null;
+                    }
+                    $fixed = $converted_fixed;
+                    $cap = $converted_cap;
                 }
             }
             if ($fixed !== null) {
@@ -556,7 +564,11 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
             // — never re-converted store-side. A response echoing a
             // different currency than the cart's would land as a raw
             // number in the wrong money; skip it rather than mischarge.
-            if ($fee['currency'] !== '' && $fee['currency'] !== get_woocommerce_currency()) {
+            // Normalised the same way the FX layer normalises currency
+            // codes (case/whitespace) so this guard can't be defeated by
+            // a harmlessly-differently-cased echo.
+            $fee_currency = strtoupper(trim((string) $fee['currency']));
+            if ($fee_currency !== '' && $fee_currency !== strtoupper(get_woocommerce_currency())) {
                 return;
             }
 

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -264,17 +264,53 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
                 'surcharge_basis' => 'buyer_pays',
             ];
 
-            // Fixed amounts and caps are sent as configured, in the store
-            // currency. WooCommerce has no FX rate provider, so multi-currency
-            // conversion is NOT supported (the one parity gap vs Magento, which
-            // converts via Magento's currency rates) — fixed surcharge should
-            // be configured on single-currency stores only. Percentage-based
-            // surcharge is currency-agnostic and unaffected.
-            if ($has_fixed && isset($row['fixed']) && (float) $row['fixed'] > 0) {
-                $buyer_fee_share['surcharge'] = (float) $row['fixed'];
+            // Fixed amounts and caps are configured in the STORE currency
+            // (the saved woocommerce_currency option) while the pricing
+            // request is made in the ACTIVE checkout currency, so when a
+            // multi-currency setup has them diverge the monetary
+            // components are converted via the Two FX layer (TWO-25104 —
+            // Magento parity, which converts via the store's own rates).
+            // A wrong-currency amount must never be sent: if the pair
+            // cannot be converted (no rate ever fetched, or an unsupported
+            // currency) the whole surcharge is withheld for this quote —
+            // fail soft to no fee, matching the quote path's
+            // never-block-checkout posture. Same-currency stores never
+            // reach the FX layer. Percentage-based surcharge is
+            // currency-agnostic and unaffected.
+            $fixed = $has_fixed && isset($row['fixed']) && (float) $row['fixed'] > 0 ? (float) $row['fixed'] : null;
+            $cap = $has_percentage && isset($row['limit']) && (float) $row['limit'] > 0 ? (float) $row['limit'] : null;
+            if ($fixed !== null || $cap !== null) {
+                $store_currency = strval(get_option('woocommerce_currency'));
+                $active_currency = get_woocommerce_currency();
+                if ($store_currency !== $active_currency) {
+                    $rate = WC_Twoinc_FX::get_rate($gateway, $store_currency, $active_currency);
+                    if ($rate === null) {
+                        if (function_exists('wc_get_logger')) {
+                            wc_get_logger()->warning(
+                                sprintf(
+                                    'Surcharge withheld: no FX rate to convert configured %s amounts to checkout currency %s',
+                                    $store_currency,
+                                    $active_currency
+                                ),
+                                ['source' => 'twoinc-payment-gateway']
+                            );
+                        }
+                        return null;
+                    }
+                    $fixed = $fixed !== null ? (float) WC_Twoinc_Helper::round_amt($fixed * $rate) : null;
+                    $cap = $cap !== null ? (float) WC_Twoinc_Helper::round_amt($cap * $rate) : null;
+                    // A tiny configured amount can round to 0.00 in a much
+                    // stronger currency; the > 0 rule above still applies
+                    // to the converted values (a 0 cap would zero the fee).
+                    $fixed = $fixed !== null && $fixed > 0 ? $fixed : null;
+                    $cap = $cap !== null && $cap > 0 ? $cap : null;
+                }
             }
-            if ($has_percentage && isset($row['limit']) && (float) $row['limit'] > 0) {
-                $buyer_fee_share['cap'] = (float) $row['limit'];
+            if ($fixed !== null) {
+                $buyer_fee_share['surcharge'] = $fixed;
+            }
+            if ($cap !== null) {
+                $buyer_fee_share['cap'] = $cap;
             }
             if ($has_percentage) {
                 $rounding = self::build_rounding($settings);
@@ -513,6 +549,14 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
             $buyer_country = $customer ? $customer->get_billing_country() : '';
             $fee = self::fetch_term_fee($gateway, $selected, self::get_fee_basis($cart), $buyer_country);
             if ($fee === null || (float) $fee['buyer_fee_share'] <= 0) {
+                return;
+            }
+            // The fee enters the basket at the pricing endpoint's output
+            // (any FX conversion happened on the request inputs, TWO-25104)
+            // — never re-converted store-side. A response echoing a
+            // different currency than the cart's would land as a raw
+            // number in the wrong money; skip it rather than mischarge.
+            if ($fee['currency'] !== '' && $fee['currency'] !== get_woocommerce_currency()) {
                 return;
             }
 

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -742,6 +742,30 @@ function wc_get_order($order_id)
     return $GLOBALS['__twoinc_test_wc_orders'][$order_id] ?? false;
 }
 
+// ── Action Scheduler stubs (FX recurring refresh, TWO-25104) ────────
+// Minimal: enough to exercise WC_Twoinc_FX::maybe_schedule_refresh's
+// has-scheduled-action guard and the $unique argument it passes, without
+// a real Action Scheduler install. Calls recorded in
+// $GLOBALS['__twoinc_test_as_schedule_calls'] for assertions.
+
+function as_has_scheduled_action($hook, $args = null, $group = '')
+{
+    return !empty($GLOBALS['__twoinc_test_as_scheduled'][$hook]);
+}
+
+function as_schedule_recurring_action($timestamp, $interval, $hook, $args = [], $group = '', $unique = false)
+{
+    $GLOBALS['__twoinc_test_as_schedule_calls'][] = ['hook' => $hook, 'unique' => $unique];
+    $GLOBALS['__twoinc_test_as_scheduled'][$hook] = true;
+    return 1;
+}
+
+function as_unschedule_all_actions($hook, $args = [], $group = '')
+{
+    unset($GLOBALS['__twoinc_test_as_scheduled'][$hook]);
+    return true;
+}
+
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Brand.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Helper.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_FX.php';

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -744,6 +744,7 @@ function wc_get_order($order_id)
 
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Brand.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Helper.php';
+require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_FX.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Payment_Terms.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Sole_Trader.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Checkout.php';

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -118,6 +118,21 @@ final class BrandConfigSpec
             'testNegativeDiscountGuardThrowsOnNegativeOrderDiscount',
             'testNegativeDiscountGuardNoFalsePositiveFromEarlyRounding',
             'testNegativeDiscountGuardSkipsRefundLineItems',
+            'testFxSameCurrencyShortCircuitsWithoutNetwork',
+            'testFxCrossRatesFromEurPivotTable',
+            'testFxFreshCacheServesAcrossRequestsWithoutRefetch',
+            'testFxStaleRefreshFailureFallsBackToLastKnownGood',
+            'testFxMalformedResponsesAreRejected',
+            'testFxUncachedCurrencyRefetchesOnceThenConcludes',
+            'testFxGateFailsClosedWhenNoRateEverFetched',
+            'testFxGateConvertsBasketAcrossCurrencies',
+            'testFxGateUsesLastKnownGoodOnApiFailure',
+            'testFxMerchantMinimumJudgedAcrossCurrencies',
+            'testBuyerFeeShareConvertsFixedAndCapAcrossCurrencies',
+            'testBuyerFeeShareWithheldWhenNoRateAvailable',
+            'testBuyerFeeShareSameCurrencyNeverTouchesFx',
+            'testCartFeeSkippedOnQuoteCurrencyMismatch',
+            'testMinimumDescriptionShowsConvertedFloorWhenRateAvailable',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -137,6 +152,8 @@ final class BrandConfigSpec
         WC_Twoinc_Payment_Terms::reset_fee_cache();
         WC_Twoinc_Sole_Trader::reset_cache();
         WC_Twoinc::reset_merchant_record_memo();
+        WC_Twoinc_FX::reset_request_cache();
+        $GLOBALS['__twoinc_test_transients'] = [];
         WC()->cart = null;
         WC()->customer = null;
         WC()->session = null;
@@ -947,6 +964,8 @@ final class BrandConfigSpec
             // TTL expiry only ever happens across requests, so an expiry is
             // also a request boundary for the per-request record memo.
             WC_Twoinc::reset_merchant_record_memo();
+        WC_Twoinc_FX::reset_request_cache();
+        $GLOBALS['__twoinc_test_transients'] = [];
         };
 
         // Default (cache-only) read NEVER fetches, even with a cold cache —
@@ -1191,6 +1210,8 @@ final class BrandConfigSpec
             $GLOBALS['__twoinc_test_options'][WC_Twoinc_Brand::prefixed_name($name)] = time() - 3601;
         }
         WC_Twoinc::reset_merchant_record_memo();
+        WC_Twoinc_FX::reset_request_cache();
+        $GLOBALS['__twoinc_test_transients'] = [];
         $gateway->responses[] = new WP_Error('http_request_failed', 'down');
 
         TinyAssert::same([30, 60], $gateway->get_merchant_available_terms(true));
@@ -1427,18 +1448,17 @@ final class BrandConfigSpec
             WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30)
         );
 
-        // Fixed amounts are sent as configured (store currency); WooCommerce
-        // does no multi-currency conversion (documented parity gap vs Magento),
-        // so the amount rides regardless of the active display currency.
+        // Fixed amounts are configured in the store currency; when the
+        // active checkout currency differs they are FX-converted
+        // (TWO-25104 closed the parity gap vs Magento). With no rate ever
+        // fetched the surcharge is withheld — a wrong-currency amount is
+        // never sent. The conversion itself is covered by the FX tests.
         $GLOBALS['__twoinc_test_currency'] = 'GBP';
-        $gateway = self::termsGateway([
+        $gateway = self::fxGateway(null, [new WP_Error()], [
             'surcharge_type' => 'fixed',
             'surcharge_grid' => [30 => ['fixed' => '10']],
         ]);
-        TinyAssert::same(
-            ['percentage' => 0.0, 'surcharge_basis' => 'buyer_pays', 'surcharge' => 10.0],
-            WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30)
-        );
+        TinyAssert::same(null, WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30));
         unset($GLOBALS['__twoinc_test_currency']);
         unset($GLOBALS['test_home_url']);
     }
@@ -2872,6 +2892,387 @@ final class BrandConfigSpec
 
         TinyAssert::same(1, count($items));
         TinyAssert::same('-10.00', $items[0]['discount_amount']);
+    }
+
+    // ── FX conversion layer (TWO-25104) ────────────────────────────────
+
+    /**
+     * Gateway fake for the FX layer: injectable platform minimum and
+     * options, canned /refdata/v1/fx-rates responses consumed as a queue
+     * (last entry sticky), and a request counter for over-fetch
+     * assertions. Any other endpoint errors — the FX layer must never
+     * stray off its own endpoint.
+     */
+    private static function fxGateway(?array $platform_minimum, array $fx_responses, array $options = []): WC_Twoinc
+    {
+        return new class ($platform_minimum, $fx_responses, $options) extends WC_Twoinc {
+            private $test_platform_minimum;
+            private $fx_responses;
+            private $options;
+            public $fx_requests = 0;
+
+            public function __construct($platform_minimum, $fx_responses, $options)
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+                $this->test_platform_minimum = $platform_minimum;
+                $this->fx_responses = $fx_responses;
+                $this->options = $options;
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $this->options[$key] ?? $empty_value ?? '';
+            }
+
+            public function get_platform_minimum_order()
+            {
+                return $this->test_platform_minimum;
+            }
+
+            public function get_merchant_available_terms(bool $refresh = false): array
+            {
+                return [14, 30, 60, 90];
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+            {
+                if (strpos($endpoint, '/refdata/v1/fx-rates') !== 0) {
+                    return new WP_Error();
+                }
+                $this->fx_requests++;
+                if (count($this->fx_responses) > 1) {
+                    return array_shift($this->fx_responses);
+                }
+                return $this->fx_responses[0] ?? new WP_Error();
+            }
+        };
+    }
+
+    private static function fxOk(array $rates, string $as_of = '2026-07-14'): array
+    {
+        return [
+            'response' => ['code' => 200],
+            'body' => json_encode(['base' => 'EUR', 'as_of' => $as_of, 'rates' => $rates]),
+        ];
+    }
+
+    /** The EUR-pivot fixture: 1 NOK = 0.085 EUR, 1 SEK = 0.088 EUR. */
+    private const FX_TABLE = ['NOK' => 0.085, 'SEK' => 0.088];
+
+    private static function assertClose(float $expected, $actual, string $message = ''): void
+    {
+        TinyAssert::true(
+            is_float($actual) && abs($expected - $actual) < 1e-9,
+            $message !== '' ? $message : 'Expected ~' . $expected . ', got ' . var_export($actual, true)
+        );
+    }
+
+    private static function testFxSameCurrencyShortCircuitsWithoutNetwork(): void
+    {
+        // Same-currency conversion is identity and must not touch the
+        // cache or the network — single-currency stores never pay for FX.
+        $gateway = self::fxGateway(null, []);
+        TinyAssert::same(1.0, WC_Twoinc_FX::get_rate($gateway, 'EUR', 'EUR'));
+        TinyAssert::same(1.0, WC_Twoinc_FX::get_rate($gateway, 'nok', 'NOK'));
+        TinyAssert::same(0, $gateway->fx_requests);
+    }
+
+    private static function testFxCrossRatesFromEurPivotTable(): void
+    {
+        $gateway = self::fxGateway(null, [self::fxOk(self::FX_TABLE)]);
+
+        // Cross rate through the EUR pivot: units of `to` per one `from`
+        // is eur_value(from) / eur_value(to) — the endpoint's own formula.
+        self::assertClose(0.085 / 0.088, WC_Twoinc_FX::get_rate($gateway, 'NOK', 'SEK'));
+        // The base itself is 1 by definition, in both directions.
+        self::assertClose(1 / 0.085, WC_Twoinc_FX::get_rate($gateway, 'EUR', 'NOK'));
+        self::assertClose(0.085, WC_Twoinc_FX::get_rate($gateway, 'NOK', 'EUR'));
+        // The whole table arrived on one fetch: no per-pair requests.
+        TinyAssert::same(1, $gateway->fx_requests);
+        // convert() is rate * amount, unrounded.
+        self::assertClose(100 * 0.085, WC_Twoinc_FX::convert($gateway, 100.0, 'NOK', 'EUR'));
+    }
+
+    private static function testFxFreshCacheServesAcrossRequestsWithoutRefetch(): void
+    {
+        $gateway = self::fxGateway(null, [self::fxOk(self::FX_TABLE)]);
+        WC_Twoinc_FX::get_rate($gateway, 'NOK', 'EUR');
+        TinyAssert::same(1, $gateway->fx_requests);
+        TinyAssert::same('2026-07-14', WC_Twoinc_FX::get_as_of($gateway));
+
+        // A new PHP request (request memo gone) within the 6h freshness
+        // window is served from the stored table — no HTTP.
+        WC_Twoinc_FX::reset_request_cache();
+        self::assertClose(0.085, WC_Twoinc_FX::get_rate($gateway, 'NOK', 'EUR'));
+        TinyAssert::same(1, $gateway->fx_requests);
+    }
+
+    private static function testFxStaleRefreshFailureFallsBackToLastKnownGood(): void
+    {
+        // Seed the durable cache.
+        $seeder = self::fxGateway(null, [self::fxOk(self::FX_TABLE)]);
+        WC_Twoinc_FX::get_rate($seeder, 'NOK', 'EUR');
+
+        // 6h later (freshness transient lapsed) the rates API is down: the
+        // refresh attempt fails and conversion falls back to the stored
+        // last-known-good table rather than flapping to null.
+        WC_Twoinc_FX::reset_request_cache();
+        delete_transient(WC_Twoinc_FX::fresh_transient_key());
+        $failing = self::fxGateway(null, [new WP_Error()]);
+        self::assertClose(0.085, WC_Twoinc_FX::get_rate($failing, 'NOK', 'EUR'));
+        TinyAssert::same(1, $failing->fx_requests);
+
+        // The failure arms the retry throttle: the next request cycle must
+        // not hammer the API again.
+        WC_Twoinc_FX::reset_request_cache();
+        self::assertClose(0.085, WC_Twoinc_FX::get_rate($failing, 'NOK', 'EUR'));
+        TinyAssert::same(1, $failing->fx_requests);
+    }
+
+    private static function testFxMalformedResponsesAreRejected(): void
+    {
+        // Non-JSON body.
+        $gateway = self::fxGateway(null, [['response' => ['code' => 200], 'body' => 'not json']]);
+        TinyAssert::same(null, WC_Twoinc_FX::get_rate($gateway, 'NOK', 'EUR'));
+
+        // Rates present but all garbage (zero/negative/non-numeric) — a
+        // poisoned table must not be stored as last-known-good.
+        WC_Twoinc_FX::reset_request_cache();
+        $gateway = self::fxGateway(null, [[
+            'response' => ['code' => 200],
+            'body' => json_encode(['base' => 'EUR', 'rates' => ['NOK' => 0, 'SEK' => -1, 'DKK' => 'x']]),
+        ]]);
+        TinyAssert::same(null, WC_Twoinc_FX::get_rate($gateway, 'NOK', 'EUR'));
+        TinyAssert::same(false, get_option(WC_Twoinc_FX::option_key()));
+
+        // Non-2xx.
+        WC_Twoinc_FX::reset_request_cache();
+        $gateway = self::fxGateway(null, [['response' => ['code' => 500], 'body' => '']]);
+        TinyAssert::same(null, WC_Twoinc_FX::get_rate($gateway, 'NOK', 'EUR'));
+    }
+
+    private static function testFxUncachedCurrencyRefetchesOnceThenConcludes(): void
+    {
+        // Seed a fresh table that carries NOK but not DKK.
+        $seeder = self::fxGateway(null, [self::fxOk(['NOK' => 0.085])]);
+        WC_Twoinc_FX::get_rate($seeder, 'NOK', 'EUR');
+
+        // A checkout in an uncached currency triggers one live re-fetch
+        // even inside the freshness window; the full table it returns then
+        // resolves the pair.
+        WC_Twoinc_FX::reset_request_cache();
+        $gateway = self::fxGateway(null, [self::fxOk(['NOK' => 0.085, 'DKK' => 0.134])]);
+        self::assertClose(0.134 / 0.085, WC_Twoinc_FX::get_rate($gateway, 'DKK', 'NOK'));
+        TinyAssert::same(1, $gateway->fx_requests);
+
+        // A currency still absent after that re-fetch is genuinely
+        // unsupported: null, and no further request in the same cycle.
+        TinyAssert::same(null, WC_Twoinc_FX::get_rate($gateway, 'XXX', 'NOK'));
+        TinyAssert::same(1, $gateway->fx_requests);
+    }
+
+    private static function testFxGateFailsClosedWhenNoRateEverFetched(): void
+    {
+        // Cross-currency basket, rates API down, nothing ever cached: the
+        // basket cannot be proven to satisfy the funding partner's
+        // minimum — the gateway is removed (fail closed, as before
+        // TWO-25104, when any cross-currency basket failed closed).
+        self::useTestbrand();
+        WC()->cart = new StubCart(10000.0);
+        WC()->customer = new StubCustomer('NL');
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+
+        $gateway = self::fxGateway(self::EUR_250_NET, [new WP_Error()]);
+        $result = $gateway->apply_brand_availability_gate(['woocommerce-gateway-testbrand' => 'gw']);
+        TinyAssert::true(!isset($result['woocommerce-gateway-testbrand']));
+    }
+
+    private static function testFxGateConvertsBasketAcrossCurrencies(): void
+    {
+        // The cross-currency scenario the ticket demands: a NOK basket
+        // judged against a EUR minimum via the endpoint rate. 250 EUR net
+        // at 1 NOK = 0.085 EUR is 2941.18 NOK.
+        self::useTestbrand();
+        WC()->customer = new StubCustomer('NL');
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $gateways = ['woocommerce-gateway-testbrand' => 'gw'];
+
+        // 3000 NOK net → 255 EUR ≥ 250: offered.
+        WC()->cart = new StubCart(3000.0);
+        $gateway = self::fxGateway(self::EUR_250_NET, [self::fxOk(self::FX_TABLE)]);
+        $result = $gateway->apply_brand_availability_gate($gateways);
+        TinyAssert::same('gw', $result['woocommerce-gateway-testbrand']);
+
+        // 2900 NOK net → 246.50 EUR < 250: removed.
+        WC()->cart = new StubCart(2900.0);
+        WC_Twoinc_FX::reset_request_cache();
+        $result = $gateway->apply_brand_availability_gate($gateways);
+        TinyAssert::true(!isset($result['woocommerce-gateway-testbrand']));
+    }
+
+    private static function testFxGateUsesLastKnownGoodOnApiFailure(): void
+    {
+        // A basket that passes on cached rates keeps passing while the
+        // rates API is down — gates run on last-known-good, so a transient
+        // outage never flaps the gateway off checkout.
+        self::useTestbrand();
+        WC()->customer = new StubCustomer('NL');
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        WC()->cart = new StubCart(3000.0);
+
+        $seeder = self::fxGateway(null, [self::fxOk(self::FX_TABLE)]);
+        WC_Twoinc_FX::get_rate($seeder, 'NOK', 'EUR');
+
+        WC_Twoinc_FX::reset_request_cache();
+        delete_transient(WC_Twoinc_FX::fresh_transient_key());
+        $gateway = self::fxGateway(self::EUR_250_NET, [new WP_Error()]);
+        $result = $gateway->apply_brand_availability_gate(['woocommerce-gateway-testbrand' => 'gw']);
+        TinyAssert::same('gw', $result['woocommerce-gateway-testbrand']);
+    }
+
+    private static function testFxMerchantMinimumJudgedAcrossCurrencies(): void
+    {
+        // The merchant's own minimum (store currency EUR) now judges a
+        // NOK basket via FX instead of failing open on the mismatch.
+        WC()->customer = new StubCustomer('NO');
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $gateways = ['woocommerce-gateway-tillit' => 'gw'];
+
+        // 6000 NOK → 510 EUR ≥ 500: offered.
+        WC()->cart = new StubCart(6000.0);
+        $gateway = self::fxGateway(null, [self::fxOk(self::FX_TABLE)], ['merchant_minimum_order' => '500']);
+        $result = $gateway->apply_brand_availability_gate($gateways);
+        TinyAssert::same('gw', $result['woocommerce-gateway-tillit']);
+
+        // 5800 NOK → 493 EUR < 500: removed.
+        WC()->cart = new StubCart(5800.0);
+        WC_Twoinc_FX::reset_request_cache();
+        $result = $gateway->apply_brand_availability_gate($gateways);
+        TinyAssert::true(!isset($result['woocommerce-gateway-tillit']));
+
+        // No rate ever fetched: fail closed (TWO-25104 semantics — the
+        // pre-FX fail-open on the merchant's bar is gone; an unprovable
+        // basket is not offered the gateway).
+        $GLOBALS['__twoinc_test_options'] = [];
+        $GLOBALS['__twoinc_test_transients'] = [];
+        WC_Twoinc_FX::reset_request_cache();
+        WC()->cart = new StubCart(6000.0);
+        $gateway = self::fxGateway(null, [new WP_Error()], ['merchant_minimum_order' => '500']);
+        $result = $gateway->apply_brand_availability_gate($gateways);
+        TinyAssert::true(!isset($result['woocommerce-gateway-tillit']));
+    }
+
+    private static function testBuyerFeeShareConvertsFixedAndCapAcrossCurrencies(): void
+    {
+        // Fixed surcharge and cap are configured in the store currency
+        // (EUR) and must reach the pricing request in the active checkout
+        // currency (NOK) at the endpoint rate: 1 EUR = 1/0.085 NOK.
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $gateway = self::fxGateway(null, [self::fxOk(self::FX_TABLE)], [
+            'surcharge_type' => 'fixed_and_percentage',
+            'surcharge_grid' => [30 => ['fixed' => 2.5, 'percentage' => 1.5, 'limit' => 10.0]],
+        ]);
+
+        $share = WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30);
+        TinyAssert::same(29.41, $share['surcharge'], 'fixed 2.50 EUR at 1/0.085 is 29.41 NOK');
+        TinyAssert::same(117.65, $share['cap'], 'cap 10.00 EUR at 1/0.085 is 117.65 NOK');
+        // The percentage component is currency-agnostic and untouched.
+        TinyAssert::same(1.5, $share['percentage']);
+    }
+
+    private static function testBuyerFeeShareWithheldWhenNoRateAvailable(): void
+    {
+        // No rate ever fetched: a wrong-currency amount must never be
+        // sent, so the whole surcharge is withheld for the quote (fail
+        // soft to no fee — checkout is never blocked).
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $gateway = self::fxGateway(null, [new WP_Error()], [
+            'surcharge_type' => 'fixed_and_percentage',
+            'surcharge_grid' => [30 => ['fixed' => 2.5, 'percentage' => 1.5, 'limit' => 10.0]],
+        ]);
+        TinyAssert::same(null, WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30));
+    }
+
+    private static function testBuyerFeeShareSameCurrencyNeverTouchesFx(): void
+    {
+        // Regression pin for single-currency stores: amounts pass through
+        // exactly as configured and the FX layer is never consulted.
+        $gateway = self::fxGateway(null, [], [
+            'surcharge_type' => 'fixed_and_percentage',
+            'surcharge_grid' => [30 => ['fixed' => 2.5, 'percentage' => 1.5, 'limit' => 10.0]],
+        ]);
+        $share = WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30);
+        TinyAssert::same(2.5, $share['surcharge']);
+        TinyAssert::same(10.0, $share['cap']);
+        TinyAssert::same(0, $gateway->fx_requests);
+    }
+
+    private static function testCartFeeSkippedOnQuoteCurrencyMismatch(): void
+    {
+        // The fee enters the basket at the pricing endpoint's output — a
+        // response echoing a different currency than the cart's would land
+        // as a raw number in the wrong money, so it is skipped.
+        $gateway = new class () extends WC_Twoinc {
+            public function __construct()
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                $options = [
+                    'surcharge_type' => 'percentage',
+                    'payment_terms_days' => [30],
+                    'surcharge_grid' => [30 => ['percentage' => 2.0]],
+                ];
+                return $options[$key] ?? $empty_value ?? '';
+            }
+
+            public function get_merchant_available_terms(bool $refresh = false): array
+            {
+                return [30, 60];
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+            {
+                return [
+                    'response' => ['code' => 200],
+                    'body' => json_encode(['buyer_fee_share' => '12.50', 'currency' => 'GBP']),
+                ];
+            }
+        };
+        self::withGatewayInstance($gateway, static function () use ($gateway) {
+            WC_Twoinc_Payment_Terms::reset_fee_cache();
+            WC()->session = new StubSession();
+            WC()->session->set('chosen_payment_method', $gateway->id);
+            WC()->customer = new StubCustomer('US');
+            $cart = new StubFeeCart();
+            WC_Twoinc_Payment_Terms::apply_cart_fee($cart);
+            TinyAssert::same(0, count($cart->fees), 'a wrong-currency quote must not become a cart fee');
+        });
+    }
+
+    private static function testMinimumDescriptionShowsConvertedFloorWhenRateAvailable(): void
+    {
+        // Display conversion: with a rate, the settings help text shows an
+        // approximate store-currency floor (250 EUR / 0.085 = 2941.18 NOK);
+        // without one it fails soft to the native-only wording.
+        self::useTestbrand();
+        $GLOBALS['__twoinc_test_store_currency'] = 'NOK';
+        try {
+            $gateway = self::fxGateway(self::EUR_250_NET, [self::fxOk(self::FX_TABLE)]);
+            $description = $gateway->get_merchant_minimum_order_description();
+            TinyAssert::true(strpos($description, 'approximately NOK 2,941.18') !== false, $description);
+
+            $GLOBALS['__twoinc_test_options'] = [];
+            $GLOBALS['__twoinc_test_transients'] = [];
+            WC_Twoinc_FX::reset_request_cache();
+            $gateway = self::fxGateway(self::EUR_250_NET, [new WP_Error()]);
+            $description = $gateway->get_merchant_minimum_order_description();
+            TinyAssert::true(strpos($description, 'cannot be checked') !== false, $description);
+        } finally {
+            unset($GLOBALS['__twoinc_test_store_currency']);
+        }
     }
 }
 

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -124,6 +124,9 @@ final class BrandConfigSpec
             'testFxStaleRefreshFailureFallsBackToLastKnownGood',
             'testFxMalformedResponsesAreRejected',
             'testFxUncachedCurrencyRefetchesOnceThenConcludes',
+            'testFxFreshTableMissingCurrencyDoesNotRefetch',
+            'testFxCorruptedStoredTableIsRejectedNotFatal',
+            'testFxDuplicateScheduleGuardedByUniqueFlag',
             'testFxGateFailsClosedWhenNoRateEverFetched',
             'testFxGateConvertsBasketAcrossCurrencies',
             'testFxGateUsesLastKnownGoodOnApiFailure',
@@ -131,6 +134,7 @@ final class BrandConfigSpec
             'testBuyerFeeShareConvertsFixedAndCapAcrossCurrencies',
             'testBuyerFeeShareWithheldWhenNoRateAvailable',
             'testBuyerFeeShareSameCurrencyNeverTouchesFx',
+            'testBuyerFeeShareCapRoundingToZeroWithholdsWholeSurcharge',
             'testCartFeeSkippedOnQuoteCurrencyMismatch',
             'testMinimumDescriptionShowsConvertedFloorWhenRateAvailable',
         ];
@@ -154,6 +158,8 @@ final class BrandConfigSpec
         WC_Twoinc::reset_merchant_record_memo();
         WC_Twoinc_FX::reset_request_cache();
         $GLOBALS['__twoinc_test_transients'] = [];
+        $GLOBALS['__twoinc_test_as_scheduled'] = [];
+        $GLOBALS['__twoinc_test_as_schedule_calls'] = [];
         WC()->cart = null;
         WC()->customer = null;
         WC()->session = null;
@@ -2959,6 +2965,23 @@ final class BrandConfigSpec
     /** The EUR-pivot fixture: 1 NOK = 0.085 EUR, 1 SEK = 0.088 EUR. */
     private const FX_TABLE = ['NOK' => 0.085, 'SEK' => 0.088];
 
+    /**
+     * Age the stored FX table past the freshness window on BOTH signals
+     * (the freshness transient and the durable fetched_at fallback that
+     * covers object-cache eviction of the transient) — simulates "6h+
+     * later" for tests that need a genuinely stale table, as opposed to
+     * merely an evicted transient.
+     */
+    private static function ageStoredFxTable(): void
+    {
+        delete_transient(WC_Twoinc_FX::fresh_transient_key());
+        $raw = $GLOBALS['__twoinc_test_options'][WC_Twoinc_FX::option_key()] ?? null;
+        TinyAssert::true($raw !== null, 'ageStoredFxTable requires a table already stored');
+        $table = json_decode($raw, true);
+        $table['fetched_at'] = time() - WC_Twoinc_FX::REFRESH_INTERVAL - WC_Twoinc_FX::FRESHNESS_GRACE - 1;
+        $GLOBALS['__twoinc_test_options'][WC_Twoinc_FX::option_key()] = json_encode($table);
+    }
+
     private static function assertClose(float $expected, $actual, string $message = ''): void
     {
         TinyAssert::true(
@@ -3017,7 +3040,7 @@ final class BrandConfigSpec
         // refresh attempt fails and conversion falls back to the stored
         // last-known-good table rather than flapping to null.
         WC_Twoinc_FX::reset_request_cache();
-        delete_transient(WC_Twoinc_FX::fresh_transient_key());
+        self::ageStoredFxTable();
         $failing = self::fxGateway(null, [new WP_Error()]);
         self::assertClose(0.085, WC_Twoinc_FX::get_rate($failing, 'NOK', 'EUR'));
         TinyAssert::same(1, $failing->fx_requests);
@@ -3053,13 +3076,14 @@ final class BrandConfigSpec
 
     private static function testFxUncachedCurrencyRefetchesOnceThenConcludes(): void
     {
-        // Seed a fresh table that carries NOK but not DKK.
+        // Seed a STALE table (freshness transient expired) that carries
+        // NOK but not DKK: a currency missing from a stale table is
+        // inconclusive (a newer fetch might carry it), so one live
+        // re-fetch is worth it before giving up.
         $seeder = self::fxGateway(null, [self::fxOk(['NOK' => 0.085])]);
         WC_Twoinc_FX::get_rate($seeder, 'NOK', 'EUR');
+        self::ageStoredFxTable();
 
-        // A checkout in an uncached currency triggers one live re-fetch
-        // even inside the freshness window; the full table it returns then
-        // resolves the pair.
         WC_Twoinc_FX::reset_request_cache();
         $gateway = self::fxGateway(null, [self::fxOk(['NOK' => 0.085, 'DKK' => 0.134])]);
         self::assertClose(0.134 / 0.085, WC_Twoinc_FX::get_rate($gateway, 'DKK', 'NOK'));
@@ -3069,6 +3093,79 @@ final class BrandConfigSpec
         // unsupported: null, and no further request in the same cycle.
         TinyAssert::same(null, WC_Twoinc_FX::get_rate($gateway, 'XXX', 'NOK'));
         TinyAssert::same(1, $gateway->fx_requests);
+    }
+
+    private static function testFxFreshTableMissingCurrencyDoesNotRefetch(): void
+    {
+        // The bug three reviewers converged on: a currency missing from a
+        // table that is ALREADY FRESH must not trigger a re-fetch. The
+        // endpoint always returns its complete table, so "fresh but
+        // missing DKK" already conclusively means DKK is unsupported —
+        // re-fetching would repeat that same conclusion on every request
+        // for every buyer in that currency (an unbounded synchronous-fetch
+        // loop disguised as a cache).
+        $seeder = self::fxGateway(null, [self::fxOk(['NOK' => 0.085])]);
+        WC_Twoinc_FX::get_rate($seeder, 'NOK', 'EUR');
+
+        WC_Twoinc_FX::reset_request_cache();
+        $gateway = self::fxGateway(null, [self::fxOk(['NOK' => 0.085, 'DKK' => 0.134])]);
+        TinyAssert::same(null, WC_Twoinc_FX::get_rate($gateway, 'DKK', 'NOK'));
+        TinyAssert::same(0, $gateway->fx_requests, 'a fresh table must not be re-fetched for a currency it conclusively lacks');
+
+        // Across many simulated requests in the same unsupported
+        // currency, still zero fetches — this was the reproduced
+        // per-request fetch storm.
+        for ($i = 0; $i < 5; $i++) {
+            WC_Twoinc_FX::reset_request_cache();
+            TinyAssert::same(null, WC_Twoinc_FX::get_rate($gateway, 'DKK', 'NOK'));
+        }
+        TinyAssert::same(0, $gateway->fx_requests);
+    }
+
+    private static function testFxCorruptedStoredTableIsRejectedNotFatal(): void
+    {
+        // A table can reach wp_options by a route other than fetch_table
+        // (a DB import, an older/newer plugin version's shape, manual
+        // editing). A poisoned rate — zero, negative, or non-numeric —
+        // must be dropped on read, not divided against: reproduced as a
+        // DivisionByZeroError before the fix.
+        $GLOBALS['__twoinc_test_options'][WC_Twoinc_FX::option_key()] = json_encode([
+            'base' => 'EUR',
+            'rates' => ['NOK' => 0, 'SEK' => -1, 'DKK' => 'not-a-number'],
+            'as_of' => '2026-07-14',
+            'fetched_at' => time(),
+        ]);
+        $gateway = self::fxGateway(null, []);
+        TinyAssert::same(null, WC_Twoinc_FX::get_rate($gateway, 'NOK', 'EUR'));
+        TinyAssert::same(null, WC_Twoinc_FX::get_rate($gateway, 'SEK', 'DKK'));
+
+        // A valid entry alongside garbage entries is still usable — only
+        // the poisoned keys are dropped, not the whole table.
+        $GLOBALS['__twoinc_test_options'][WC_Twoinc_FX::option_key()] = json_encode([
+            'base' => 'EUR',
+            'rates' => ['NOK' => 0.085, 'SEK' => -1],
+            'as_of' => '2026-07-14',
+            'fetched_at' => time(),
+        ]);
+        WC_Twoinc_FX::reset_request_cache();
+        self::assertClose(0.085, WC_Twoinc_FX::get_rate(self::fxGateway(null, []), 'NOK', 'EUR'));
+    }
+
+    private static function testFxDuplicateScheduleGuardedByUniqueFlag(): void
+    {
+        // Two concurrent requests in the cold state (nothing scheduled
+        // yet) both observe "not scheduled" before either schedules — the
+        // has-scheduled-action check is not atomic with the schedule
+        // call. $unique = true is what prevents a duplicate recurring
+        // series from being created; assert it is actually passed.
+        WC_Twoinc_FX::maybe_schedule_refresh();
+        TinyAssert::same(1, count($GLOBALS['__twoinc_test_as_schedule_calls']));
+        TinyAssert::same(true, $GLOBALS['__twoinc_test_as_schedule_calls'][0]['unique']);
+        TinyAssert::same(WC_Twoinc_FX::refresh_hook(), $GLOBALS['__twoinc_test_as_schedule_calls'][0]['hook']);
+
+        // Already scheduled: a second call is a no-op.
+        WC_Twoinc_FX::maybe_schedule_refresh();
+        TinyAssert::same(1, count($GLOBALS['__twoinc_test_as_schedule_calls']));
     }
 
     private static function testFxGateFailsClosedWhenNoRateEverFetched(): void
@@ -3124,7 +3221,7 @@ final class BrandConfigSpec
         WC_Twoinc_FX::get_rate($seeder, 'NOK', 'EUR');
 
         WC_Twoinc_FX::reset_request_cache();
-        delete_transient(WC_Twoinc_FX::fresh_transient_key());
+        self::ageStoredFxTable();
         $gateway = self::fxGateway(self::EUR_250_NET, [new WP_Error()]);
         $result = $gateway->apply_brand_availability_gate(['woocommerce-gateway-testbrand' => 'gw']);
         TinyAssert::same('gw', $result['woocommerce-gateway-testbrand']);
@@ -3205,6 +3302,25 @@ final class BrandConfigSpec
         TinyAssert::same(2.5, $share['surcharge']);
         TinyAssert::same(10.0, $share['cap']);
         TinyAssert::same(0, $gateway->fx_requests);
+    }
+
+    private static function testBuyerFeeShareCapRoundingToZeroWithholdsWholeSurcharge(): void
+    {
+        // A cap configured in a strong store currency can round to 0.00
+        // once converted into a much weaker checkout currency. Dropping
+        // only the cap (as an earlier version of this code did) would
+        // send the percentage fee UNCAPPED — the opposite of the
+        // merchant's configuration — so the whole surcharge is withheld
+        // instead, same as the no-rate-available case.
+        $GLOBALS['__twoinc_test_currency'] = 'JPY';
+        $gateway = self::fxGateway(null, [self::fxOk(['JPY' => 1000000.0])], [
+            // Store currency EUR (default in these tests): a cap of 0.001
+            // EUR converts to 1000000 * 0.001 = 1000 JPY... use an
+            // absurdly weak rate the other way so the cap rounds to 0.
+            'surcharge_type' => 'fixed_and_percentage',
+            'surcharge_grid' => [30 => ['fixed' => 0.001, 'percentage' => 1.5, 'limit' => 0.001]],
+        ]);
+        TinyAssert::same(null, WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30));
     }
 
     private static function testCartFeeSkippedOnQuoteCurrencyMismatch(): void

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -77,6 +77,7 @@ function load_twoinc_classes()
     // Load classes
     require_once __DIR__ . '/class/WC_Twoinc_Brand.php';
     require_once __DIR__ . '/class/WC_Twoinc_Helper.php';
+    require_once __DIR__ . '/class/WC_Twoinc_FX.php';
     require_once __DIR__ . '/class/WC_Twoinc_Payment_Terms.php';
     require_once __DIR__ . '/class/WC_Twoinc_Sole_Trader.php';
     require_once __DIR__ . '/class/WC_Twoinc_Checkout.php';
@@ -100,6 +101,14 @@ function load_twoinc_classes()
     // (enabled + chosen-payment-method + selected-term), so registering it on
     // every request is safe.
     add_action('woocommerce_cart_calculate_fees', ['WC_Twoinc_Payment_Terms', 'apply_cart_fee']);
+
+    // FX rate cache (TWO-25104): a recurring 6h Action Scheduler refresh
+    // keeps the spot table warm so checkout conversions (min-order gates,
+    // fixed-surcharge amounts) are served from cache. Registered on init —
+    // Action Scheduler's data stores are not ready at plugins_loaded. The
+    // hook callback is static and self-bootstrapping via get_instance().
+    add_action('init', ['WC_Twoinc_FX', 'maybe_schedule_refresh']);
+    add_action(WC_Twoinc_FX::refresh_hook(), ['WC_Twoinc_FX', 'run_scheduled_refresh']);
     add_action('wc_ajax_two_term_fees', ['WC_Twoinc_Payment_Terms', 'ajax_term_fees']);
     add_action('wc_ajax_two_select_term', ['WC_Twoinc_Payment_Terms', 'ajax_select_term']);
     add_action('wc_ajax_two_sole_trader_availability', ['WC_Twoinc_Sole_Trader', 'ajax_availability']);

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -104,11 +104,21 @@ function load_twoinc_classes()
 
     // FX rate cache (TWO-25104): a recurring 6h Action Scheduler refresh
     // keeps the spot table warm so checkout conversions (min-order gates,
-    // fixed-surcharge amounts) are served from cache. Registered on init —
-    // Action Scheduler's data stores are not ready at plugins_loaded. The
-    // hook callback is static and self-bootstrapping via get_instance().
-    add_action('init', ['WC_Twoinc_FX', 'maybe_schedule_refresh']);
-    add_action(WC_Twoinc_FX::refresh_hook(), ['WC_Twoinc_FX', 'run_scheduled_refresh']);
+    // fixed-surcharge amounts) are served from cache. Both registrations
+    // are deferred to init, in one closure, rather than resolved here at
+    // plugins_loaded: WC_Twoinc_FX::refresh_hook() reads the brand prefix
+    // on first call, which PERMANENTLY caches WC_Twoinc_Brand's config
+    // (see its class header — an overlay's twoinc_brand_file filter must
+    // be registered by plugins_loaded at default priority). Calling it
+    // here, at plugins_loaded priority 10, would move that first read
+    // earlier than the gateway construction it used to happen at,
+    // narrowing the window a compliant same-priority overlay has to
+    // register first. Action Scheduler's data stores are also not ready
+    // at plugins_loaded, independent of the brand-timing concern.
+    add_action('init', static function () {
+        add_action(WC_Twoinc_FX::refresh_hook(), ['WC_Twoinc_FX', 'run_scheduled_refresh']);
+        WC_Twoinc_FX::maybe_schedule_refresh();
+    });
     add_action('wc_ajax_two_term_fees', ['WC_Twoinc_Payment_Terms', 'ajax_term_fees']);
     add_action('wc_ajax_two_select_term', ['WC_Twoinc_Payment_Terms', 'ajax_select_term']);
     add_action('wc_ajax_two_sole_trader_availability', ['WC_Twoinc_Sole_Trader', 'ajax_availability']);


### PR DESCRIPTION
[TWO-25104](https://linear.app/two-inc/issue/TWO-25104) — WooCommerce half of the FX cutover (parent TWO-24815 / TWO-24739). Net-new capability: WooCommerce had **no FX layer at all** (the acknowledged single-currency-only parity gap vs Magento).

## What's here

**New `WC_Twoinc_FX`** — the plugin's single FX source, backed by checkout-api's live `GET /refdata/v1/fx-rates` (EUR-pivot spot table, merchant-API-key authed, TWO-24776):

- Full-table fetch via `make_request` (server-side only; key and rates never reach browser JS).
- **Cache**: request memo → 6h freshness transient → durable last-known-good option (non-autoloaded, survives transient expiry and fetch failures). Recurring 6h Action Scheduler refresh keeps it warm; deactivation unschedules it.
- **On-demand path**: a checkout in a currency the cached table lacks triggers one live re-fetch (5s timeout); a failed fetch arms a 5-min retry throttle so a flapping API is never hammered per conversion. (The ticket's "parallel with the order-intent call" is adapted: WC's checkout is synchronous PHP with no order-intent analogue, so it's one tight-timeout synchronous fetch at first use, then cached.)
- Cross rates computed exactly as the endpoint does (`eur_value(from) / eur_value(to)`); `as_of` stored for observability.

**Consumers wired, per ticket fail semantics:**

| Surface | Behaviour | On no rate |
|---|---|---|
| Platform + merchant min-order gates | basket converted into the minimum's currency, last-known-good rates | fail **closed** (only when no rate ever fetched) |
| Fixed surcharge + cap (`build_buyer_fee_share`) | converted store → active checkout currency before the pricing quote | surcharge **withheld** — a wrong-currency amount is never sent (fail-soft, checkout never blocked) |
| Cart fee (`apply_cart_fee`) | enters the basket at the pricing endpoint's output, no store re-conversion; a quote echoing a different currency than the cart is skipped | n/a |
| Settings help text (platform floor) | approximate converted figure appended | fail **soft** (native-only wording) |

The `WC_Twoinc_Payment_Terms` "no FX" acknowledgement comment is gone; same-currency stores never touch the FX layer (regression-pinned in tests).

**Behaviour change to note:** the merchant's own minimum previously failed *open* on a cross-currency basket (unjudgeable by design). It is now judged via FX and fails closed when no rate was ever fetched — uniform gate semantics per the ticket.

## Validation

- Unit suite (WC custom runner, php 8.2 container as CI runs it): 16 new tests — cache freshness/no-over-fetch and `as_of`, last-known-good fallback + retry throttle, malformed/non-2xx rejection, uncached-currency single re-fetch, cross-currency converted surcharge/cap and min-order gate outcomes from the endpoint rate, fail-closed/fail-soft matrix, same-currency no-op pins. All green.
- Manual staging QA (display currency ≠ merchant base currency: converted fixed surcharge + min-order gate) still owed before this is called done — tracked on the ticket.