### PR TITLE
TWO-25170/fix: resolve checkout page host from the same environment as the API host

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -197,6 +197,10 @@ if (!class_exists('WC_Twoinc')) {
             // an explicit Production selection is indistinguishable from the
             // never-configured default, so the sniffer still applies there.
             // Set checkout_env instead of extending the sniffer.
+            //
+            // WC_Twoinc_Helper::get_effective_environment_mode() encodes the
+            // same condition so that every other host the gateway emits lands
+            // in the environment this host picks; keep the two in step.
             if (
                 WC_Twoinc_Helper::get_environment_mode($this) === 'production'
                 && WC_Twoinc_Helper::is_twoinc_development()

--- a/class/WC_Twoinc_Helper.php
+++ b/class/WC_Twoinc_Helper.php
@@ -1048,11 +1048,79 @@ if (!class_exists('WC_Twoinc_Helper')) {
         }
 
         /**
+         * The environment the gateway actually talks to, i.e. the one the API
+         * host resolves to — which is not always the configured mode.
+         *
+         * On a dev-sniffed shop (see is_twoinc_development()) carrying the
+         * never-configured default mode, the API host comes from the free-text
+         * `test_checkout_host` option rather than from the brand template, so
+         * the configured mode ('production') is not the environment in use.
+         * Every host the gateway hands the browser has to follow the API host,
+         * or the shop mints tokens in one environment and sends the buyer to
+         * an app in another (TWO-25170: staging-minted delegation tokens
+         * rejected 401 by the production API behind the production hosted
+         * signup page). So read the environment back out of the test host.
+         *
+         * @param WC_Payment_Gateway $gateway
+         *
+         * @return string one of ENVIRONMENT_MODES
+         */
+        public static function get_effective_environment_mode($gateway)
+        {
+            $mode = self::get_environment_mode($gateway);
+            if ($mode !== 'production' || !self::is_twoinc_development()) {
+                return $mode;
+            }
+            return self::environment_mode_of_host((string) $gateway->get_option('test_checkout_host'));
+        }
+
+        /**
+         * Classify an API host into an environment mode: the brand's
+         * production API host is 'production', a host whose leading labels are
+         * `api.<mode>` is that mode (any domain — dev shops legitimately point
+         * the test host off the brand's domains).
+         *
+         * A dev-sniffed shop is by definition not a production shop, so a host
+         * this cannot classify (localhost, a bespoke tunnel) falls back to
+         * 'staging' — the option's own default, and the safe direction: a test
+         * environment can neither take real money nor accept a production
+         * token.
+         *
+         * @param string $host
+         *
+         * @return string one of ENVIRONMENT_MODES
+         */
+        private static function environment_mode_of_host($host)
+        {
+            $hostname = (string) parse_url($host, PHP_URL_HOST);
+            $production = (string) parse_url(
+                sprintf(WC_Twoinc_Brand::get('checkout_url_template'), 'api'),
+                PHP_URL_HOST
+            );
+            if ($hostname !== '' && $hostname === $production) {
+                return 'production';
+            }
+            $labels = explode('.', $hostname);
+            if (
+                count($labels) > 1
+                && $labels[0] === 'api'
+                && in_array($labels[1], self::ENVIRONMENT_MODES, true)
+                && $labels[1] !== 'production'
+            ) {
+                return $labels[1];
+            }
+            return 'staging';
+        }
+
+        /**
          * Build an environment host from the brand's URL template, mirroring
          * the Magento config repository: ('api', mode 'staging') on the Two
          * brand -> https://api.staging.two.inc; production drops the mode
          * suffix. The template itself comes from the brand registry, so a
          * brand overlay carries its own domains.
+         *
+         * Resolves off the *effective* mode, so every service host the gateway
+         * emits sits in the same environment as its API host.
          *
          * @param string             $service 'api' or 'checkout'
          * @param WC_Payment_Gateway $gateway
@@ -1061,7 +1129,7 @@ if (!class_exists('WC_Twoinc_Helper')) {
          */
         public static function get_environment_host($service, $gateway)
         {
-            $mode = self::get_environment_mode($gateway);
+            $mode = self::get_effective_environment_mode($gateway);
             $prefix = $mode === 'production' ? $service : $service . '.' . $mode;
             return sprintf(WC_Twoinc_Brand::get('checkout_url_template'), $prefix);
         }

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -100,6 +100,7 @@ final class BrandConfigSpec
             'testEnvironmentHostFollowsModeAndBrandTemplate',
             'testLocaleFollowsRequestLocaleWithEnglishFallback',
             'testCheckoutHostPrefersExplicitModeOverDevSniffing',
+            'testServiceHostsShareTheApiHostsEnvironment',
             'testCheckoutEnvOptionsPreserveStoredModeWithoutSettingsApi',
             'testInvoiceDownloadStreamsPdf',
             'testInvoiceDownloadFulfillingIsInfoNotice',
@@ -2396,6 +2397,89 @@ final class BrandConfigSpec
         // Non-dev brand shop with explicit staging mode: no sniffing needed.
         $GLOBALS['test_home_url'] = 'https://brand-shop.staging.brand.example';
         TinyAssert::same('https://api.staging.two.inc', $make(['checkout_env' => 'staging'])->get_twoinc_checkout_host());
+    }
+
+    /**
+     * The invariant TWO-25170 violated: every service host the gateway emits
+     * resolves to the environment the API host resolves to. A dev-sniffed shop
+     * on the never-configured default mode reaches staging over the API, so its
+     * hosted signup page has to be staging's — a production page rejects the
+     * staging-minted delegation token with 401.
+     */
+    private static function testServiceHostsShareTheApiHostsEnvironment(): void
+    {
+        $make = static function (array $options) {
+            return new class ($options) extends WC_Twoinc {
+                private $options;
+                public function __construct($options)
+                {
+                    $this->id = WC_Twoinc_Brand::get('gateway_id');
+                    $this->options = $options;
+                }
+                public function get_option($key, $empty_value = null)
+                {
+                    return $this->options[$key] ?? $empty_value ?? '';
+                }
+            };
+        };
+
+        // Dev-sniffed shop, default mode, default test host: staging both ways.
+        $GLOBALS['test_home_url'] = 'https://woocom.staging.two.inc';
+        $gateway = $make(['test_checkout_host' => 'https://api.staging.two.inc']);
+        TinyAssert::same('https://api.staging.two.inc', $gateway->get_twoinc_checkout_host());
+        TinyAssert::same(
+            'https://checkout.staging.two.inc',
+            WC_Twoinc_Helper::get_environment_host('checkout', $gateway)
+        );
+        TinyAssert::same(
+            'https://checkout.staging.two.inc/soletrader/signup',
+            WC_Twoinc_Sole_Trader::get_signup_page_url($gateway)
+        );
+
+        // The page host tracks whichever environment the test host names.
+        $gateway = $make(['test_checkout_host' => 'https://api.sandbox.two.inc']);
+        TinyAssert::same('https://api.sandbox.two.inc', $gateway->get_twoinc_checkout_host());
+        TinyAssert::same(
+            'https://checkout.sandbox.two.inc',
+            WC_Twoinc_Helper::get_environment_host('checkout', $gateway)
+        );
+
+        // An unclassifiable test host (local tunnel) is still not production.
+        $gateway = $make(['test_checkout_host' => 'http://localhost:8080']);
+        TinyAssert::same(
+            'https://checkout.staging.two.inc',
+            WC_Twoinc_Helper::get_environment_host('checkout', $gateway)
+        );
+
+        // A dev shop deliberately pointed at the production API keeps the
+        // production page, so the pair stays consistent in that direction too.
+        $gateway = $make(['test_checkout_host' => 'https://api.two.inc']);
+        TinyAssert::same('https://api.two.inc', $gateway->get_twoinc_checkout_host());
+        TinyAssert::same(
+            'https://checkout.two.inc',
+            WC_Twoinc_Helper::get_environment_host('checkout', $gateway)
+        );
+
+        // A real merchant shop is untouched: production API, production page.
+        $GLOBALS['test_home_url'] = 'https://shop.merchant.example';
+        $gateway = $make([]);
+        TinyAssert::same('https://api.two.inc', $gateway->get_twoinc_checkout_host());
+        TinyAssert::same(
+            'https://checkout.two.inc',
+            WC_Twoinc_Helper::get_environment_host('checkout', $gateway)
+        );
+
+        // Brand-agnostic: an overlay's own domains follow the same rule, with
+        // no brand-specific branch — the resolution is template-driven.
+        WC_Twoinc_Brand::reset();
+        self::useTestbrand();
+        $GLOBALS['test_home_url'] = 'https://woocom-brand.staging.two.inc';
+        $gateway = $make(['test_checkout_host' => 'https://api.staging.testbrand.example']);
+        TinyAssert::same('https://api.staging.testbrand.example', $gateway->get_twoinc_checkout_host());
+        TinyAssert::same(
+            'https://checkout.staging.testbrand.example',
+            WC_Twoinc_Helper::get_environment_host('checkout', $gateway)
+        );
     }
 
     private static function testCheckoutEnvOptionsPreserveStoredModeWithoutSettingsApi(): void


### PR DESCRIPTION
## Problem

The plugin resolves the API host and the hosted checkout-page host through two different code paths, and only the API path honours the legacy dev-host sniff:

- `WC_Twoinc::get_twoinc_checkout_host()` (`class/WC_Twoinc.php`) — when the stored mode resolves to `production` **and** `WC_Twoinc_Helper::is_twoinc_development()` matches the shop hostname, it returns the `test_checkout_host` option, i.e. a staging API host.
- `WC_Twoinc_Sole_Trader::get_signup_page_url()` → `WC_Twoinc_Helper::get_environment_host('checkout', …)` — no dev branch, re-derived from the stored mode alone, so it returned the **production** checkout host.

On a staging shop with `checkout_env` never configured, the browser was therefore told: mint against staging, open the popup on production. The production signup app validates the delegation token against the production API, which rejects it (`401 AUTHENTICATION_INVALID`), and the sole-trader flow dies inside the popup. That is the reported TWO-25170 symptom.

Magento and PrestaShop do not have this bug because both derive the API host and the page host from the same setting. WooCommerce was the only one with an escape hatch on one host and not the other.

## Fix

`WC_Twoinc_Helper::get_effective_environment_mode()` — the environment the gateway *actually* talks to. It equals the stored mode except on a dev-sniffed shop carrying the never-configured default, where the API host comes from the free-text `test_checkout_host` option rather than the brand template; there the mode is read back out of that host.

`get_environment_host()` now resolves off the effective mode, so every service host the gateway emits sits in the same environment as its API host. That is the invariant the bug violated, and it means a future page-host consumer inherits correct behaviour instead of needing its own special case — no special-casing of the sole-trader URL.

Classification is template-driven off the brand registry's `checkout_url_template`, with no brand-specific branch. A test host the classifier cannot place (localhost, a bespoke tunnel) falls back to `staging`: a dev-sniffed shop is by definition not a production shop, `staging` is the option's own default, and a test environment can neither take real money nor accept a production token.

## Brand overlays

`woocommerce-abn-plugin` supplies only `checkout_url_template` and overrides none of `get_environment_host()`, `get_signup_page_url()` or the `twoinc_sole_trader_signup_url` filter — checked by grepping that repo's `staging` branch for all of them. It inherits the fix unchanged, and the new test covers an overlay brand explicitly (`api.staging.<brand>` → `checkout.staging.<brand>`). No change needed in the overlay repo.

## Tests

New `testServiceHostsShareTheApiHostsEnvironment` asserts the API host and the checkout-page host agree on environment across: dev-sniffed shop on a staging test host, on a sandbox test host, on an unclassifiable test host, on a deliberately production test host, a real merchant shop, and an overlay brand. Existing environment-mode/host tests are unchanged and still pass.

```
$ php tests/unit/run.php
PASS BrandConfigSpec::testSoleTraderSignupUrlFollowsEnvAndFilter
PASS BrandConfigSpec::testEnvironmentHostFollowsModeAndBrandTemplate
PASS BrandConfigSpec::testCheckoutHostPrefersExplicitModeOverDevSniffing
PASS BrandConfigSpec::testServiceHostsShareTheApiHostsEnvironment
...
All tests passed.
```

## Static analysis is red on the base branch

`staging` is already failing both static-analysis gates — **phpcs 3 errors** (`class/WC_Twoinc_FX.php:356`, `tests/unit/run.php:974-975`) and **phpstan 11 errors** (all `WC_Twoinc::$fx_requests` in `tests/unit/run.php`) — pre-existing, none in code this PR touches. Running both pinned tools (phpcs 4.0.1, phpstan 2.2.5, same stub SHAs as CI) with and without this change gives byte-identical findings; phpstan's only difference is line numbers shifting past the inserted test. So a red static-analysis job here is base breakage, not this PR. The gate repair is already carried by woocommerce-plugin PR #371 and PR #372, so it is deliberately not duplicated here.

## Not done here

The legacy hostname sniff arguably ought to be retired in favour of an explicit `checkout_env` everywhere, rather than mirrored into a second resolution path. That is a wider and riskier change — it silently repoints any dev install that never set `checkout_env` — and is out of scope for an urgent fix.

Linear: TWO-25170

🤖 Generated with [Claude Code](https://claude.com/claude-code)
