### PR TITLE
TWO-25163/refactor: gate sole trader on country only, drop enable_sole_trader

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -17,12 +17,12 @@ jobs:
   e2e-tests:
     runs-on: ${{ vars.RUNNER_STANDARD }}
     # Must exceed Playwright's own worst case, or a fully-failing suite is
-    # killed before it can report: 3 tests x 2 attempts (retries: 1) x the
-    # 180s per-test timeout = 18m of testing, plus ~4m of setup. At 15m the
+    # killed before it can report: 4 tests x 2 attempts (retries: 1) x the
+    # 180s per-test timeout = 24m of testing, plus ~4m of setup. At 15m the
     # job was cancelled mid-run, which discards the reporter output AND the
     # traces, leaving no way to see why a test failed. A passing run still
-    # takes ~4m, so this ceiling only ever costs time on a broken suite.
-    timeout-minutes: 25
+    # takes ~5m, so this ceiling only ever costs time on a broken suite.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -16,7 +16,13 @@ concurrency:
 jobs:
   e2e-tests:
     runs-on: ${{ vars.RUNNER_STANDARD }}
-    timeout-minutes: 15
+    # Must exceed Playwright's own worst case, or a fully-failing suite is
+    # killed before it can report: 3 tests x 2 attempts (retries: 1) x the
+    # 180s per-test timeout = 18m of testing, plus ~4m of setup. At 15m the
+    # job was cancelled mid-run, which discards the reporter output AND the
+    # traces, leaving no way to see why a test failed. A passing run still
+    # takes ~4m, so this ceiling only ever costs time on a broken suite.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
 
@@ -85,12 +91,18 @@ jobs:
           TWO_ADMIN_PASSWORD: ${{ steps.secrets.outputs.TWO_ADMIN_PASSWORD }}
 
       - name: Upload test results
-        if: failure()
+        # always(), not failure(): a job that exceeds timeout-minutes is
+        # CANCELLED, not failed, and a cancelled job skips every step whose
+        # condition doesn't explicitly reference always()/cancelled() — so
+        # failure() silently threw away the traces for exactly the runs that
+        # needed them most.
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: tests/e2e/test-results/
           retention-days: 7
