### PR TITLE
refactor: rename days_on_invoice option to merchant_due_in_days (TWO-24859)

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -57,10 +57,11 @@ if (!class_exists('WC_Twoinc')) {
             $this->init_form_fields();
             $this->init_settings();
             $this->drop_removed_settings();
+            $this->drop_renamed_option_rows();
 
             $this->title = sprintf(
                 __($this->get_option('title'), 'twoinc-payment-gateway'),
-                strval($this->get_merchant_default_days_on_invoice())
+                strval($this->get_merchant_due_in_days())
             );
             /**
              * Filter the checkout payment-box description so a brand
@@ -324,15 +325,15 @@ if (!class_exists('WC_Twoinc')) {
          * frontend TTL-expiry write into the blob can silently revert a
          * concurrent admin settings save.
          */
-        public function get_merchant_default_days_on_invoice()
+        public function get_merchant_due_in_days()
         {
-            $days_option = WC_Twoinc_Brand::prefixed_name('days_on_invoice');
-            $checked_option = WC_Twoinc_Brand::prefixed_name('days_on_invoice_checked_on');
+            $days_option = WC_Twoinc_Brand::prefixed_name('merchant_due_in_days');
+            $checked_option = WC_Twoinc_Brand::prefixed_name('merchant_due_in_days_checked_on');
 
             // Default to 14 days when nothing is cached
-            $days_on_invoice = (int) get_option($days_option);
-            if ($days_on_invoice <= 0) {
-                $days_on_invoice = 14;
+            $due_in_days = (int) get_option($days_option);
+            if ($due_in_days <= 0) {
+                $due_in_days = 14;
             }
 
             if ($this->get_merchant_id() && $this->get_option('api_key')) {
@@ -344,13 +345,13 @@ if (!class_exists('WC_Twoinc')) {
                     $record = $this->fetch_merchant_record();
                     if (is_array($record)) {
                         // A null due_in_days on the record also means 14 days
-                        $days_on_invoice = !empty($record['due_in_days']) ? (int) $record['due_in_days'] : 14;
-                        update_option($days_option, $days_on_invoice, false);
+                        $due_in_days = !empty($record['due_in_days']) ? (int) $record['due_in_days'] : 14;
+                        update_option($days_option, $due_in_days, false);
                     }
                 }
             }
 
-            return $days_on_invoice;
+            return $due_in_days;
         }
 
         /**
@@ -593,8 +594,8 @@ if (!class_exists('WC_Twoinc')) {
             $names = [
                 'merchant_available_terms',
                 'merchant_available_terms_checked_on',
-                'days_on_invoice',
-                'days_on_invoice_checked_on',
+                'merchant_due_in_days',
+                'merchant_due_in_days_checked_on',
                 'platform_minimum_order',
                 'platform_minimum_order_checked_on',
                 'merchant_surcharge_limit',
@@ -624,6 +625,37 @@ if (!class_exists('WC_Twoinc')) {
          *
          * @return void
          */
+        /**
+         * Delete option rows whose key was renamed, so an upgraded install
+         * doesn't leave an orphan row behind under the old name.
+         *
+         * Same self-limiting shape as drop_removed_settings(): it only
+         * writes when a legacy row is actually present, and after that one
+         * pass there is nothing left to do on any later request — no
+         * versioned migration runner needed. To retire another renamed row,
+         * add its unprefixed name to $renamed.
+         *
+         * Currently: `days_on_invoice` / `days_on_invoice_checked_on`
+         * (TWO-24859) — renamed to `merchant_due_in_days` /
+         * `merchant_due_in_days_checked_on`, because the value is the
+         * MERCHANT's default due-in-days off GET /v1/merchant, not anything
+         * about a specific invoice. No value is carried across: the row is a
+         * 1h TTL cache of the merchant record, so the new key self-heals on
+         * the first request that has an API key.
+         *
+         * @return void
+         */
+        private function drop_renamed_option_rows()
+        {
+            $renamed = ['days_on_invoice', 'days_on_invoice_checked_on'];
+            foreach ($renamed as $name) {
+                $option = WC_Twoinc_Brand::prefixed_name($name);
+                if (get_option($option, null) !== null) {
+                    delete_option($option);
+                }
+            }
+        }
+
         private function drop_removed_settings()
         {
             $removed = ['enable_sole_trader'];
@@ -1394,7 +1426,7 @@ if (!class_exists('WC_Twoinc')) {
                 '<span class="payment-term-number">%s</span><span class="payment-term-nonumber">%s</span>',
                 sprintf(
                     __($this->get_option('title'), 'twoinc-payment-gateway'),
-                    '<span class="due-in-days">' . strval($this->get_merchant_default_days_on_invoice()) . '</span>'
+                    '<span class="due-in-days">' . strval($this->get_merchant_due_in_days()) . '</span>'
                 ),
                 __('Pay on invoice with agreed terms', 'twoinc-payment-gateway')
             );

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -256,7 +256,7 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                 'supported_buyer_countries' => $supported_buyer_countries,
                 'gateway_id' => WC_Twoinc_Brand::get('gateway_id'),
                 'merchant' => $merchant,
-                'days_on_invoice' => $this->wc_twoinc->get_merchant_default_days_on_invoice(),
+                'merchant_due_in_days' => $this->wc_twoinc->get_merchant_due_in_days(),
                 'shop_base_country' => strtolower(WC()->countries->get_base_country()),
                 'currency' => $currency,
                 'price_decimal_separator' => wc_get_price_decimal_separator(),

--- a/snippets/two-demo/functions-part.php
+++ b/snippets/two-demo/functions-part.php
@@ -52,7 +52,7 @@ function replaceDueInDays() {
     if (jQuery('#twoinc-due-in-days').length == 0) {
         jQuery('label[for="payment_method_woocommerce-gateway-tillit"]').html(
             jQuery('label[for="payment_method_woocommerce-gateway-tillit"]').html()
-                .replace(twoinc.days_on_invoice, '<span id="twoinc-due-in-days"></span>')
+                .replace(twoinc.merchant_due_in_days, '<span id="twoinc-due-in-days"></span>')
         )
     }
     jQuery('#twoinc-due-in-days').text(jQuery('#billing_due_in_days').val())
@@ -101,7 +101,7 @@ function getNodesThatContain(text) {
 
 function replaceDueInDays() {
     let dueInDays = <?php echo $twoinc_due_in_days; ?>;
-    let defaultDueInDays = <?php echo $twoinc_obj->get_merchant_default_days_on_invoice(); ?>;
+    let defaultDueInDays = <?php echo $twoinc_obj->get_merchant_due_in_days(); ?>;
     let twoincMethodText = "<?php echo $twoinc_obj->title; ?>";
     getNodesThatContain(twoincMethodText).each(function (){
         jQuery(this).html(jQuery(this).html().replace(twoincMethodText, twoincMethodText.replace(defaultDueInDays, dueInDays)))

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -64,6 +64,7 @@ final class BrandConfigSpec
             'testMerchantAvailableTermsInvalidatedOnMerchantIdChange',
             'testDeactivationCleanupClearsSettingsAndTermCache',
             'testMerchantRecordFetchSharedAcrossConsumersAndOffTheBlob',
+            'testLegacyDaysOnInvoiceOptionRowsDropped',
             'testPaymentTermsValidationNonDestructiveOnUnresolvedOrNarrowedList',
             'testSurchargeGridPreservesRowsNotOnTheForm',
             'testPaymentTermsSelectorVisibleOnlyWithMultiple',
@@ -1199,7 +1200,7 @@ final class BrandConfigSpec
 
         // All four consumers in one request: exactly ONE wire fetch
         TinyAssert::same([30, 60], $gateway->get_merchant_available_terms(true));
-        TinyAssert::same(21, $gateway->get_merchant_default_days_on_invoice());
+        TinyAssert::same(21, $gateway->get_merchant_due_in_days());
         $minimum = $gateway->get_platform_minimum_order();
         TinyAssert::same(['amount' => 100.0, 'currency' => 'NOK', 'basis' => 'net'], $minimum);
         TinyAssert::same(['amount' => 25.0, 'currency' => 'EUR'], $gateway->get_merchant_surcharge_limit(true));
@@ -1209,10 +1210,10 @@ final class BrandConfigSpec
         // a frontend TTL-expiry write into the blob can silently revert a
         // concurrent admin settings save (WC_Settings_API::update_option
         // rewrites the whole array from an in-memory snapshot).
-        TinyAssert::same(21, (int) $GLOBALS['__twoinc_test_options'][WC_Twoinc_Brand::prefixed_name('days_on_invoice')]);
+        TinyAssert::same(21, (int) $GLOBALS['__twoinc_test_options'][WC_Twoinc_Brand::prefixed_name('merchant_due_in_days')]);
         TinyAssert::true(isset($GLOBALS['__twoinc_test_options'][WC_Twoinc_Brand::prefixed_name('platform_minimum_order')]));
-        TinyAssert::same(false, array_key_exists('days_on_invoice', $gateway->options));
-        TinyAssert::same(false, array_key_exists('days_on_invoice_last_checked_on', $gateway->options));
+        TinyAssert::same(false, array_key_exists('merchant_due_in_days', $gateway->options));
+        TinyAssert::same(false, array_key_exists('merchant_due_in_days_checked_on', $gateway->options));
         TinyAssert::same(false, array_key_exists('platform_minimum_order', $gateway->options));
         TinyAssert::same(false, array_key_exists('platform_minimum_order_last_checked_on', $gateway->options));
 
@@ -1220,7 +1221,7 @@ final class BrandConfigSpec
         // stall total (memo covers failures), each consumer keeps its own
         // degrade posture — days serves stale, minimum blanks to null,
         // terms serve stale.
-        foreach (['merchant_available_terms_checked_on', 'days_on_invoice_checked_on', 'platform_minimum_order_checked_on', 'merchant_surcharge_limit_checked_on'] as $name) {
+        foreach (['merchant_available_terms_checked_on', 'merchant_due_in_days_checked_on', 'platform_minimum_order_checked_on', 'merchant_surcharge_limit_checked_on'] as $name) {
             $GLOBALS['__twoinc_test_options'][WC_Twoinc_Brand::prefixed_name($name)] = time() - 3601;
         }
         WC_Twoinc::reset_merchant_record_memo();
@@ -1229,10 +1230,47 @@ final class BrandConfigSpec
         $gateway->responses[] = new WP_Error('http_request_failed', 'down');
 
         TinyAssert::same([30, 60], $gateway->get_merchant_available_terms(true));
-        TinyAssert::same(21, $gateway->get_merchant_default_days_on_invoice());
+        TinyAssert::same(21, $gateway->get_merchant_due_in_days());
         TinyAssert::same(null, $gateway->get_platform_minimum_order());
         TinyAssert::same(['amount' => 25.0, 'currency' => 'EUR'], $gateway->get_merchant_surcharge_limit(true));
         TinyAssert::same(2, $gateway->calls);
+    }
+
+    private static function testLegacyDaysOnInvoiceOptionRowsDropped(): void
+    {
+        // TWO-24859: the merchant's default due-in-days cache moved from
+        // `days_on_invoice` to `merchant_due_in_days`. No value is carried
+        // across - the row is a 1h TTL cache of GET /v1/merchant, so the new
+        // key self-heals on the first request with an API key - but the old
+        // rows must not be left behind as orphans.
+        $gateway = new class () extends WC_Twoinc {
+            public function __construct()
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+            }
+        };
+        $drop = new ReflectionMethod(WC_Twoinc::class, 'drop_renamed_option_rows');
+        $drop->setAccessible(true);
+
+        $legacy_days = WC_Twoinc_Brand::prefixed_name('days_on_invoice');
+        $legacy_checked = WC_Twoinc_Brand::prefixed_name('days_on_invoice_checked_on');
+        $current_days = WC_Twoinc_Brand::prefixed_name('merchant_due_in_days');
+
+        $GLOBALS['__twoinc_test_options'][$legacy_days] = 21;
+        $GLOBALS['__twoinc_test_options'][$legacy_checked] = time();
+        $GLOBALS['__twoinc_test_options'][$current_days] = 30;
+
+        $drop->invoke($gateway);
+
+        TinyAssert::same(false, array_key_exists($legacy_days, $GLOBALS['__twoinc_test_options']));
+        TinyAssert::same(false, array_key_exists($legacy_checked, $GLOBALS['__twoinc_test_options']));
+        // The renamed row is untouched.
+        TinyAssert::same(30, $GLOBALS['__twoinc_test_options'][$current_days]);
+
+        // Nothing stored under the legacy names: self-limiting, no writes.
+        $drop->invoke($gateway);
+        TinyAssert::same(false, array_key_exists($legacy_days, $GLOBALS['__twoinc_test_options']));
+        TinyAssert::same(30, $GLOBALS['__twoinc_test_options'][$current_days]);
     }
 
     private static function testPaymentTermsValidationNonDestructiveOnUnresolvedOrNarrowedList(): void


### PR DESCRIPTION
## What

The `days_on_invoice` option holds the **merchant's** default due-in-days, sourced from `due_in_days` on `GET /v1/merchant` — nothing about a specific invoice. Renamed to say so.

| Before | After |
|---|---|
| `days_on_invoice` (brand-prefixed wp_option) | `merchant_due_in_days` |
| `days_on_invoice_checked_on` | `merchant_due_in_days_checked_on` |
| `WC_Twoinc::get_merchant_default_days_on_invoice()` | `WC_Twoinc::get_merchant_due_in_days()` |
| localized checkout property `twoinc.days_on_invoice` | `twoinc.merchant_due_in_days` |

## The "zero migration" claim — checked, not assumed

It holds, but not for the reason "it isn't persisted": the value **is** a real `wp_options` row (`update_option($days_option, …, false)`), so existing merchants do have one. It needs no migration because it is a **1-hour TTL cache of the merchant record, never merchant-entered**:

- `get_merchant_due_in_days()` reads the cached row, falls back to 14 when absent, then refetches whenever `…_checked_on` is missing or older than 3600s.
- After the rename both new keys are absent, so the TTL gate is stale by construction and the very next request that has a merchant id + API key refetches from `GET /v1/merchant` and repopulates. There is no merchant-authored value that could be lost.

So: no migration, and **no read-fallback to the old key either** — a fallback would only serve a stale copy of a value the next request re-derives anyway. Worst case is one page render showing the 14-day default before the refetch lands, on a site with no API key configured (where the value was never authoritative regardless).

What the old rows *would* be is orphans. `drop_renamed_option_rows()` deletes them, called from the constructor next to the existing `drop_removed_settings()` and built to the same self-limiting shape: it only writes when a legacy row is actually present, so after one pass there is nothing left to do — no versioned migration runner introduced.

`invalidate_merchant_record_caches()`'s registered name-pair list is updated to the new names, so a merchant-identity change still clears the cache.

## Cross-repo check on the renamed method and JS property

`gh search code --owner two-inc days_on_invoice` — the only consumers outside this repo are in `woocommerce-abn-plugin`, whose `WC_ABN` on `origin/staging` is a standalone class that neither extends `WC_Twoinc` nor references `days_on_invoice` at all. The overlay's `main` still carries its own independent copy of a similarly-named method; it resolves against its own class, so nothing here breaks it. In-repo, `snippets/two-demo/functions-part.php` was the only other consumer (both the PHP getter call and the `twoinc.days_on_invoice` JS read) and is updated in this diff. No `.js` in this repo reads the localized property.

## Docs

Grepped `README.md`, `AGENTS.md`, `readme.txt` for `days_on_invoice` / "days on invoice" — no doc describes this option (no `.ai/` dir, no CHANGELOG in this repo), so nothing to update.

## Verification

Run the way CI does:

- `php tests/unit/run.php` (the Unit tests job): `All tests passed.`, including the new `testLegacyDaysOnInvoiceOptionRowsDropped` spec — legacy rows deleted, the renamed row untouched, second pass a no-op.
- `phpcs` 4.0.1 against `phpcs.xml`: exit 0, 0 errors (pre-existing line-length warnings only, unchanged by this diff).
- `phpstan` 2.2.5 with the pinned WP/WC stub SHAs: `[OK] No errors`.
- `php -l` on all four changed files.

No live shop or database touched.

## Note on Linear TWO-24859

TWO-24859 as written would break term resolution — it conflates this merchant-default due-in-days with the offerable-terms list that drives term selection. It needs amending. Not edited from here — leaving that to Doug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)