### PR TITLE
TWO-25196/feat: stamp deployed commit into released zips

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,6 +29,16 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y subversion rsync
       - run: echo ${{ github.ref_name }}
+      # Released zips carry no git metadata, so the admin provenance line
+      # and the API `client_v` param have nothing to report the deployed
+      # commit from. Stamp it into the workspace before the 10up action
+      # rsyncs it into the build (TWO-25196). The SHA goes through `env:`
+      # rather than `${{ }}` interpolation so it is never spliced into the
+      # shell source.
+      - name: Stamp deployed commit
+        env:
+          SHA: ${{ github.sha }}
+        run: echo "${SHA:0:7}" > "$GITHUB_WORKSPACE/.two-deployed-commit"
       - name: WordPress Plugin Deploy
         id: deploy
         uses: 10up/action-wordpress-plugin-deploy@stable

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ dev/stubs/
 
 # Local worktrees (org convention: <repo>/.worktrees/<branch-slug>/)
 .worktrees/
+
+# Release provenance stamp, written by the deploy workflow
+.two-deployed-commit

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -3830,7 +3830,7 @@ if (!class_exists('WC_Twoinc')) {
         public function make_request($endpoint, $payload = [], $method = 'POST', $params = array(), $api_key_override = null, $timeout = 30)
         {
             $params['client'] = 'wp';
-            $params['client_v'] = get_twoinc_plugin_version();
+            $params['client_v'] = self::client_version();
             # If api_key_override is defined, use that key instead of the saved key
             $api_key = $api_key_override ?: $this->get_option('api_key');
             $headers = [
@@ -4021,12 +4021,9 @@ if (!class_exists('WC_Twoinc')) {
         private static function describe_component_provenance($main_file, $version)
         {
             $detail = [];
-            $git_pointer = dirname($main_file) . '/.git';
-            if (is_file($git_pointer) && is_readable($git_pointer)) {
-                $pointer = (string) file_get_contents($git_pointer);
-                if (preg_match('#gitdir:\s*.*/([0-9a-f]{40})\s*$#', trim($pointer), $m)) {
-                    $detail[] = substr($m[1], 0, 12);
-                }
+            $commit = self::resolve_component_commit(dirname($main_file));
+            if ($commit !== null) {
+                $detail[] = substr($commit, 0, 12);
             }
             $mtime = is_readable($main_file) ? filemtime($main_file) : false;
             if ($detail && $mtime) {
@@ -4037,6 +4034,61 @@ if (!class_exists('WC_Twoinc')) {
                 );
             }
             return $detail ? sprintf('%s (%s)', $version, implode(', ', $detail)) : $version;
+        }
+
+        /**
+         * Deployed commit SHA for one component directory, or null when it
+         * cannot be established. Two sources, in precedence order:
+         *
+         *  1. `.two-deployed-commit` — a sidecar written by the release
+         *     workflow and shipped inside the zip, so wp.org / released
+         *     installs (which carry no git metadata at all) still know
+         *     which commit they were built from.
+         *  2. The `.git` gitlink FILE of a git-sync worktree copy, whose
+         *     gitdir path ends in the commit SHA.
+         *
+         * An absent, unreadable, empty or malformed sidecar falls through
+         * to the gitlink rather than winning. Never throws.
+         *
+         * @param string $dir component directory (no trailing slash needed)
+         *
+         * @return string|null lowercase hex SHA, 7-40 chars
+         */
+        private static function resolve_component_commit($dir)
+        {
+            $dir = rtrim((string) $dir, '/');
+
+            $stamp = $dir . '/.two-deployed-commit';
+            if (is_file($stamp) && is_readable($stamp)) {
+                $raw = @file_get_contents($stamp);
+                if (is_string($raw) && preg_match('/^[0-9a-f]{7,40}$/i', trim($raw))) {
+                    return strtolower(trim($raw));
+                }
+            }
+
+            $git_pointer = $dir . '/.git';
+            if (is_file($git_pointer) && is_readable($git_pointer)) {
+                $pointer = @file_get_contents($git_pointer);
+                if (is_string($pointer) && preg_match('#gitdir:\s*.*/([0-9a-f]{40})\s*$#', trim($pointer), $m)) {
+                    return strtolower($m[1]);
+                }
+            }
+
+            return null;
+        }
+
+        /**
+         * Value of the `client_v` API query param: the plugin version,
+         * suffixed with `+<7-char sha>` only when the deployed commit
+         * resolves. Never emits a bare trailing `+`.
+         *
+         * @return string
+         */
+        private static function client_version()
+        {
+            $version = get_twoinc_plugin_version();
+            $commit = self::resolve_component_commit(WC_TWOINC_PLUGIN_PATH);
+            return $commit === null ? $version : $version . '+' . substr($commit, 0, 7);
         }
 
         /**

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -811,6 +811,16 @@ function as_unschedule_all_actions($hook, $args = [], $group = '')
     return true;
 }
 
+// The real one lives in tillit-payment-gateway.php, which the suite does
+// not load (it bootstraps WordPress hooks on include). Tests that care
+// override $GLOBALS['__twoinc_test_plugin_version'].
+function get_twoinc_plugin_version()
+{
+    return isset($GLOBALS['__twoinc_test_plugin_version'])
+        ? $GLOBALS['__twoinc_test_plugin_version']
+        : '2.23.9';
+}
+
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Brand.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_Helper.php';
 require WC_TWOINC_PLUGIN_PATH . 'class/WC_Twoinc_FX.php';

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -144,6 +144,12 @@ final class BrandConfigSpec
             'testBuyerFeeShareCapRoundingToZeroWithholdsWholeSurcharge',
             'testCartFeeSkippedOnQuoteCurrencyMismatch',
             'testMinimumDescriptionShowsConvertedFloorWhenRateAvailable',
+            'testDeployedCommitSidecarWinsOverGitlink',
+            'testGarbageOrEmptySidecarFallsThroughToGitlink',
+            'testNoProvenanceSourcesYieldsBareVersion',
+            'testClientVersionNeverEmitsTrailingPlus',
+            'testClientVersionSuffixesShortShaWhenStamped',
+            'testClientVersionIsQueryEncodedAsPlus',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -3678,6 +3684,140 @@ final class BrandConfigSpec
         } finally {
             unset($GLOBALS['__twoinc_test_store_currency']);
         }
+    }
+
+    /**
+     * Scratch component dir containing a plugin main file, plus whichever
+     * of the two provenance sources the caller asked for. Returns the dir.
+     */
+    private static function makeComponentDir(array $files): string
+    {
+        $dir = sys_get_temp_dir() . '/twoinc-prov-' . bin2hex(random_bytes(6));
+        mkdir($dir, 0777, true);
+        file_put_contents($dir . '/main.php', "<?php\n");
+        foreach ($files as $name => $contents) {
+            file_put_contents($dir . '/' . $name, $contents);
+        }
+        return $dir;
+    }
+
+    private static function removeComponentDir(string $dir): void
+    {
+        foreach ((array) glob($dir . '/{,.}*', GLOB_BRACE) as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+        if (is_dir($dir)) {
+            rmdir($dir);
+        }
+    }
+
+    private static function provenanceOf(string $dir, string $version): string
+    {
+        $method = new ReflectionMethod(WC_Twoinc::class, 'describe_component_provenance');
+        $method->setAccessible(true);
+        return $method->invoke(null, $dir . '/main.php', $version);
+    }
+
+    private static function clientVersion(): string
+    {
+        $method = new ReflectionMethod(WC_Twoinc::class, 'client_version');
+        $method->setAccessible(true);
+        return $method->invoke(null);
+    }
+
+    private static function testDeployedCommitSidecarWinsOverGitlink(): void
+    {
+        // Released zips ship .two-deployed-commit; when both sources are
+        // present the sidecar is authoritative.
+        $gitlink = 'gitdir: /var/sync/worktrees/' . str_repeat('a', 40) . "\n";
+        $dir = self::makeComponentDir([
+            '.two-deployed-commit' => "deadbee\n",
+            '.git' => $gitlink,
+        ]);
+        try {
+            TinyAssert::true(
+                strpos(self::provenanceOf($dir, '2.23.9'), '2.23.9 (deadbee,') === 0,
+                self::provenanceOf($dir, '2.23.9')
+            );
+        } finally {
+            self::removeComponentDir($dir);
+        }
+    }
+
+    private static function testGarbageOrEmptySidecarFallsThroughToGitlink(): void
+    {
+        // An empty or non-hex sidecar must not win, and must not suppress
+        // the gitlink that git-synced shops still rely on.
+        $sha = str_repeat('b', 40);
+        $gitlink = 'gitdir: /var/sync/worktrees/' . $sha . "\n";
+        foreach (["\n", '   ', 'not-a-sha', 'abc', str_repeat('f', 41)] as $junk) {
+            $dir = self::makeComponentDir([
+                '.two-deployed-commit' => $junk,
+                '.git' => $gitlink,
+            ]);
+            try {
+                $described = self::provenanceOf($dir, '2.23.9');
+                TinyAssert::true(strpos($described, '2.23.9 (bbbbbbbbbbbb,') === 0, $described);
+            } finally {
+                self::removeComponentDir($dir);
+            }
+        }
+    }
+
+    private static function testNoProvenanceSourcesYieldsBareVersion(): void
+    {
+        $dir = self::makeComponentDir([]);
+        try {
+            TinyAssert::same('2.23.9', self::provenanceOf($dir, '2.23.9'));
+        } finally {
+            self::removeComponentDir($dir);
+        }
+    }
+
+    private static function testClientVersionNeverEmitsTrailingPlus(): void
+    {
+        // No sidecar and no gitlink SHA in the checkout: client_v is the
+        // bare version, never "2.23.9+".
+        $GLOBALS['__twoinc_test_plugin_version'] = '2.23.9';
+        try {
+            $value = self::clientVersion();
+            TinyAssert::same('2.23.9', $value);
+            TinyAssert::true(substr($value, -1) !== '+', $value);
+        } finally {
+            unset($GLOBALS['__twoinc_test_plugin_version']);
+        }
+    }
+
+    private static function testClientVersionSuffixesShortShaWhenStamped(): void
+    {
+        // With the release stamp present, client_v carries the 7-char SHA.
+        $stamp = WC_TWOINC_PLUGIN_PATH . '.two-deployed-commit';
+        $preexisting = is_file($stamp) ? file_get_contents($stamp) : null;
+        $GLOBALS['__twoinc_test_plugin_version'] = '2.23.9';
+        file_put_contents($stamp, "1a2b3c4\n");
+        try {
+            TinyAssert::same('2.23.9+1a2b3c4', self::clientVersion());
+        } finally {
+            unset($GLOBALS['__twoinc_test_plugin_version']);
+            if ($preexisting === null) {
+                unlink($stamp);
+            } else {
+                file_put_contents($stamp, $preexisting);
+            }
+        }
+    }
+
+    private static function testClientVersionIsQueryEncodedAsPlus(): void
+    {
+        // make_request builds its query with http_build_query, which
+        // percent-encodes '+' as %2B. A literal '+' would decode to a
+        // space server-side, so this encoding is load-bearing.
+        TinyAssert::same(
+            'client_v=2.23.9%2B1a2b3c4',
+            http_build_query(['client_v' => '2.23.9+1a2b3c4'])
+        );
     }
 }
 


### PR DESCRIPTION
## Problem

`describe_component_provenance()` can already report the deployed commit on **git-synced** shops: the plugin dir carries a `.git` gitlink FILE whose gitdir path ends in the SHA, and base + ABN overlay each have their own. **Released (wp.org) zips have no git metadata at all**, so both the admin provenance line and the API `client_v` param go blind exactly where support needs them most.

Linear: TWO-25196

## Change

1. **`.github/workflows/deploy.yaml`** — new `Stamp deployed commit` step between the `ref_name` echo and the 10up deploy, writing `${SHA:0:7}` to `$GITHUB_WORKSPACE/.two-deployed-commit`. The SHA arrives via `env: SHA: ${{ github.sha }}` rather than being interpolated into the shell source.

2. **`resolve_component_commit($dir)`** (new, `private static`) — reads `<component-dir>/.two-deployed-commit` first, validated against `/^[0-9a-f]{7,40}$/i` after trimming; an absent, unreadable, empty or malformed sidecar **falls through** to the unchanged gitlink parse rather than winning. Never throws (`@file_get_contents`, `is_readable` guards). Called per component, so the overlay row gets its own stamp.

3. **`client_version()`** (new, `private static`) — `make_request()`'s `client_v` becomes `<version>` plus `'+' . $sha7` **only** when a commit resolves. Never a bare trailing `+`. Shares the accessor with the provenance line rather than duplicating the regex.

4. `.gitignore` — the stamp is a build artifact, not source.

## Encoding: the `+` is safe

`make_request()` builds its query with `http_build_query($params)`, which percent-encodes `+` as `%2B`. Verified by emitting the real URL:

```
$ php -r 'echo sprintf("%s%s?%s", "https://api.two.inc", "/v1/order", http_build_query(["client"=>"wp","client_v"=>"2.23.9+1a2b3c4"])), "\n";'
https://api.two.inc/v1/order?client=wp&client_v=2.23.9%2B1a2b3c4
```

No `rawurlencode` needed — and a regression test pins that encoding, since a literal `+` would decode to a space server-side.

## The stamp actually ships

`.distignore` and `.gitattributes` are explicit deny-lists that do not mention `.two-deployed-commit`, but that was proved rather than assumed. The 10up action's `deploy.sh:124` runs:

```
rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "$GITHUB_WORKSPACE/" trunk/ --delete --delete-excluded
```

Ran exactly that against a scratch dir with the stamp in place:

```
$ echo "1a2b3c4" > .two-deployed-commit
$ rsync -rc --exclude-from=".distignore" "./" "$SCRATCH/build/" --delete --delete-excluded
$ cat $SCRATCH/build/.two-deployed-commit
1a2b3c4
```

Survives.

## Tests

Six new cases in `tests/unit/run.php`: sidecar-wins-over-gitlink, garbage/empty/short/overlong sidecar falls through to gitlink, no-sources yields bare version, `client_v` never emits a trailing `+`, `client_v` suffixes the short SHA when stamped, and the `%2B` query encoding. `tests/unit/bootstrap.php` gains a `get_twoinc_plugin_version()` stub (the real one lives in `tillit-payment-gateway.php`, which the suite does not load).

## CI run locally

```
$ php tests/unit/run.php
All tests passed.

$ phpcs        # 4.0.1, exit 0 — 0 errors, pre-existing line-length warnings only

$ phpstan analyse --no-progress --memory-limit=4G   # 2.2.5, with pinned stubs
 [OK] No errors

$ pre-commit run --files ...
prettier.................................................................Passed
```

Repo disallows squash — merge commit please.