### PR TITLE
ABN-467/feat: brand-configurable admin method title

### DIFF
--- a/brands/two.php
+++ b/brands/two.php
@@ -19,6 +19,15 @@ return [
     'provider' => 'Two',
     'provider_full_name' => 'Two',
     'product_name' => 'Two',
+    // Admin-facing gateway name in WooCommerce's Settings > Payments
+    // list (WC_Payment_Gateway::$method_title). Separate from
+    // product_name because an overlay may want a different admin label
+    // there without moving the load-bearing product_name used in the
+    // plugin name, API-key labels, error notices and about copy. null
+    // or '' falls back to product_name, so an overlay that never declares
+    // this key behaves exactly as before.
+    // WC_Twoinc::get_brand_method_title is the only reader.
+    'method_title' => null,
     'sign_up_url' => 'https://portal.two.inc/auth/merchant/signup',
     // sprintf template building environment hosts, mirroring the Magento
     // brand descriptor's checkout_url_template: %s receives 'api' /

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -48,7 +48,7 @@ if (!class_exists('WC_Twoinc')) {
             $this->id = WC_Twoinc_Brand::get('gateway_id');
             $this->has_fields = false;
             $this->order_button_text = __('Place order', 'twoinc-payment-gateway');
-            $this->method_title = WC_Twoinc_Brand::get('product_name');
+            $this->method_title = self::get_brand_method_title();
             $this->method_description = __('Making it easy for businesses to buy online.', 'twoinc-payment-gateway');
             $this->icon = WC_HTTPS::force_https_url(WC_Twoinc_Brand::get('logo_url'));
             $this->supports = ['products', 'refunds'];
@@ -635,6 +635,23 @@ if (!class_exists('WC_Twoinc')) {
              * @param WC_Twoinc $gateway The gateway instance.
              */
             return apply_filters('twoinc_about_html', $html, $this);
+        }
+
+        /**
+         * Admin-facing gateway name shown in WooCommerce's
+         * Settings > Payments list.
+         *
+         * A brand overlay may set 'method_title' to label the gateway
+         * there without touching product_name, which is load-bearing
+         * elsewhere. An absent or empty key falls back to product_name,
+         * so an overlay that never declares it behaves as before.
+         *
+         * @return string
+         */
+        public static function get_brand_method_title()
+        {
+            $method_title = WC_Twoinc_Brand::get('method_title');
+            return $method_title ? strval($method_title) : strval(WC_Twoinc_Brand::get('product_name'));
         }
 
         /**

--- a/class/WC_Twoinc_FX.php
+++ b/class/WC_Twoinc_FX.php
@@ -353,7 +353,8 @@ if (!class_exists('WC_Twoinc_FX')) {
             }
             $from_value = self::base_value($table, $from);
             $to_value = self::base_value($table, $to);
-            if (($from_value === null || $to_value === null)
+            if (
+                ($from_value === null || $to_value === null)
                 && $gateway
                 && !self::$fetched_this_request
                 && !self::is_fresh($table)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -79,6 +79,12 @@ parameters:
 			path: tests/unit/run.php
 
 		-
+			message: '#^Access to an undefined property WC_Twoinc\:\:\$fx_requests\.$#'
+			identifier: property.notFound
+			count: 11
+			path: tests/unit/run.php
+
+		-
 			message: '#^Access to an undefined property WC_Twoinc\:\:\$requests\.$#'
 			identifier: property.notFound
 			count: 6

--- a/tests/unit/fixtures/methodtitlebrand.php
+++ b/tests/unit/fixtures/methodtitlebrand.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Brand fixture for the admin method_title override — an overlay that
+ * labels the Settings > Payments row differently from its product_name.
+ */
+
+return [
+    'code' => 'methodtitlebrand',
+    'product_name' => 'Methodtitlebrand',
+    'method_title' => 'Admin Label Override',
+];

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -137,6 +137,8 @@ final class BrandConfigSpec
             'testBuyerFeeShareCapRoundingToZeroWithholdsWholeSurcharge',
             'testCartFeeSkippedOnQuoteCurrencyMismatch',
             'testMinimumDescriptionShowsConvertedFloorWhenRateAvailable',
+            'testMethodTitleUsesBrandOverrideWhenDeclared',
+            'testMethodTitleFallsBackToProductNameWhenAbsent',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -3389,6 +3391,30 @@ final class BrandConfigSpec
         } finally {
             unset($GLOBALS['__twoinc_test_store_currency']);
         }
+    }
+
+    private static function testMethodTitleUsesBrandOverrideWhenDeclared(): void
+    {
+        // An overlay declaring method_title labels the admin
+        // Settings > Payments row without disturbing product_name.
+        add_filter('twoinc_brand_file', static function ($file) {
+            return __DIR__ . '/fixtures/methodtitlebrand.php';
+        });
+
+        TinyAssert::same('Admin Label Override', WC_Twoinc::get_brand_method_title());
+        TinyAssert::same('Methodtitlebrand', WC_Twoinc_Brand::get('product_name'));
+    }
+
+    private static function testMethodTitleFallsBackToProductNameWhenAbsent(): void
+    {
+        // Two declares no method_title, and testbrand (like any overlay
+        // predating the key) does not either — both fall back.
+        TinyAssert::same(null, WC_Twoinc_Brand::get('method_title'));
+        TinyAssert::same('Two', WC_Twoinc::get_brand_method_title());
+
+        WC_Twoinc_Brand::reset();
+        self::useTestbrand();
+        TinyAssert::same('Testbrand', WC_Twoinc::get_brand_method_title());
     }
 }
 

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -972,8 +972,8 @@ final class BrandConfigSpec
             // TTL expiry only ever happens across requests, so an expiry is
             // also a request boundary for the per-request record memo.
             WC_Twoinc::reset_merchant_record_memo();
