### PR TITLE
TWO-25160/fix: company-search label sandwiched between the name fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ tests/e2e/test-results/
 tests/e2e/playwright-report/
 .review/
 dev/stubs/
+
+# Local worktrees (org convention: <repo>/.worktrees/<branch-slug>/)
+.worktrees/

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -97,7 +97,15 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                         'data-multiple' => true,
                         'data-multi' => true
                     ],*/
-                    'class' => array('billing_company_selectwoo', 'hidden'),
+                    // form-row-wide is what carries WooCommerce's
+                    // `clear: both` (and full width) for a checkout row.
+                    // Without it this row does not clear the
+                    // form-row-first/form-row-last float pair that the first-
+                    // and last-name rows form, so its label's line boxes get
+                    // squeezed into the gutter between those two 47% floats —
+                    // the label renders wrapped between the two name inputs
+                    // (TWO-25160).
+                    'class' => array('billing_company_selectwoo', 'form-row-wide', 'hidden'),
                     'options' => [
                         '' => '&nbsp;'
                     ],


### PR DESCRIPTION
## Problem

On the classic checkout, the label of the injected company-search field
(`#billing_company_display`) renders wrapped into the narrow gutter *between*
the first-name and last-name inputs, instead of sitting above its own select
below the name row. Cosmetic, but it is on the primary checkout surface and
reads as broken.

## Diagnosis

Reproduced on the live WooCommerce staging shop (`woocom.staging.two.inc`,
Astra theme) — the company row's box shares the same `y` as the two name rows
and its label wraps to 135px tall, three characters per line.

The cause is the missing width class, not the field priority:

* The field is declared with `class => ['billing_company_selectwoo', 'hidden']`
  — no `form-row-*` class at all. `form-row-wide` is what carries WooCommerce's
  `clear: both` (and full width) for a checkout row; WooCommerce's own
  `billing_company` field has it. Without it the row never clears the
  `form-row-first` / `form-row-last` float pair the two name rows form, so the
  row box overlaps that band and the label's line boxes are shortened to the
  ~6% gutter between the two 47% floats.
* Priority was ruled out: the row sorts at 30, correctly after last name at 20
  (`data-priority` confirmed in the rendered staging HTML).
* Label placement was ruled out: the label is already inside the row's own
  `<p id="billing_company_display_field">` wrapper.

## Fix

One class added to the field definition. Verified on the live staging checkout
by applying exactly this class: the company row moves below the name rows, its
label collapses to a single full-width 27px line, and both name rows keep
byte-identical geometry — the 50/50 pair is untouched.

Not affected: the order-pay page builds its own
`#billing_company_display_field` markup in `views/woocommerce_order_pay.php`
and never passes through the `woocommerce_checkout_fields` filter.

## Also in this PR

* `chore: gitignore .worktrees` — the org convention puts task worktrees inside
  the repo at `.worktrees/<branch-slug>/`, which was not ignored here.
* `fix: repair phpcs + phpstan gates broken on staging` — both static-analysis
  gates are red on `origin/staging` independently of this change. The
  TWO-25108 gate and the TWO-25104 FX cutover landed around the same time and
  the workflow only triggers on `pull_request`, so it never ran against the
  merge result. 3 phpcs errors (indentation in the unit harness, a PSR-12
  multi-line `if` in `WC_Twoinc_FX`) and 11 phpstan errors (`fxGateway()`'s
  declared `WC_Twoinc` return type hid the anonymous subclass's `$fx_requests`
  counter). **This breakage lives on the shared base, so this PR is not the
  only place that needs it.**

## Verification

```
phpcs   → A TOTAL OF 0 ERRORS AND 281 WARNINGS WERE FOUND IN 11 FILES  (exit 0)
phpstan → [OK] No errors                                              (exit 0)
tests   → All tests passed.
```

## Known related, not fixed here

The ABN overlay (`woocommerce-abn-plugin`) inherits this field definition from
the base plugin, so it carries the same latent defect; it does not currently
manifest on `woocom.staging.achterafbetalen.co` because WooCommerce's own
(full-width) Company field sits between the name row and the company-search
row there and already clears the floats. It is fixed for free by this change.

Linear: TWO-25160

🤖 Generated with [Claude Code](https://claude.com/claude-code)