### PR TITLE
TWO-25108: add phpcs + phpstan CI gates

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,0 +1,59 @@
+name: Static analysis
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: static-analysis-${{ github.ref_name }}
+  cancel-in-progress: true
+
+# phpcs (PSR-12, phpcs.xml) + phpstan (level 2, phpstan.neon) — TWO-25108.
+# The repo has no Composer, so both tools are installed as standalone phars
+# via shivammathur/setup-php `tools:` (same action the unit-test matrix
+# already uses). Tool versions are pinned to the releases the committed
+# baselines were generated with; bump them together with a baseline refresh.
+jobs:
+  phpcs:
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          tools: phpcs:4.0.1
+
+      - name: Run phpcs
+        run: phpcs
+
+  phpstan:
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          tools: phpstan:2.2.5
+
+      # No Composer, so the WordPress/WooCommerce API stubs are fetched
+      # fresh rather than committed (large, third-party, would go stale).
+      # phpstan.neon references them via scanFiles at this path.
+      # Pinned to a commit SHA (not `master`) so stub content — and thus
+      # what phpstan-baseline.neon reflects — only changes when we
+      # deliberately bump these SHAs and regenerate the baseline.
+      - name: Download WordPress/WooCommerce stubs
+        run: |
+          mkdir -p dev/stubs
+          curl -sSfL --retry 3 --retry-connrefused --max-time 30 https://raw.githubusercontent.com/php-stubs/wordpress-stubs/04ebb2e841429038322c92043154a0ff5641e3c9/wordpress-stubs.php -o dev/stubs/wordpress-stubs.php
+          curl -sSfL --retry 3 --retry-connrefused --max-time 30 https://raw.githubusercontent.com/php-stubs/woocommerce-stubs/8e52e5bfbcd0f5cb65a8bec696761867e3096ab7/woocommerce-stubs.php -o dev/stubs/woocommerce-stubs.php
+
+      - name: Run phpstan
+        run: phpstan analyse --no-progress --memory-limit=4G

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ coverage/
 tests/e2e/test-results/
 tests/e2e/playwright-report/
 .review/
+dev/stubs/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: help install configure run debug proxy stop clean logs logs-wpcli \
 	test-unit test format archive patch minor major \
-	e2e-install e2e-test e2e-test-headed
+	e2e-install e2e-test e2e-test-headed phpcs phpstan
 
 .DEFAULT_GOAL := help
 
@@ -73,6 +73,22 @@ test: test-unit
 ## Format frontend/config files with pre-commit
 format:
 	pre-commit run --all-files
+
+## Run PHP_CodeSniffer (PSR-12 gate, same as CI)
+phpcs:
+	@mkdir -p dev/stubs
+	@test -f dev/stubs/phpcs.phar || curl -sSfL --retry 3 --retry-connrefused --max-time 30 https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/download/4.0.1/phpcs.phar -o dev/stubs/phpcs.phar
+	docker run --rm -v "$(CURDIR)":/app -w /app php:8.3-cli php dev/stubs/phpcs.phar
+
+## Run PHPStan (level 2 + baseline, same as CI)
+# Stub SHAs pinned below must match .github/workflows/static-analysis.yaml —
+# bump both together, deliberately, alongside a baseline regen.
+phpstan:
+	@mkdir -p dev/stubs
+	@test -f dev/stubs/phpstan.phar || curl -sSfL --retry 3 --retry-connrefused --max-time 30 https://github.com/phpstan/phpstan/releases/download/2.2.5/phpstan.phar -o dev/stubs/phpstan.phar
+	@test -f dev/stubs/wordpress-stubs.php || curl -sSfL --retry 3 --retry-connrefused --max-time 30 https://raw.githubusercontent.com/php-stubs/wordpress-stubs/04ebb2e841429038322c92043154a0ff5641e3c9/wordpress-stubs.php -o dev/stubs/wordpress-stubs.php
+	@test -f dev/stubs/woocommerce-stubs.php || curl -sSfL --retry 3 --retry-connrefused --max-time 30 https://raw.githubusercontent.com/php-stubs/woocommerce-stubs/8e52e5bfbcd0f5cb65a8bec696761867e3096ab7/woocommerce-stubs.php -o dev/stubs/woocommerce-stubs.php
+	docker run --rm -v "$(CURDIR)":/app -w /app php:8.3-cli php dev/stubs/phpstan.phar analyse --no-progress --memory-limit=4G
 
 ## Create a versioned zip archive
 archive:

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -11,7 +11,6 @@
  * @author Two
  */
 
