### PR TITLE
TWO-25185 / TWO-25186: drain non-2xx autofill response bodies, and fix the order-flow e2e flake

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1364,8 +1364,15 @@ let twoincSoleTrader = {
     })
       .then(function (response) {
         if (response.ok) return response.json();
-        if (response.status === 404) return null;
-        throw new Error("autofill/v1/buyer/current failed");
+        // Every non-2xx path must still drain the body. Abandoning an unread
+        // response leaves the request in flight as far as the browser is
+        // concerned, so the in-flight request count never returns to zero and
+        // anything waiting on network-idle (tooling, analytics, some themes)
+        // hangs.
+        return response.text().then(function () {
+          if (response.status === 404) return null;
+          throw new Error("autofill/v1/buyer/current failed");
+        });
       })
       .then(function (json) {
         cb(json || null);

--- a/tests/e2e/pages/wp-admin.ts
+++ b/tests/e2e/pages/wp-admin.ts
@@ -15,8 +15,26 @@ export async function navigateToOrders(page: Page) {
   await page.waitForLoadState("load");
 }
 
+/**
+ * Open an order from the WP admin order list.
+ *
+ * The list renders whatever the order query returned at page load, so an order
+ * placed moments earlier is not guaranteed to be listed on the first render.
+ * Reload until the row appears instead of clicking a locator that is not there
+ * yet and relying on the click timeout plus a test retry.
+ */
 export async function openOrder(page: Page, searchTerm: string) {
-  await page.locator(`a.order-view:has-text("${searchTerm}")`).first().click();
+  const orderLink = page.locator(`a.order-view:has-text("${searchTerm}")`).first();
+
+  await expect(async () => {
+    if ((await orderLink.count()) === 0) {
+      await page.reload();
+      await page.waitForLoadState("load");
+    }
+    await expect(orderLink).toBeVisible({ timeout: 2_000 });
+  }).toPass({ timeout: 60_000, intervals: [1_000, 2_000, 5_000] });
+
+  await orderLink.click();
   await page.waitForLoadState("load");
 }
 


### PR DESCRIPTION
Two independent defects surfaced by the e2e work on PR #374 in this repository. One commit each.

## TWO-25185 — `fetchCurrentBuyer` left a dangling request (priority: Medium)

`twoincSoleTrader.fetchCurrentBuyer` in `assets/js/twoinc.js` called `GET /autofill/v1/buyer/current` and, on a 404, returned `null` straight out of the first `.then` without reading the response body; the other non-2xx path threw immediately, likewise without reading it. An abandoned unread `fetch` body keeps the request in flight from the browser's point of view, so the in-flight request count never returns to zero.

This is a real plugin defect rather than a test artefact. A 404 is the normal case for a buyer with no Two cookie, so it left a dangling request on ordinary checkout page loads, and anything depending on network-idle (third-party tooling, some analytics, themes that defer work until the network settles) is affected. It was found via a Playwright trace where `page.waitForLoadState("networkidle")` could never resolve.

The fix reads and discards the body before deciding the outcome, so both non-2xx paths settle the request. Audited for the same shape elsewhere: this is the only `fetch` call site in the file — the remaining requests go through jQuery, which consumes bodies itself.

## TWO-25186 — `order-flow` e2e flake (priority: Low)

`openOrder()` in `tests/e2e/pages/wp-admin.ts` clicked the order link immediately after loading the WP admin order list. The list renders whatever the order query returned at page load, so an order placed moments earlier is not guaranteed to be listed on the first render — the click then timed out on attempt 1 and the test passed only on the Playwright retry.

The fix reloads the list until the row appears, then clicks it. No assertion is weakened and no timeout is raised. `cancel-order.spec.ts` uses the same helper and benefits equally.

## Verification

Run the way CI runs:

- `make phpcs` — exit 0 (pre-existing line-length warnings only, in PHP files this PR does not touch).
- `make phpstan` — `[OK] No errors`.
- `make test-unit` (`php:8.2-cli` container; local PHP is 8.5) — `All tests passed.`
- `npx tsc --noEmit` in `tests/e2e` — exit 0.
- `pre-commit run prettier` on both changed files — Passed.

Two gaps stated plainly:

- No unit test was added for TWO-25185. The unit harness is PHP-only (`tests/unit/run.php` in a PHP container); there is no JS unit-test lane in this repository for the fix to land in.
- The e2e suite was not run locally — the merchant-key write it requires is blocked in this environment. TWO-25186 relies on CI.