-        WC_Twoinc_FX::reset_request_cache();
-        $GLOBALS['__twoinc_test_transients'] = [];
+            WC_Twoinc_FX::reset_request_cache();
+            $GLOBALS['__twoinc_test_transients'] = [];
         };
 
         // Default (cache-only) read NEVER fetches, even with a cold cache —


### PR DESCRIPTION
## What

Adds a new brand-config key `method_title` to `brands/two.php`, and reads it for `WC_Payment_Gateway::$method_title` — the gateway name WooCommerce shows in the admin **Settings > Payments** list.

- `brands/two.php`: `'method_title' => null`, documented in the same comment style as its neighbours.
- `class/WC_Twoinc.php`: new `WC_Twoinc::get_brand_method_title()`; the constructor calls it instead of reading `product_name` directly. An absent, `null` or `''` value falls back to `product_name`.
- `tests/unit/`: new brand fixture plus two cases, one per branch.

## Why

Linear ABN-467 — the ABN overlay needs a different label in the admin payments list. `product_name` could not simply be changed: it is load-bearing for the plugin name, the API-key setting labels, error notices and the about copy. Splitting out an admin-only label leaves all of those untouched.

`method_title` is a fixed contract between the base plugin and its overlays. **The consumer half is a separate PR on the ABN overlay repo**, which sets the key in its own brand file. Any overlay that does not declare the key keeps today's behaviour exactly — that fallback is what the second unit test pins.

## Commits

1. `ABN-467/feat` — the change described above. **This is the only commit that touches behaviour.**
2. `ABN-467/fix` — 3 pre-existing **phpcs** errors. `phpcbf` auto-fixes, no behaviour change: `WC_Twoinc_FX.php` PSR-12 multi-line control structure, and two statements in `tests/unit/run.php` indented as if outside the closure they were always inside.
3. `ABN-467/fix` — 11 pre-existing **phpstan** errors, via one `phpstan-baseline.neon` entry. `tests/unit/run.php` reads `$fx_requests` off an anonymous `WC_Twoinc` subclass; the baseline already carries the identical pattern for `$requests` (count 6) and `$test_post_data` (count 2).

Commits 2 and 3 are **not part of this ticket**. Both gates were already failing on `staging` and would have kept every new PR red — the FX cutover and the branch that introduced phpcs/phpstan landed without re-validating against each other, so `staging` carries errors neither PR saw. They are split into their own labelled commits so the feature diff stays legible, and the fix belongs on the shared base rather than only in this branch. Verified against CI, not just locally: phpcs failed on the first push with exactly those 3 errors and passed after commit 2.

## Verification

Ran the gates CI runs (`unit-tests.yaml`, `static-analysis.yaml`) locally, against the tool versions those workflows pin:

- `php tests/unit/run.php` → `All tests passed.`, including `testMethodTitleUsesBrandOverrideWhenDeclared` and `testMethodTitleFallsBackToProductNameWhenAbsent`.
- Mutation-checked the new tests: stubbing the fallback out to always return `product_name` makes the override test fail with `Expected 'Admin Label Override', got 'Methodtitlebrand'` — so they are not vacuous.
- `phpcs` 4.0.1 → `A TOTAL OF 0 ERRORS AND 281 WARNINGS WERE FOUND IN 11 FILES` (warnings are ungated by `phpcs.xml`).
- `phpstan` 2.2.5, level 2, pinned stubs → `[OK] No errors`.
- Before commits 2 and 3, both tools reported findings byte-identical with and without the feature diff, so **the feature change introduces no new violations of either gate**.