-
 if (!class_exists('WC_Twoinc')) {
     class WC_Twoinc extends WC_Payment_Gateway
     {
@@ -119,7 +118,6 @@ if (!class_exists('WC_Twoinc')) {
 
                 // On setting updated
                 add_action('woocommerce_update_options_payment_gateways_' . $this->id, [$this, 'process_admin_options']); // Built-in process_admin_options
-
             }
 
             // Return if plugin setup is not complete
@@ -1416,7 +1414,6 @@ if (!class_exists('WC_Twoinc')) {
             $twoinc_order_id = $this->get_twoinc_order_id($order);
 
             if ($twoinc_order_id) {
-
                 // Route the downloads through the plugin's admin-ajax handler
                 // (ajax_download_invoice) instead of linking straight at the
                 // API: a direct link surfaces the raw 400 ORDER_NOT_FULFILLED
@@ -2168,7 +2165,7 @@ if (!class_exists('WC_Twoinc')) {
          */
         public static function display_user_meta_edit($user)
         {
-?>
+            ?>
             <h3><?php printf(__('%s pre-filled fields', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')); ?></h3>
 
             <table class="form-table">
@@ -2201,7 +2198,7 @@ if (!class_exists('WC_Twoinc')) {
                     </td>
                 </tr>
             </table>
-        <?php
+            <?php
         }
 
         /**
@@ -2888,9 +2885,11 @@ if (!class_exists('WC_Twoinc')) {
         private function is_confirmation_page()
         {
 
-            if (isset($_REQUEST['order_id'])
+            if (
+                isset($_REQUEST['order_id'])
                 && isset($_REQUEST[WC_Twoinc_Brand::prefixed_name('order_reference')])
-                && isset($_REQUEST[WC_Twoinc_Brand::prefixed_name('nonce')])) {
+                && isset($_REQUEST[WC_Twoinc_Brand::prefixed_name('nonce')])
+            ) {
                 return true;
                 // Temporarily commented out until we find a solution for redirect plugins
                 // $confirm_path = '/twoinc-payment-gateway/confirm';
@@ -3351,18 +3350,18 @@ if (!class_exists('WC_Twoinc')) {
             $data = wp_parse_args($data, $defaults);
 
             ob_start();
-        ?>
+            ?>
             <tr valign="top">
                 <th scope="row" class="titledesc">
                     <label for="<?php echo esc_attr($field_key); ?>"><?php echo wp_kses_post($data['title']); ?> <?php echo $this->get_tooltip_html($data); // WPCS: XSS ok.
-                                                                                                                    ?></label>
+                    ?></label>
                 </th>
                 <td class="forminp">
                     <fieldset>
                         <legend class="screen-reader-text"><span><?php echo wp_kses_post($data['title']); ?></span></legend>
                         <div style="position: relative; display: inline-block;">
                             <input class="input-text regular-input <?php echo esc_attr($data['class']); ?>" type="password" name="<?php echo esc_attr($field_key); ?>" id="<?php echo esc_attr($field_key); ?>" style="<?php echo esc_attr($data['css']); ?> padding-right: 35px;" value="<?php echo esc_attr($this->get_option($key)); ?>" placeholder="<?php echo esc_attr($data['placeholder']); ?>" <?php disabled($data['disabled'], true); ?> <?php echo $this->get_custom_attribute_html($data); // WPCS: XSS ok.
-                                                                                                                                                                                                                                                                                                                                                                                                                                                    ?> />
+                            ?> />
                             <span id="api-key-verification-icon" style="position: absolute; right: 8px; top: 50%; transform: translateY(-50%); display: none; pointer-events: none; z-index: 10;">
                                 <span class="dashicons dashicons-yes-alt" style="color: #46b450; display: none; font-size: 18px;" id="api-key-valid"></span>
                                 <span class="dashicons dashicons-dismiss" style="color: #dc3232; display: none; font-size: 18px;" id="api-key-invalid"></span>
@@ -3397,7 +3396,7 @@ if (!class_exists('WC_Twoinc')) {
                     }
                 }
             </style>
-        <?php
+            <?php
 
             return ob_get_clean();
         }
@@ -3433,20 +3432,20 @@ if (!class_exists('WC_Twoinc')) {
             }
 
             ob_start();
-        ?>
+            ?>
             <tr valign="top">
                 <td class="forminp" colspan="2">
                     <fieldset>
                         <legend class="screen-reader-text"><span><?php echo wp_kses_post($data['title']); ?></span></legend>
                         <label for="<?php echo esc_attr($field_key); ?>">
                             <input <?php disabled($data['disabled'], true); ?> class="<?php echo esc_attr($data['class']); ?>" type="radio" name="<?php echo esc_attr($field_key); ?>" id="<?php echo esc_attr($field_key); ?>" style="<?php echo esc_attr($data['css']); ?>" value="1" <?php checked($data['checked'] === true, true); ?> <?php echo $this->get_custom_attribute_html($data); // WPCS: XSS ok.
-                                                                                                                                                                                                                                                                                                                                            ?> /> <?php echo wp_kses_post($data['label']); ?></label><br />
+                            ?> /> <?php echo wp_kses_post($data['label']); ?></label><br />
                         <?php echo $this->get_description_html($data); // WPCS: XSS ok.
                         ?>
                     </fieldset>
                 </td>
             </tr>
-        <?php
+            <?php
 
             return ob_get_clean();
         }
@@ -3457,7 +3456,7 @@ if (!class_exists('WC_Twoinc')) {
             $image = $image_id ? wp_get_attachment_image_src($image_id, 'full') : null;
             $image_src = $image ? $image[0] : null;
             ob_start();
-        ?>
+            ?>
             <tr valign="top">
                 <th scope="row" class="titledesc">
                     <label for="<?php echo esc_attr($field_key); ?>"><?php echo wp_kses_post($data['title']); ?></label>
@@ -3466,7 +3465,7 @@ if (!class_exists('WC_Twoinc')) {
                     <fieldset>
                         <input type="hidden" name="woocommerce_<?php echo esc_attr($this->id); ?>_<?php echo $field_key; ?>" id="<?php echo esc_attr($field_key); ?>" class="logo_id" value="<?php echo $image_id; ?>" />
                         <div class="image-container woocommerce-twoinc-image-container">
-                            <?php if ($image_src): ?>
+                            <?php if ($image_src) : ?>
                                 <img src="<?php echo $image_src; ?>" alt="" />
                             <?php endif; ?>
                         </div>
@@ -3474,7 +3473,7 @@ if (!class_exists('WC_Twoinc')) {
                     </fieldset>
                 </td>
             </tr>
-<?php
+            <?php
             return ob_get_clean();
         }
 

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -73,7 +73,6 @@ if (!class_exists('WC_Twoinc_Checkout')) {
 
             // Return the fields list
             return $fields;
-
         }
 
         /**
@@ -90,7 +89,6 @@ if (!class_exists('WC_Twoinc_Checkout')) {
             $company_name_priority = $fields['billing']['billing_company']['priority'] ?? 30;
 
             if ($this->wc_twoinc->get_enable_company_search() === 'yes') {
-
                 $fields['billing']['billing_company_display'] = [
                     'label' => __('Company name', 'twoinc-payment-gateway'),
                     'autocomplete' => 'organization',
@@ -106,7 +104,6 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                     'required' => false,
                     'priority' => $company_name_priority
                 ];
-
             }
 
             $fields['billing']['company_id'] = [
@@ -117,36 +114,30 @@ if (!class_exists('WC_Twoinc_Checkout')) {
             ];
 
             if ($this->wc_twoinc->get_option('add_field_department') === 'yes') {
-
                 $fields['billing']['department'] = [
                     'label' => __('Department', 'twoinc-payment-gateway'),
                     'class' => array('hidden'),
                     'required' => false,
                     'priority' => $company_name_priority + 2
                 ];
-
             }
 
             if ($this->wc_twoinc->get_option('add_field_project') === 'yes') {
-
                 $fields['billing']['project'] = [
                     'label' => __('Project', 'twoinc-payment-gateway'),
                     'class' => array('hidden'),
                     'required' => false,
                     'priority' => $company_name_priority + 3
                 ];
-
             }
 
             if ($this->wc_twoinc->get_option('add_field_purchase_order_number') === 'yes') {
-
                 $fields['billing']['purchase_order_number'] = [
                     'label' => __('Purchase order number', 'twoinc-payment-gateway'),
                     'class' => array('hidden'),
                     'required' => false,
                     'priority' => $company_name_priority + 4
                 ];
-
             }
 
             if ($this->wc_twoinc->get_option('add_field_invoice_email') == 'yes') {
@@ -163,7 +154,6 @@ if (!class_exists('WC_Twoinc_Checkout')) {
 
             // Return the fields
             return $fields;
-
         }
 
         /**
@@ -185,7 +175,6 @@ if (!class_exists('WC_Twoinc_Checkout')) {
 
             // Return the fields list
             return $fields;
-
         }
 
         /**
@@ -308,7 +297,6 @@ if (!class_exists('WC_Twoinc_Checkout')) {
             }
 
             return $properties;
-
         }
 
         /**
@@ -333,6 +321,5 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                 printf('<script>window.twoinc = %s;</script>', $twoinc_obj);
             }
         }
-
     }
 }

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -306,13 +306,12 @@ if (!class_exists('WC_Twoinc_Helper')) {
 
             /** @var WC_Order_Item_Product $line_item */
             foreach ($line_items as $line_item) {
-
                 $product_simple = WC_Twoinc_Helper::get_product($line_item);
 
                 $tax_rate = WC_Twoinc_Helper::get_item_tax_rate($line_item, $order);
 
                 // Check if product exists and is a valid object. If not, use fallback values.
-                if ( ! is_object($product_simple) ) {
+                if (! is_object($product_simple)) {
                     $name = method_exists($line_item, 'get_name') ? $line_item->get_name() : 'Item';
                     $description = '';
                     $image_url = '';
@@ -323,8 +322,8 @@ if (!class_exists('WC_Twoinc_Helper')) {
                     $name = $product_simple->get_name();
                     $description = substr($product_simple->get_description(), 0, 255);
                     $image_url = '';
-                    if ( $product_simple->get_id() ) {
-                        $thumbnail = get_the_post_thumbnail_url( $product_simple->get_id() );
+                    if ($product_simple->get_id()) {
+                        $thumbnail = get_the_post_thumbnail_url($product_simple->get_id());
                         $image_url = $thumbnail ? $thumbnail : '';
                     }
                     $product_page_url = $product_simple->get_permalink();
@@ -378,7 +377,7 @@ if (!class_exists('WC_Twoinc_Helper')) {
                     ]
                 ];
 
-                if ( ! empty( $categories ) && is_array( $categories ) ) {
+                if (! empty($categories) && is_array($categories)) {
                     foreach ($categories as $category) {
                         $product['details']['categories'][] = $category->name;
                     }
@@ -469,7 +468,6 @@ if (!class_exists('WC_Twoinc_Helper')) {
 
             /** @var WC_Order_Item_Product $line_item */
             foreach ($line_items as $line_item) {
-
                 $tax_rate = WC_Twoinc_Helper::get_item_tax_rate($line_item, $order);
                 $tax_single_line = [
                     'tax_amount' => $line_item['line_tax'],

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -427,9 +427,11 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
                 'net_terms' => $net_terms,
             ], 'POST', array(), null, 10);
 
-            if (is_wp_error($response)
+            if (
+                is_wp_error($response)
                 || (int) wp_remote_retrieve_response_code($response) < 200
-                || (int) wp_remote_retrieve_response_code($response) >= 300) {
+                || (int) wp_remote_retrieve_response_code($response) >= 300
+            ) {
                 return ['success' => false];
             }
 

--- a/docker/mu-plugins/disable-sticky-cart.php
+++ b/docker/mu-plugins/disable-sticky-cart.php
@@ -1,9 +1,11 @@
 <?php
+
 /**
  * Disable Storefront sticky add-to-cart to avoid fatal error with WooCommerce 9.x.
  * The storefront_sticky_single_add_to_cart function calls is_purchasable() on a
  * string instead of a WC_Product object after order processing.
  */
+
 add_action('init', function () {
     remove_action('storefront_after_footer', 'storefront_sticky_single_add_to_cart', 999);
 });

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,6 +11,12 @@
     <exclude-pattern>*/tests/e2e/*</exclude-pattern>
     <!-- Downloaded WP/WC stubs + phars used by phpstan (gitignored) -->
     <exclude-pattern>*/dev/stubs/*</exclude-pattern>
+    <!-- Defensive: this repo has no vendor/ or coverage/ today (no Composer,
+         no PHPUnit), but exclude them so a local `composer install` or
+         coverage-report run doesn't sweep third-party/generated PHP into
+         a scan. -->
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/coverage/*</exclude-pattern>
 
     <arg name="extensions" value="php"/>
     <arg name="colors"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<ruleset name="TwoincWooCommercePlugin">
+    <description>PSR-12 house style for the Two WooCommerce plugin (TWO-25108).</description>
+
+    <file>.</file>
+
+    <!-- Non-PHP / third-party / generated trees -->
+    <exclude-pattern>*/\.git/*</exclude-pattern>
+    <exclude-pattern>*/node_modules/*</exclude-pattern>
+    <exclude-pattern>*/volumes/*</exclude-pattern>
+    <exclude-pattern>*/tests/e2e/*</exclude-pattern>
+    <!-- Downloaded WP/WC stubs + phars used by phpstan (gitignored) -->
+    <exclude-pattern>*/dev/stubs/*</exclude-pattern>
+
+    <arg name="extensions" value="php"/>
+    <arg name="colors"/>
+    <arg value="sp"/>
+
+    <!-- Warnings (e.g. the PSR-12 120-char soft line limit) are reported but
+         do not fail the run; only errors gate CI. -->
+    <config name="ignore_warnings_on_exit" value="1"/>
+
+    <rule ref="PSR12">
+        <!-- WooCommerce gateway API and WordPress hook callbacks are
+             snake_case by upstream convention (process_payment,
+             init_form_fields, ...); renaming would break the integration. -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName"/>
+        <!-- Classes follow the WooCommerce core naming convention
+             (WC_Twoinc mirrors WC_Payment_Gateway). -->
+        <exclude name="Squiz.Classes.ValidClassName.NotPascalCase"/>
+        <!-- Classic WordPress plugin: prefixed classes in the global
+             namespace by design. -->
+        <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
+    </rule>
+
+    <!-- WordPress plugin entry point, drop-in snippets and the test harness
+         are side-effect files by nature. class/ stays gated. -->
+    <rule ref="PSR1.Files.SideEffects">
+        <exclude-pattern>tillit-payment-gateway\.php</exclude-pattern>
+        <exclude-pattern>*/snippets/*</exclude-pattern>
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
+    <!-- The dependency-free test harness keeps its WP/WC shim classes in one
+         bootstrap file on purpose. -->
+    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+</ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,97 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Access to an undefined property WC_Cart\:\:\$total\.$#'
+			identifier: property.notFound
+			count: 2
+			path: class/WC_Twoinc.php
+
+		-
+			message: '#^Call to sprintf contains 2 placeholders, 3 values given\.$#'
+			identifier: argument.sprintf
+			count: 1
+			path: class/WC_Twoinc.php
+
+		-
+			message: '#^Comparison operation "\>" between \*NEVER\* and 0 results in an error\.$#'
+			identifier: greater.invalid
+			count: 1
+			path: class/WC_Twoinc.php
+
+		-
+			message: '#^Method WC_Twoinc\:\:process_admin_options\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: class/WC_Twoinc.php
+
+		-
+			message: '#^PHPDoc tag @extends has invalid value \(WC_Payment_Gateway\)\: Unexpected token "\\n \* ", expected ''\<'' at offset 133 on line 7$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: class/WC_Twoinc.php
+
+		-
+			message: '#^Result of method WC_Twoinc\:\:process_refund\(\) \(void\) is used\.$#'
+			identifier: method.void
+			count: 1
+			path: class/WC_Twoinc.php
+
+		-
+			message: '#^Variable \$_POST in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 2
+			path: class/WC_Twoinc.php
+
+		-
+			message: '#^Variable \$response in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: class/WC_Twoinc.php
+
+		-
+			message: '#^Variable \$categories in empty\(\) always exists and is always falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: class/WC_Twoinc_Helper.php
+
+		-
+			message: '#^Function add_sorting_query\(\) should return array but return statement is missing\.$#'
+			identifier: return.missing
+			count: 2
+			path: snippets/admin-order-list-columns.php
+
+		-
+			message: '#^Undefined variable\: \$order$#'
+			identifier: variable.undefined
+			count: 2
+			path: snippets/delivery-date-checkout.php
+
+		-
+			message: '#^Call to an undefined static method WC_Tax\:\:get_rates_for_class\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: tests/unit/bootstrap.php
+
+		-
+			message: '#^Access to an undefined property WC_Payment_Gateway\:\:\$requests\.$#'
+			identifier: property.notFound
+			count: 3
+			path: tests/unit/run.php
+
+		-
+			message: '#^Access to an undefined property WC_Twoinc\:\:\$requests\.$#'
+			identifier: property.notFound
+			count: 6
+			path: tests/unit/run.php
+
+		-
+			message: '#^Access to an undefined property WC_Twoinc\:\:\$test_post_data\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/unit/run.php
+
+		-
+			message: '#^Constant ABSPATH not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: tillit-payment-gateway.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,25 @@
+
+# Static analysis config (TWO-25108). The repo has no Composer, so the
+# WordPress/WooCommerce stubs are downloaded into dev/stubs/ (gitignored)
+# before running — see .github/workflows/static-analysis.yaml and the
+# Makefile's `phpstan` target for the pinned-SHA curl commands (bump those,
+# not this comment, when refreshing stubs).
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 2
+    # Analyse as the plugin's declared PHP floor (see unit-tests.yaml matrix)
+    # so results don't drift with the PHP version running phpstan.
+    phpVersion: 70400
+    paths:
+        - tillit-payment-gateway.php
+        - class
+        - brands
+        - snippets
+        - views
+        - tests/unit
+        - docker/mu-plugins
+    scanFiles:
+        - dev/stubs/wordpress-stubs.php
+        - dev/stubs/woocommerce-stubs.php

--- a/snippets/admin-order-list-columns.php
+++ b/snippets/admin-order-list-columns.php
@@ -24,7 +24,6 @@ function add_filtering_query($query)
         && in_array($pagenow, array('edit.php', 'upload.php'))
         && (! empty($_GET['delivery_date_from']) || ! empty($_GET['delivery_date_to']))
     ) {
-
         $orderby = $query->get('orderby');
 
         if (true || 'order_delivery_date' == $orderby) {
@@ -94,7 +93,6 @@ function add_custom_columns($columns)
     }
 
     return $new_columns;
-
 }
 
 
@@ -109,7 +107,6 @@ function add_custom_sortable_columns($columns)
     $columns['order_delivery_date'] = 'order_delivery_date';
 
     return $columns;
-
 }
 
 
@@ -137,7 +134,6 @@ function add_custom_columns_content($column)
             }
         }
     }
-
 }
 
 
@@ -180,5 +176,4 @@ function add_delivery_date_filter_form_inputs()
 
     });
     </script>';
-
 }

--- a/snippets/delivery-date-checkout.php
+++ b/snippets/delivery-date-checkout.php
@@ -33,7 +33,7 @@ function add_delivery_date_field($checkout)
     $dateoptions = array('' => __('Select Pickup Date', 'twoinc-payment-gateway'));
 
     echo '<div id="delivery-date">';
-    echo '<h3>'.__('Delivery Date', 'twoinc-payment-gateway').'</h3>';
+    echo '<h3>' . __('Delivery Date', 'twoinc-payment-gateway') . '</h3>';
 
     echo '
     <script>
@@ -147,12 +147,10 @@ function prepend_to_order_note($post_id, $post, $update)
     $existing_note = $order->get_customer_note();
     $order->set_customer_note('Delivery date: ' . $d->format(get_option('date_format')));
     if ($existing_note) {
-
         $order->set_customer_note($order->get_customer_note() . '
 '
         . $existing_note);
     }
 
     $order->save();
-
 }

--- a/snippets/two-demo/functions-part.php
+++ b/snippets/two-demo/functions-part.php
@@ -67,7 +67,7 @@ document.addEventListener("DOMContentLoaded", function() {
 })
 </script>
 
-<?php
+    <?php
 }
 add_action('woocommerce_before_checkout_billing_form', 'add_demo_replace_due_in_days_script');
 
@@ -115,7 +115,7 @@ document.addEventListener("DOMContentLoaded", function() {
 })
 </script>
 
-<?php
+        <?php
     }
 }
 add_action('wp_footer', 'update_due_in_days_in_confirm_page');

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -347,9 +347,11 @@ function twoinc_ajax_term_fees()
     $raw_terms = isset($_POST['terms']) ? wp_unslash($_POST['terms']) : '';
     $decoded = is_string($raw_terms) ? json_decode($raw_terms, true) : $raw_terms;
     $terms = is_array($decoded) ? array_map('intval', $decoded) : [];
-    if (count(array_filter($terms, static function ($d) {
-        return $d > 0;
-    })) === 0) {
+    if (
+        count(array_filter($terms, static function ($d) {
+            return $d > 0;
+        })) === 0
+    ) {
         wp_send_json_error('No terms');
         return;
     }

--- a/views/woocommerce_checkout.php
+++ b/views/woocommerce_checkout.php
@@ -1,5 +1,7 @@
 <?php
+
 /**
  * @global WC_Checkout $checkout
  */
-$checkout = WC()->checkout(); ?>
+
+$checkout = WC()->checkout();

--- a/views/woocommerce_order_pay.php
+++ b/views/woocommerce_order_pay.php
@@ -19,13 +19,13 @@
                 <?php
                     $countries = WC()->countries->get_countries();
                     $base_country = WC()->countries->get_base_country();
-                    foreach ($countries as $country_code => $country_name) {
-                        if ($base_country === $country_code) {
-                            printf('<option value="%s" selected>%s</option>', $country_code, $country_name);
-                        } else {
-                            printf('<option value="%s">%s</option>', $country_code, $country_name);
-                        }
+                foreach ($countries as $country_code => $country_name) {
+                    if ($base_country === $country_code) {
+                        printf('<option value="%s" selected>%s</option>', $country_code, $country_name);
+                    } else {
+                        printf('<option value="%s">%s</option>', $country_code, $country_name);
                     }
+                }
                 ?>
             </select>
         </div>


### PR DESCRIPTION
## Summary

WooCommerce plugin CI ran unit (custom runner) + style (pre-commit) + e2e, but had no static-analysis layer — unlike Magento's phpstan+codesniffer gate. This adds both, matching the org pattern.

- **phpcs** — PSR-12 ruleset (`phpcs.xml`). Not WordPress-Extra/WPCS: WPCS needs PHPCSUtils + PHPCompatibility as separate dependencies, which would require Composer or fragile git-clone wiring in a repo that deliberately has neither. PSR-12 is built into phpcs core — zero extra deps. Documented excludes for WC/WordPress conventions (snake_case gateway callback methods, `WC_`-prefixed classes, no namespace, side-effect entry files). Existing violations were `phpcbf`-fixed (whitespace/brace only, no behaviour change); remaining line-length issues are visible warnings, non-gating.
- **phpstan** — level 2 (`phpstan.neon` + `phpstan-baseline.neon`). `phpVersion` pinned to the plugin's declared PHP floor (7.4) so results don't drift with whatever PHP the CI runner uses. No Composer, so WP/WooCommerce API stubs (`php-stubs/wordpress-stubs`, `php-stubs/woocommerce-stubs`) are fetched fresh per CI run rather than committed — pinned to a commit SHA (not `master`) so stub content, and what the baseline reflects, only changes on a deliberate bump.
- New `.github/workflows/static-analysis.yaml` with `phpcs` + `phpstan` jobs, same `on:`/`concurrency:`/`permissions:`/`RUNNER_STANDARD` conventions as `unit-tests.yaml`. Existing unit/style/e2e workflows untouched.
- Optional local `make phpcs` / `make phpstan` targets mirroring CI exactly (same tool versions, same PHP minor, same pinned stub SHAs).

## Validation

* phpcs job runs on PR; confirmed locally a deliberate PSR-12 violation fails the check (exit 1), reverted, HEAD is clean (exit 0, warnings only).
* phpstan job runs on PR; confirmed locally a deliberate undefined-method call fails the check (exit 1), reverted, HEAD is clean (`[OK] No errors`).
* `tests/unit/run.php` passes unchanged.

## Self-review

Adversarially reviewed (Leia/Han/Vader/Obi-Wan personas, 4 lenses). Findings applied:
- **[Fixed, 3/4 convergent]** Stub curl URLs were unpinned to `master` — a supply-chain risk (upstream change could break CI or silently drift the baseline with zero diff on this PR). Pinned to commit SHAs, both in the workflow and the Makefile.
- **[Fixed, Vader]** `phpstan.neon`'s `paths:` omitted `docker/mu-plugins/` even though it ships real production PHP and phpcs already gated it. Added — reran phpstan, no new errors, no baseline change needed.
- **[Fixed, 3 reviewers]** Makefile's local Docker image (`php:8.2-cli`) didn't match CI's PHP 8.3. Bumped to match.
- **[Fixed, Han]** Added retry/timeout flags to the stub curl calls so a transient network blip doesn't fail the gate with a confusing signal.
- **[Noted, not blocking]** The phpstan baseline silently accepts two pre-existing real bugs (undefined `$order` in `delivery-date-checkout.php`; a `sprintf` arg-count mismatch in `WC_Twoinc.php`) — worth a follow-up ticket, out of scope here.

— posted by Claude