+          if-no-files-found: ignore
 
       - name: Stop WordPress
         if: always()

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1037,7 +1037,7 @@ let twoincSoleTrader = {
   lastPrefetchEmail: null,
 
   config: function () {
-    return (window.twoinc && window.twoinc.sole_trader) || { enabled: false };
+    return (window.twoinc && window.twoinc.sole_trader) || {};
   },
 
   currentCountry: function () {
@@ -1055,13 +1055,14 @@ let twoincSoleTrader = {
 
   /**
    * Re-evaluate the toggle after every checkout update or country change.
-   * Availability is decided server-side (registry endpoint + merchant
-   * toggle); responses are cached per country for the page's lifetime.
+   * Availability is decided server-side by the registry answer for the
+   * billing country (there is no merchant toggle — TWO-25163); responses
+   * are cached per country for the page's lifetime.
    */
   refresh: function () {
     const cfg = twoincSoleTrader.config();
     const $container = jQuery(".twoinc-sole-trader-toggle");
-    if (!cfg.enabled || !cfg.availability_url || $container.length === 0) {
+    if (!cfg.availability_url || $container.length === 0) {
       twoincSoleTrader.hide();
       return;
     }

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -56,6 +56,7 @@ if (!class_exists('WC_Twoinc')) {
             // Load the settings
             $this->init_form_fields();
             $this->init_settings();
+            $this->drop_removed_settings();
 
             $this->title = sprintf(
                 __($this->get_option('title'), 'twoinc-payment-gateway'),
@@ -602,6 +603,43 @@ if (!class_exists('WC_Twoinc')) {
             foreach ($names as $name) {
                 delete_option(WC_Twoinc_Brand::prefixed_name($name));
             }
+        }
+
+        /**
+         * Drop settings keys whose feature no longer exists, so an upgraded
+         * install doesn't carry a dead key inside the gateway settings blob
+         * (a WooCommerce gateway keeps every setting in the single
+         * `woocommerce_<gateway id>_settings` option, so there is no row to
+         * delete — the key has to be unset from the stored array).
+         *
+         * The plugin has no versioned migration runner, and this deliberately
+         * doesn't introduce one: the routine is self-limiting. It only writes
+         * when a removed key is actually present, and after that one write
+         * there is nothing left for it to do on any later request. To retire
+         * another key, add it to $removed.
+         *
+         * Currently: `enable_sole_trader` (TWO-25163) — sole trader checkout
+         * is gated on the registry's country answer alone, never a merchant
+         * toggle, so a stored value would be silently ignored.
+         *
+         * @return void
+         */
+        private function drop_removed_settings()
+        {
+            $removed = ['enable_sole_trader'];
+            $present = [];
+            foreach ($removed as $key) {
+                if (is_array($this->settings) && array_key_exists($key, $this->settings)) {
+                    $present[] = $key;
+                }
+            }
+            if (count($present) === 0) {
+                return;
+            }
+            foreach ($present as $key) {
+                unset($this->settings[$key]);
+            }
+            update_option($this->get_option_key(), $this->settings);
         }
 
         /**
@@ -3205,18 +3243,9 @@ if (!class_exists('WC_Twoinc')) {
                     'type'        => 'checkbox',
                     'default'     => 'yes'
                 ],
-                'section_sole_trader' => [
-                    'type'  => 'title',
-                    'title' => __('Sole trader checkout', 'twoinc-payment-gateway'),
-                ],
-                'enable_sole_trader' => [
-                    'title'       => __('Enable sole trader checkout', 'twoinc-payment-gateway'),
-                    'description' => __('Lets buyers check out as a sole trader by registering or logging in with Two. The option only appears for billing countries where sole traders are supported, determined automatically.', 'twoinc-payment-gateway'),
-                    'desc_tip'    => true,
-                    'label'       => ' ',
-                    'type'        => 'checkbox',
-                    'default'     => 'no'
-                ],
+                // No sole-trader section: sole trader checkout is gated on the
+                // registry's answer for the billing country alone, with no
+                // merchant setting to configure (TWO-25163).
                 'section_payment_terms' => [
                     'type'  => 'title',
                     'title' => __('Payment terms and offset pricing', 'twoinc-payment-gateway'),

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -283,7 +283,6 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                 // availability and token minting come from the wc-ajax
                 // endpoints in WC_Twoinc_Sole_Trader.
                 'sole_trader' => [
-                    'enabled' => WC_Twoinc_Sole_Trader::is_enabled($this->wc_twoinc),
                     'availability_url' => class_exists('WC_AJAX') ? WC_AJAX::get_endpoint('two_sole_trader_availability') : '',
                     'tokens_url' => class_exists('WC_AJAX') ? WC_AJAX::get_endpoint('two_sole_trader_tokens') : '',
                     'nonce' => wp_create_nonce('twoinc_checkout'),

--- a/class/WC_Twoinc_Sole_Trader.php
+++ b/class/WC_Twoinc_Sole_Trader.php
@@ -7,11 +7,13 @@
  * methods return (the Gutenberg block checkout port must not need a
  * business-logic rewrite, see TWO-24767).
  *
- * Two gates decide whether the Sole Trader option shows for a billing
- * country, and both must pass:
- *  - country-level legal truth from the registry endpoint
- *    GET /registry/v1/supported-company-types/<ISO> (TWO-24753), and
- *  - the merchant's `enable_sole_trader` admin toggle.
+ * One gate decides whether the Sole Trader option shows for a billing
+ * country: country-level legal truth from the registry endpoint
+ * GET /registry/v1/supported-company-types/<ISO> (TWO-24753). There is
+ * deliberately no merchant on/off toggle (TWO-25163) — whether a country's
+ * company types include sole trader is a fact about the country, not a
+ * merchant preference, and a second gate only adds a way for the feature to
+ * be invisible for its whole life because an installer defaulted it off.
  *
  * The flow mirrors the Magento reference (gateway_method.js): the buyer
  * switches to sole-trader mode, the plugin server-side mints two delegated
@@ -36,14 +38,6 @@ if (!class_exists('WC_Twoinc_Sole_Trader')) {
 
         /** @var array<string, string[]> request-scoped cache, keyed by country */
         private static $types_cache = [];
-
-        /**
-         * Whether the merchant has opted into offering sole trader checkout.
-         */
-        public static function is_enabled($gateway): bool
-        {
-            return $gateway->get_option('enable_sole_trader') === 'yes';
-        }
 
         /**
          * The buyer company types the Two registry supports for a billing
@@ -127,12 +121,13 @@ if (!class_exists('WC_Twoinc_Sole_Trader')) {
 
         /**
          * Whether the Sole Trader option should be offered for a billing
-         * country: merchant toggle on AND the country legally supports it.
+         * country: the registry's answer for that country, and nothing else.
+         * This is the ONLY gate, and it is also the authorisation gate the
+         * token-minting endpoint relies on (see ajax_tokens()).
          */
         public static function is_available($gateway, string $country): bool
         {
-            return self::is_enabled($gateway)
-                && in_array(self::SOLE_TRADER, self::get_supported_company_types($gateway, $country), true);
+            return in_array(self::SOLE_TRADER, self::get_supported_company_types($gateway, $country), true);
         }
 
         /**
@@ -186,7 +181,7 @@ if (!class_exists('WC_Twoinc_Sole_Trader')) {
         /**
          * wc-ajax handler: whether the sole trader option applies for a
          * billing country. JS re-queries this when the billing country
-         * changes; the answer combines both gates server-side.
+         * changes; the registry answer is resolved server-side.
          */
         public static function ajax_availability(): void
         {
@@ -217,20 +212,22 @@ if (!class_exists('WC_Twoinc_Sole_Trader')) {
                 return;
             }
             $gateway = WC_Twoinc::get_instance();
-            if (!$gateway || !self::is_enabled($gateway)) {
-                wp_send_json_error('Sole trader checkout is not enabled');
+            if (!$gateway) {
+                wp_send_json_error('Gateway unavailable');
                 return;
             }
-            // Defence-in-depth: only mint delegated-authority tokens when the
-            // buyer's billing country actually supports sole trader. Without
-            // this the endpoint would mint write-scoped tokens for any request
-            // gated on the merchant toggle alone (a minting oracle). Gate on
+            // The authorisation gate: only mint delegated-authority tokens
+            // when the buyer's billing country actually supports sole trader.
+            // With the merchant toggle removed (TWO-25163) this country check
+            // is the ONLY thing standing between an unauthenticated request
+            // and a write-scoped token pair — it must never be relaxed, or
+            // the endpoint becomes a minting oracle for any country. Gate on
             // the country the browser posts (the same value the availability
             // check used) rather than WC()->customer, which lags the DOM
             // within the checkout-update debounce and would wrongly block a
-            // legitimate buyer. is_available() still re-checks the registry
+            // legitimate buyer. is_available() re-checks the registry
             // server-side, so spoofing only permits minting for a country the
-            // merchant already supports — no privilege gain.
+            // registry already supports — no privilege gain.
             $country = isset($_REQUEST['country']) ? sanitize_text_field(wp_unslash($_REQUEST['country'])) : '';
             if (!self::is_available($gateway, (string) $country)) {
                 wp_send_json_error('Sole trader checkout is not available for this country');

--- a/class/WC_Twoinc_Sole_Trader.php
+++ b/class/WC_Twoinc_Sole_Trader.php
@@ -179,6 +179,27 @@ if (!class_exists('WC_Twoinc_Sole_Trader')) {
         }
 
         /**
+         * Log why a sole-trader wc-ajax request was refused.
+         *
+         * The early bails in the two handlers below are indistinguishable to
+         * the buyer — the checkout renders one generic error whichever fires —
+         * which is how a live break stayed unnoticed for two weeks
+         * (TWO-25170). The buyer-facing copy stays generic on purpose; the log
+         * line does not, so a store's WooCommerce logs say which gate refused.
+         *
+         * @return void
+         */
+        private static function log_refusal(string $handler, string $reason)
+        {
+            if (function_exists('wc_get_logger')) {
+                wc_get_logger()->warning(
+                    sprintf('Sole trader %s refused: %s', $handler, $reason),
+                    ['source' => 'twoinc-payment-gateway']
+                );
+            }
+        }
+
+        /**
          * wc-ajax handler: whether the sole trader option applies for a
          * billing country. JS re-queries this when the billing country
          * changes; the registry answer is resolved server-side.
@@ -186,11 +207,13 @@ if (!class_exists('WC_Twoinc_Sole_Trader')) {
         public static function ajax_availability(): void
         {
             if (!check_ajax_referer('twoinc_checkout', 'nonce', false)) {
+                self::log_refusal('availability check', 'invalid or expired checkout nonce');
                 wp_send_json_error('Invalid nonce');
                 return;
             }
             $gateway = WC_Twoinc::get_instance();
             if (!$gateway) {
+                self::log_refusal('availability check', 'gateway instance unavailable');
                 wp_send_json_error('Gateway unavailable');
                 return;
             }
@@ -208,11 +231,13 @@ if (!class_exists('WC_Twoinc_Sole_Trader')) {
         public static function ajax_tokens(): void
         {
             if (!check_ajax_referer('twoinc_checkout', 'nonce', false)) {
+                self::log_refusal('token mint', 'invalid or expired checkout nonce');
                 wp_send_json_error('Invalid nonce');
                 return;
             }
             $gateway = WC_Twoinc::get_instance();
             if (!$gateway) {
+                self::log_refusal('token mint', 'gateway instance unavailable');
                 wp_send_json_error('Gateway unavailable');
                 return;
             }
@@ -230,11 +255,16 @@ if (!class_exists('WC_Twoinc_Sole_Trader')) {
             // registry already supports — no privilege gain.
             $country = isset($_REQUEST['country']) ? sanitize_text_field(wp_unslash($_REQUEST['country'])) : '';
             if (!self::is_available($gateway, (string) $country)) {
+                self::log_refusal(
+                    'token mint',
+                    sprintf('billing country "%s" is not sole-trader capable per the registry', (string) $country)
+                );
                 wp_send_json_error('Sole trader checkout is not available for this country');
                 return;
             }
             $tokens = self::mint_tokens($gateway);
             if ($tokens === null) {
+                self::log_refusal('token mint', 'the delegation endpoints did not return a usable token pair');
                 wp_send_json_error('Could not initialise the sole trader flow');
                 return;
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -79,12 +79,6 @@ parameters:
 			path: tests/unit/run.php
 
 		-
-			message: '#^Access to an undefined property WC_Twoinc\:\:\$fx_requests\.$#'
-			identifier: property.notFound
-			count: 11
-			path: tests/unit/run.php
-
-		-
 			message: '#^Access to an undefined property WC_Twoinc\:\:\$requests\.$#'
 			identifier: property.notFound
 			count: 6

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -75,7 +75,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property WC_Payment_Gateway\:\:\$requests\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 5
 			path: tests/unit/run.php
 
 		-

--- a/tests/e2e/pages/checkout.ts
+++ b/tests/e2e/pages/checkout.ts
@@ -1,6 +1,12 @@
 import { type Page, expect } from "@playwright/test";
 
-import { BUYER_COMPANY, LONG_TIMEOUT, PHONE_NUMBER, RECIPIENT_EMAIL } from "../config.js";
+import {
+  BUYER_COMPANY,
+  DEFAULT_TIMEOUT,
+  LONG_TIMEOUT,
+  PHONE_NUMBER,
+  RECIPIENT_EMAIL
+} from "../config.js";
 
 export async function selectTwoPayment(page: Page) {
   const radio = page.locator("#payment_method_woocommerce-gateway-tillit");
@@ -10,8 +16,48 @@ export async function selectTwoPayment(page: Page) {
   }
 }
 
+export const SOLE_TRADER_TOGGLE = ".twoinc-sole-trader-toggle";
+export const MODE_CHIP = ".twoinc-mode-item";
+
+/**
+ * The pay box renders a "Registered company / Sole trader" chooser whenever
+ * the registry says the billing country supports sole traders — GB does, and
+ * since TWO-25163 there is no merchant toggle left to suppress it. A business
+ * buyer picks Registered company; do the same before driving the company
+ * search, so the specs exercise the real GB checkout instead of assuming a
+ * checkout with no mode chooser at all.
+ *
+ * The chip is only clicked when Registered company is not already the live
+ * mode: clicking re-initialises the company-search select2 from scratch, so a
+ * redundant click would be a source of flakiness rather than fidelity.
+ *
+ * No-op when the chooser is absent (country not sole-trader capable), so the
+ * helper is safe to call from every spec.
+ */
+export async function selectRegisteredCompany(page: Page) {
+  const chip = page.locator(`${SOLE_TRADER_TOGGLE} ${MODE_CHIP}[data-mode="business"]`);
+  try {
+    await chip.waitFor({ state: "visible", timeout: DEFAULT_TIMEOUT });
+  } catch {
+    return;
+  }
+  const selected = await chip.evaluate((el) => el.classList.contains("twoinc-mode-item--selected"));
+  if (!selected) {
+    await chip.click();
+  }
+  await expect(chip).toHaveClass(/twoinc-mode-item--selected/);
+}
+
 export async function fillCompanySearch(page: Page, companyName = BUYER_COMPANY, retries = 3) {
-  await page.waitForLoadState("networkidle");
+  // Waiting for "networkidle" here used to stand in for "the checkout has
+  // settled", and it deadlocked the whole suite once the sole-trader chooser
+  // started rendering on GB: the autofill prefetch's 404 from
+  // /autofill/v1/buyer/current is never drained by the browser, so Chromium's
+  // in-flight request count never drops to zero and the wait can only time
+  // out. Playwright discourages networkidle for exactly this reason — wait on
+  // the UI that the next step needs instead, which is what the chooser and
+  // the select2 container waits below do.
+  await selectRegisteredCompany(page);
 
   for (let attempt = 1; attempt <= retries; attempt++) {
     try {

--- a/tests/e2e/pages/checkout.ts
+++ b/tests/e2e/pages/checkout.ts
@@ -86,6 +86,28 @@ export async function fillCompanySearch(page: Page, companyName = BUYER_COMPANY,
   }
 }
 
+/**
+ * Pick a billing country through the select2 the checkout actually renders
+ * (the underlying <select> is hidden, so it cannot be driven directly).
+ */
+export async function setBillingCountry(page: Page, countryName: string) {
+  const container = page.locator("#select2-billing_country-container");
+  await container.waitFor({ state: "visible" });
+  await container.click();
+
+  const search = page.locator(".select2-container--open .select2-search__field");
+  await search.waitFor({ state: "visible", timeout: DEFAULT_TIMEOUT });
+  await search.pressSequentially(countryName, { delay: 50 });
+
+  const option = page
+    .locator(".select2-container--open .select2-results__option:not(.select2-results__message)")
+    .first();
+  await option.waitFor({ state: "visible", timeout: DEFAULT_TIMEOUT });
+  await option.click();
+
+  await expect(container).toHaveText(countryName, { timeout: DEFAULT_TIMEOUT });
+}
+
 export async function fillBillingDetails(page: Page, firstName: string, lastName: string) {
   await page.locator("#billing_first_name").fill(firstName);
   await page.locator("#billing_last_name").fill(lastName);

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -2,6 +2,11 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
+  // Default in CI is the dot reporter, which emits a single character per
+  // finished test and so produced 13 minutes of blank log before the job was
+  // killed. list names each test and its outcome, so a killed run at least
+  // shows how far it got.
+  reporter: "list",
   timeout: 180_000,
   expect: { timeout: 15_000 },
   fullyParallel: false,

--- a/tests/e2e/tests/sole-trader-availability.spec.ts
+++ b/tests/e2e/tests/sole-trader-availability.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+import { LONG_TIMEOUT } from "../config.js";
+import * as checkout from "../pages/checkout.js";
+import * as store from "../pages/store.js";
+
+/**
+ * Sole trader checkout is gated on the registry's answer for the billing
+ * country alone (TWO-25163 removed the merchant `enable_sole_trader`
+ * toggle). That gate had no e2e coverage at all, which is how the flow
+ * stayed broken in production for two weeks (TWO-25170). This asserts the
+ * chooser appears exactly where the registry supports it — GB yes, NO no —
+ * without driving the cross-origin hosted-signup popup.
+ */
+test("sole trader mode chooser follows registry country support", async ({ page }) => {
+  await store.addProductToCart(page, "Product 1");
+  await store.goToCheckout(page);
+
+  await checkout.fillBillingDetails(page, "Test", "E2ESoleTrader");
+  await checkout.selectTwoPayment(page);
+
+  const toggle = page.locator(checkout.SOLE_TRADER_TOGGLE);
+  const businessChip = toggle.locator(`${checkout.MODE_CHIP}[data-mode="business"]`);
+  const soleTraderChip = toggle.locator(`${checkout.MODE_CHIP}[data-mode="sole_trader"]`);
+
+  // GB is the store's default country and is sole-trader capable.
+  await expect(toggle).toBeVisible({ timeout: LONG_TIMEOUT });
+  await expect(businessChip).toHaveText("Registered company");
+  await expect(soleTraderChip).toHaveText("Sole trader");
+  // Registered company is the default mode, so an unattended business
+  // checkout is unaffected by the chooser being present.
+  await expect(businessChip).toHaveClass(/twoinc-mode-item--selected/);
+  await expect(soleTraderChip).not.toHaveClass(/twoinc-mode-item--selected/);
+
+  // Norway is not sole-trader capable, so the chooser must disappear.
+  await checkout.setBillingCountry(page, "Norway");
+  await expect(toggle).toBeHidden({ timeout: LONG_TIMEOUT });
+});

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -350,6 +350,19 @@ class WC_Payment_Gateway
     {
         return $this->plugin_id . $this->id . '_settings';
     }
+
+    // Mirrors WC_Settings_API::$settings and init_settings(): the stored
+    // settings blob, read from the single wp option WooCommerce keeps every
+    // gateway setting in. Unlike core it does NOT merge form-field defaults
+    // over the stored values — tests that care about defaults read
+    // form_fields directly.
+    public $settings = [];
+
+    public function init_settings()
+    {
+        $stored = get_option($this->get_option_key(), []);
+        $this->settings = is_array($stored) ? $stored : [];
+    }
 }
 
 class WC_HTTPS
@@ -640,6 +653,11 @@ function absint($maybeint)
     return abs((int) $maybeint);
 }
 
+function sanitize_text_field($str)
+{
+    return is_string($str) ? trim(strip_tags($str)) : '';
+}
+
 function sanitize_key($key)
 {
     return preg_replace('/[^a-z0-9_\-]/', '', strtolower((string) $key));
@@ -740,6 +758,28 @@ function wp_die($message = '', $title = '', $args = [])
 function wc_get_order($order_id)
 {
     return $GLOBALS['__twoinc_test_wc_orders'][$order_id] ?? false;
+}
+
+// ── wc-ajax handler stubs (sole-trader availability / token minting) ─
+// The real wp_send_json_* die; these record the outcome instead, which is
+// enough because every handler returns immediately after calling them.
+// $GLOBALS['__twoinc_test_ajax_nonce_ok'] drives the nonce branch and
+// $GLOBALS['__twoinc_test_ajax_json'] holds the last response.
+
+function check_ajax_referer($action = -1, $query_arg = false, $stop = true)
+{
+    $GLOBALS['__twoinc_test_ajax_referer_actions'][] = $action;
+    return $GLOBALS['__twoinc_test_ajax_nonce_ok'] ?? true;
+}
+
+function wp_send_json_success($data = null, $status_code = null, $flags = 0)
+{
+    $GLOBALS['__twoinc_test_ajax_json'] = ['success' => true, 'data' => $data];
+}
+
+function wp_send_json_error($data = null, $status_code = null, $flags = 0)
+{
+    $GLOBALS['__twoinc_test_ajax_json'] = ['success' => false, 'data' => $data];
 }
 
 // ── Action Scheduler stubs (FX recurring refresh, TWO-25104) ────────

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -87,8 +87,10 @@ final class BrandConfigSpec
             'testOrderPayloadCarriesSelectedAndAvailableTerms',
             'testPaymentTermsInvalidPostFallsBackToDefault',
             'testPaymentTermsDisabledMeansNoPayloadTerms',
-            'testSoleTraderAvailableWhenRegistryAndToggleAgree',
-            'testSoleTraderHiddenWhenToggleOff',
+            'testSoleTraderAvailableWhenRegistryListsIt',
+            'testSoleTraderTokensRefusedForNonCapableCountry',
+            'testSoleTraderTokensMintedForCapableCountry',
+            'testSoleTraderHasNoMerchantToggleSetting',
             'testSoleTraderHiddenWhenRegistryOmitsIt',
             'testSoleTraderRegistryErrorFallsBackToNoSoleTrader',
             'testSoleTraderRegistryRejectsMalformedCountry',
@@ -2167,9 +2169,9 @@ final class BrandConfigSpec
         ];
     }
 
-    private static function testSoleTraderAvailableWhenRegistryAndToggleAgree(): void
+    private static function testSoleTraderAvailableWhenRegistryListsIt(): void
     {
-        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+        $gateway = self::soleTraderGateway([], [
             '/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER']),
         ]);
         TinyAssert::true(WC_Twoinc_Sole_Trader::is_available($gateway, 'GB'));
@@ -2178,12 +2180,107 @@ final class BrandConfigSpec
         TinyAssert::true(WC_Twoinc_Sole_Trader::is_available($gateway, 'gb'));
     }
 
-    private static function testSoleTraderHiddenWhenToggleOff(): void
+    /**
+     * Run the token-minting wc-ajax handler with $gateway installed as the
+     * gateway singleton, and return the recorded JSON response.
+     */
+    private static function runTokensHandler($gateway): array
     {
-        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'no'], [
-            '/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER']),
+        $prop = new ReflectionProperty(WC_Twoinc::class, 'instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null, $gateway);
+        $GLOBALS['__twoinc_test_ajax_json'] = null;
+        try {
+            WC_Twoinc_Sole_Trader::ajax_tokens();
+        } finally {
+            $prop->setValue(null, null);
+        }
+        return $GLOBALS['__twoinc_test_ajax_json'];
+    }
+
+    /** Gateway that would happily mint if it were ever asked to. */
+    private static function tokenMintingGateway(array $types): WC_Payment_Gateway
+    {
+        return self::soleTraderGateway([], [
+            '/registry/v1/supported-company-types/' => self::registryOk($types),
+            '/registry/v1/delegation' => [
+                'response' => ['code' => 200],
+                'headers' => ['two-delegated-authority-token' => 'reg-token'],
+            ],
+            '/autofill/v1/delegation' => [
+                'response' => ['code' => 200],
+                'headers' => ['two-delegated-authority-token' => 'autofill-token'],
+            ],
         ]);
-        TinyAssert::same(false, WC_Twoinc_Sole_Trader::is_available($gateway, 'GB'));
+    }
+
+    private static function testSoleTraderTokensRefusedForNonCapableCountry(): void
+    {
+        // With the merchant toggle gone (TWO-25163) the country check is the
+        // ONLY authorisation gate on the token mint. A country the registry
+        // does not list must still be refused, and must not reach either
+        // delegation endpoint.
+        $gateway = self::tokenMintingGateway([]);
+        $_REQUEST = ['country' => 'NO'];
+        $response = self::runTokensHandler($gateway);
+        $_REQUEST = [];
+        TinyAssert::same(false, $response['success']);
+        TinyAssert::same(['/registry/v1/supported-company-types/NO'], $gateway->requests);
+
+        // A missing country is equally unauthorised (and never hits the API).
+        WC_Twoinc_Sole_Trader::reset_cache();
+        $gateway = self::tokenMintingGateway(['SOLE_TRADER']);
+        $_REQUEST = [];
+        $response = self::runTokensHandler($gateway);
+        TinyAssert::same(false, $response['success']);
+        TinyAssert::same([], $gateway->requests);
+    }
+
+    private static function testSoleTraderTokensMintedForCapableCountry(): void
+    {
+        $gateway = self::tokenMintingGateway(['SOLE_TRADER']);
+        $_REQUEST = ['country' => 'GB'];
+        $response = self::runTokensHandler($gateway);
+        $_REQUEST = [];
+        TinyAssert::true($response['success']);
+        TinyAssert::same('reg-token', $response['data']['delegation_token']);
+        TinyAssert::same('autofill-token', $response['data']['autofill_token']);
+        TinyAssert::same(
+            'https://checkout.two.inc/soletrader/signup',
+            $response['data']['signup_url']
+        );
+    }
+
+    private static function testSoleTraderHasNoMerchantToggleSetting(): void
+    {
+        $gateway = new class () extends WC_Twoinc {
+            public function __construct()
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+            }
+        };
+        $gateway->init_form_fields();
+        // Nothing merchant-facing left to configure (TWO-25163) — neither the
+        // toggle nor the section heading that existed only to carry it.
+        TinyAssert::same(false, array_key_exists('enable_sole_trader', $gateway->form_fields));
+        TinyAssert::same(false, array_key_exists('section_sole_trader', $gateway->form_fields));
+
+        // An upgraded install that stored the toggle has the dead key removed
+        // from the settings blob rather than left behind.
+        $key = $gateway->get_option_key();
+        $drop = new ReflectionMethod(WC_Twoinc::class, 'drop_removed_settings');
+        $drop->setAccessible(true);
+
+        $GLOBALS['__twoinc_test_options'][$key] = ['enable_sole_trader' => 'no', 'api_key' => 'keep-me'];
+        $gateway->init_settings();
+        $drop->invoke($gateway);
+        TinyAssert::same(['api_key' => 'keep-me'], $GLOBALS['__twoinc_test_options'][$key]);
+
+        // Nothing stored: the routine self-limits and leaves the blob alone.
+        $GLOBALS['__twoinc_test_options'][$key] = ['api_key' => 'keep-me'];
+        $gateway->init_settings();
+        $drop->invoke($gateway);
+        TinyAssert::same(['api_key' => 'keep-me'], $GLOBALS['__twoinc_test_options'][$key]);
     }
 
     private static function testSoleTraderHiddenWhenRegistryOmitsIt(): void
@@ -2191,7 +2288,7 @@ final class BrandConfigSpec
         // Countries without sole trader support return an empty list:
         // registered businesses need no registry enrollment, so the
         // endpoint deliberately omits them.
-        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+        $gateway = self::soleTraderGateway([], [
             '/registry/v1/supported-company-types/' => self::registryOk([]),
         ]);
         TinyAssert::same(false, WC_Twoinc_Sole_Trader::is_available($gateway, 'NO'));
@@ -2200,19 +2297,19 @@ final class BrandConfigSpec
     private static function testSoleTraderRegistryErrorFallsBackToNoSoleTrader(): void
     {
         // Network error
-        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], []);
+        $gateway = self::soleTraderGateway([], []);
         TinyAssert::same([], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB'));
 
         // Non-200
         WC_Twoinc_Sole_Trader::reset_cache();
-        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+        $gateway = self::soleTraderGateway([], [
             '/registry/v1/supported-company-types/' => ['response' => ['code' => 404], 'body' => ''],
         ]);
         TinyAssert::same([], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB'));
 
         // Malformed body
         WC_Twoinc_Sole_Trader::reset_cache();
-        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+        $gateway = self::soleTraderGateway([], [
             '/registry/v1/supported-company-types/' => ['response' => ['code' => 200], 'body' => 'not json'],
         ]);
         TinyAssert::same([], WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB'));
@@ -2220,7 +2317,7 @@ final class BrandConfigSpec
 
     private static function testSoleTraderRegistryRejectsMalformedCountry(): void
     {
-        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+        $gateway = self::soleTraderGateway([], [
             '/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER']),
         ]);
         // Never hits the API for junk country input
@@ -2232,7 +2329,7 @@ final class BrandConfigSpec
 
     private static function testSoleTraderRegistryResponseCachedPerRequest(): void
     {
-        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+        $gateway = self::soleTraderGateway([], [
             '/registry/v1/supported-company-types/' => self::registryOk(['SOLE_TRADER']),
         ]);
         WC_Twoinc_Sole_Trader::get_supported_company_types($gateway, 'GB');
@@ -2246,7 +2343,7 @@ final class BrandConfigSpec
 
     private static function testSoleTraderTokenMintReadsHeaderCaseInsensitively(): void
     {
-        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+        $gateway = self::soleTraderGateway([], [
             '/registry/v1/delegation' => [
                 'response' => ['code' => 200],
                 'headers' => ['Two-Delegated-Authority-Token' => 'reg-token'],
@@ -2265,7 +2362,7 @@ final class BrandConfigSpec
     private static function testSoleTraderTokenMintFailsClosed(): void
     {
         // Second mint failing voids the pair — never hand the browser half a flow
-        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+        $gateway = self::soleTraderGateway([], [
             '/registry/v1/delegation' => [
                 'response' => ['code' => 200],
                 'headers' => ['two-delegated-authority-token' => 'reg-token'],
@@ -2275,7 +2372,7 @@ final class BrandConfigSpec
         TinyAssert::same(null, WC_Twoinc_Sole_Trader::mint_tokens($gateway));
 
         // Missing header on a 200 also fails closed
-        $gateway = self::soleTraderGateway(['enable_sole_trader' => 'yes'], [
+        $gateway = self::soleTraderGateway([], [
             '/registry/v1/delegation' => ['response' => ['code' => 200], 'headers' => []],
             '/autofill/v1/delegation' => [
                 'response' => ['code' => 200],


### PR DESCRIPTION
## What

Sole trader checkout is now gated **solely** on the registry's answer for the buyer's billing country (`GET /registry/v1/supported-company-types`, TWO-24753). The merchant-facing `enable_sole_trader` gateway option is removed.

Whether a country's company types include sole trader is a fact about the country, not a merchant preference. The second gate bought nothing and cost real availability — it is exactly the shape of failure that leaves a shipped feature invisible for its whole life because an installer defaulted it off. Magento is already toggle-less; this brings WooCommerce to that target state. PrestaShop is tracked separately as TWO-25166.

## Removed

- the `enable_sole_trader` settings field, and the `section_sole_trader` heading that existed only to carry it
- `WC_Twoinc_Sole_Trader::is_enabled()`, and the toggle term inside `is_available()`
- the `enabled` flag in the checkout JS bootstrap, and the `cfg.enabled` short-circuit in the client's refresh path

## The authorisation path is deliberately not weakened

`ajax_tokens()` mints a **write-scoped** delegated-authority token pair, and had two early bails that could refuse: the merchant toggle, and the billing-country capability check. Only the toggle bail is gone. The country check stays and is now the sole thing between an unauthenticated request and a token pair, so removing the toggle does **not** make the endpoint mintable for any country.

Covered by tests: a non-capable country is refused and reaches neither delegation endpoint, a missing country is refused without any API call at all, and a capable country still mints both tokens.

## Stored-option cleanup

A WooCommerce gateway keeps every setting inside the single `woocommerce_<gateway id>_settings` option, so there is no row to delete — the dead key has to be unset from the stored array. The plugin has no versioned migration runner and this does not add one: `drop_removed_settings()` runs after `init_settings()` and only writes when a removed key is actually present, so it self-limits to one write per upgraded install and no-ops on every request thereafter. Retiring another key later is one array entry.

That mechanism would also cover the orphan `checkout_sole_trader` key in TWO-25165, but that is a different already-dead key and is deliberately left out of this PR. Note there is no `checkout_sole_trader` reference anywhere in this repo.

## Second commit — refusal logging

TWO-25170's investigation found the early bails are indistinguishable to the buyer (one generic checkout error whichever fires) and wrote nothing server-side either, which is how a live break stayed unnoticed for two weeks. Each refusal in both sole-trader wc-ajax handlers now emits a distinct WooCommerce log line naming the handler and the gate. Buyer-facing copy is unchanged on purpose.

## Gates (run locally the way CI does)

- `docker run --rm -v "$PWD":/app -w /app php:8.2-cli php tests/unit/run.php` → `All tests passed.` (exit 0)
- `make phpcs` → exit 0, 0 errors (pre-existing long-line warnings only, ungated)
- `make phpstan` → `[OK] No errors`

The phpstan baseline count for `WC_Payment_Gateway::$requests` in the test harness moves 3 → 5 for the two new assertions on the fake gateway's recorded requests; no new pattern added.

## Validate on staging

Fresh install, no admin configuration touched: the sole trader option appears at checkout for a supported billing country (GB/US) and is absent for an unsupported one. On an install that had the toggle stored as off, the option now appears for a supported country and the key is gone from the settings blob.

Parent: TWO-24739. Closes TWO-25163 (WooCommerce half).

<sub>by Claude</sub>