### PR TITLE
TWO-24816/fix: source the API locale from determine_locale()

### DIFF
--- a/class/WC_Twoinc_FX.php
+++ b/class/WC_Twoinc_FX.php
@@ -353,7 +353,8 @@ if (!class_exists('WC_Twoinc_FX')) {
             }
             $from_value = self::base_value($table, $from);
             $to_value = self::base_value($table, $to);
-            if (($from_value === null || $to_value === null)
+            if (
+                ($from_value === null || $to_value === null)
                 && $gateway
                 && !self::$fetched_this_request
                 && !self::is_fresh($table)

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -1067,15 +1067,25 @@ if (!class_exists('WC_Twoinc_Helper')) {
         }
 
         /**
-         * Get the user locale in full form, e.g. en_US — sent as the
-         * invoice PDF `lang` parameter and the Accept-Language header,
-         * both of which accept the full form.
+         * Get the locale of the current request in full form, e.g. en_US —
+         * sent as the invoice PDF `lang` parameter and the Accept-Language
+         * header, both of which accept the full form (underscore, not
+         * hyphen: the API matches `lang` literally against its allow-list).
+         *
+         * determine_locale(), not get_user_locale(): on the storefront the
+         * page — including this plugin's own translated strings — is rendered
+         * in the site/switched locale, so that is the language the API should
+         * answer in too. get_user_locale() instead returns the WP profile
+         * language of a logged-in buyer, which can differ from the checkout
+         * page around it. In wp-admin (and admin-ajax, i.e. the invoice
+         * download) determine_locale() resolves to the user locale anyway,
+         * so that path is unchanged.
          *
          * @return string
          */
         public static function get_locale()
         {
-            $locale = get_user_locale();
+            $locale = determine_locale();
             if ($locale && strlen($locale) > 0) {
                 return $locale;
             }

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -103,9 +103,9 @@ function wc_get_price_decimals()
     return 2;
 }
 
-function get_user_locale()
+function determine_locale()
 {
-    return 'en_US';
+    return $GLOBALS['__twoinc_test_locale'] ?? 'en_US';
 }
 
 function is_admin()

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -971,8 +971,8 @@ final class BrandConfigSpec
             // TTL expiry only ever happens across requests, so an expiry is
             // also a request boundary for the per-request record memo.
             WC_Twoinc::reset_merchant_record_memo();
-        WC_Twoinc_FX::reset_request_cache();
-        $GLOBALS['__twoinc_test_transients'] = [];
+            WC_Twoinc_FX::reset_request_cache();
+            $GLOBALS['__twoinc_test_transients'] = [];
         };
 
         // Default (cache-only) read NEVER fetches, even with a cold cache —
@@ -2927,8 +2927,12 @@ final class BrandConfigSpec
      * (last entry sticky), and a request counter for over-fetch
      * assertions. Any other endpoint errors — the FX layer must never
      * stray off its own endpoint.
+     *
+     * No `: WC_Twoinc` return type — that widens the anonymous class away
+     * and static analysis then cannot see $fx_requests on the returned
+     * object. Returning it untyped lets the exact anon class be inferred.
      */
-    private static function fxGateway(?array $platform_minimum, array $fx_responses, array $options = []): WC_Twoinc
+    private static function fxGateway(?array $platform_minimum, array $fx_responses, array $options = [])
     {
         return new class ($platform_minimum, $fx_responses, $options) extends WC_Twoinc {
             private $test_platform_minimum;

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -98,6 +98,7 @@ final class BrandConfigSpec
             'testSoleTraderSignupUrlFollowsEnvAndFilter',
             'testEnvironmentModeNormalisesStoredCheckoutEnv',
             'testEnvironmentHostFollowsModeAndBrandTemplate',
+            'testLocaleFollowsRequestLocaleWithEnglishFallback',
             'testCheckoutHostPrefersExplicitModeOverDevSniffing',
             'testCheckoutEnvOptionsPreserveStoredModeWithoutSettingsApi',
             'testInvoiceDownloadStreamsPdf',
@@ -2314,6 +2315,24 @@ final class BrandConfigSpec
         foreach ($cases as [$stored, $expected]) {
             $gateway = self::soleTraderGateway(['checkout_env' => $stored], []);
             TinyAssert::same($expected, WC_Twoinc_Helper::get_environment_mode($gateway), $stored ?: '(empty)');
+        }
+    }
+
+    private static function testLocaleFollowsRequestLocaleWithEnglishFallback(): void
+    {
+        // The locale travels as the Accept-Language header and the invoice
+        // PDF `lang` param, so it must describe the language of the request
+        // being served. determine_locale() is the source (the stub is the
+        // only definition in the harness — reverting to get_user_locale()
+        // would fatal here), and an empty result falls back to en_US rather
+        // than sending a blank header.
+        $GLOBALS['__twoinc_test_locale'] = 'nb_NO';
+        try {
+            TinyAssert::same('nb_NO', WC_Twoinc_Helper::get_locale());
+            $GLOBALS['__twoinc_test_locale'] = '';
+            TinyAssert::same('en_US', WC_Twoinc_Helper::get_locale());
+        } finally {
+            unset($GLOBALS['__twoinc_test_locale']);
         }
     }
 


### PR DESCRIPTION
## Audit (TWO-24816)

`get_locale()` in this plugin is a helper, not WordPress's `get_locale()`. Every call site goes through it — there are no direct WordPress locale calls anywhere in the plugin:

| Call site | Locale used for | Verdict |
| --- | --- | --- |
| `class/WC_Twoinc_Helper.php:1076` (`WC_Twoinc_Helper::get_locale`) | The single source for both consumers below | Was `get_user_locale()` — wrong on the storefront, fixed here |
| `class/WC_Twoinc.php:3774` (`make_request`) | `Accept-Language` header on every API request, including checkout order create/update | Buyer/request locale is what is meant; `determine_locale()` is the WordPress function that resolves it |
| `class/WC_Twoinc.php:1507` (`resolve_invoice_download`) | `lang` query parameter on the invoice PDF fetch | Admin-ajax, so the admin user's locale — behaviour unchanged (`determine_locale()` returns the user locale in admin) |
| `snippets/two-demo/functions-part.php:19` | Picks a hard-coded checkout field label per language, demo snippet only | Storefront locale is what is meant; inherits the helper fix, snippet untouched |

## Fix

Only the helper changes: `determine_locale()` instead of `get_user_locale()`.

On the storefront the page — including this plugin's own translated strings — is rendered in the site or language-switched locale, which WordPress resolves with `determine_locale()`. `get_user_locale()` instead returns a logged-in buyer's WordPress profile language, so a buyer whose profile is set to one language while shopping the store in another had the API answer in a different language from the page around it. In wp-admin and admin-ajax `determine_locale()` resolves to the user locale anyway, so the invoice-download path is unchanged.

### Deliberately not changed

- **The underscore form (`nb_NO`, not `nb-NO`).** The API matches the `lang` query parameter literally against an allow-list of underscore locales, so hyphenating it would break the invoice PDF language. On the header side Werkzeug normalises the separator before matching, so `nb_NO` resolves correctly there too. Documented on the helper so it does not get "corrected" later.
- **No translation-loading changes, no user-visible strings.**

## Test coverage

`testLocaleFollowsRequestLocaleWithEnglishFallback` covers both branches (resolved locale, and the `en_US` fallback on an empty result). The harness stub for `get_user_locale()` is replaced by one for `determine_locale()`, so a regression back to the user locale fails loudly with an undefined function rather than silently.

## Second commit: red base

Staging is currently red on both static-analysis gates, unrelated to this work — TWO-25108 added the gates and TWO-25104 added the FX layer, both green when they last ran, but neither re-ran after the other merged. `TWO-25104/fix` in this PR carries the fix (one PSR-12 multi-line condition, one mis-indented pair of statements in a test closure, and eleven phpstan `property.notFound` errors caused by `fxGateway()`'s return type widening away the anonymous class that declares `$fx_requests`). The fix is only in this PR — it is not on staging.

Local runs of the CI commands, on this branch:

- `make phpcs` → exit 0 (warnings only; `ignore_warnings_on_exit`)
- `make phpstan` → `[OK] No errors`
- `make test-unit` → `All tests passed.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)