### PR TITLE
TWO-25196/fix: resolve deployed commit from .git gitlink before sidecar

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -4040,15 +4040,19 @@ if (!class_exists('WC_Twoinc')) {
          * Deployed commit SHA for one component directory, or null when it
          * cannot be established. Two sources, in precedence order:
          *
-         *  1. `.two-deployed-commit` — a sidecar written by the release
+         *  1. The `.git` gitlink FILE of a git-sync worktree copy, whose
+         *     gitdir path ends in the commit SHA. This reflects what is
+         *     checked out RIGHT NOW, so it wins: on a live git-synced shop
+         *     a stamped tree can later be checked out over, at which point
+         *     the sidecar is frozen at the build that produced it and lies.
+         *  2. `.two-deployed-commit` — a sidecar written by the release
          *     workflow and shipped inside the zip, so wp.org / released
          *     installs (which carry no git metadata at all) still know
          *     which commit they were built from.
-         *  2. The `.git` gitlink FILE of a git-sync worktree copy, whose
-         *     gitdir path ends in the commit SHA.
          *
-         * An absent, unreadable, empty or malformed sidecar falls through
-         * to the gitlink rather than winning. Never throws.
+         * Each source falls THROUGH to the next when it is absent,
+         * unreadable, empty or malformed — neither short-circuits to null.
+         * Never throws.
          *
          * @param string $dir component directory (no trailing slash needed)
          *
@@ -4058,19 +4062,19 @@ if (!class_exists('WC_Twoinc')) {
         {
             $dir = rtrim((string) $dir, '/');
 
+            $git_pointer = $dir . '/.git';
+            if (is_file($git_pointer) && is_readable($git_pointer)) {
+                $pointer = @file_get_contents($git_pointer);
+                if (is_string($pointer) && preg_match('#gitdir:\s*.*/([0-9a-f]{7,40})\s*$#i', trim($pointer), $m)) {
+                    return strtolower($m[1]);
+                }
+            }
+
             $stamp = $dir . '/.two-deployed-commit';
             if (is_file($stamp) && is_readable($stamp)) {
                 $raw = @file_get_contents($stamp);
                 if (is_string($raw) && preg_match('/^[0-9a-f]{7,40}$/i', trim($raw))) {
                     return strtolower(trim($raw));
-                }
-            }
-
-            $git_pointer = $dir . '/.git';
-            if (is_file($git_pointer) && is_readable($git_pointer)) {
-                $pointer = @file_get_contents($git_pointer);
-                if (is_string($pointer) && preg_match('#gitdir:\s*.*/([0-9a-f]{40})\s*$#', trim($pointer), $m)) {
-                    return strtolower($m[1]);
                 }
             }
 

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -144,8 +144,9 @@ final class BrandConfigSpec
             'testBuyerFeeShareCapRoundingToZeroWithholdsWholeSurcharge',
             'testCartFeeSkippedOnQuoteCurrencyMismatch',
             'testMinimumDescriptionShowsConvertedFloorWhenRateAvailable',
-            'testDeployedCommitSidecarWinsOverGitlink',
+            'testDeployedCommitGitlinkWinsOverSidecar',
             'testGarbageOrEmptySidecarFallsThroughToGitlink',
+            'testGarbageOrEmptyGitlinkFallsThroughToSidecar',
             'testNoProvenanceSourcesYieldsBareVersion',
             'testClientVersionNeverEmitsTrailingPlus',
             'testClientVersionSuffixesShortShaWhenStamped',
@@ -3727,20 +3728,19 @@ final class BrandConfigSpec
         return $method->invoke(null);
     }
 
-    private static function testDeployedCommitSidecarWinsOverGitlink(): void
+    private static function testDeployedCommitGitlinkWinsOverSidecar(): void
     {
-        // Released zips ship .two-deployed-commit; when both sources are
-        // present the sidecar is authoritative.
+        // The gitlink reflects what is checked out RIGHT NOW; the sidecar is
+        // frozen at the build that stamped it, so when both are present the
+        // gitlink is authoritative (org-wide order, TWO-25196).
         $gitlink = 'gitdir: /var/sync/worktrees/' . str_repeat('a', 40) . "\n";
         $dir = self::makeComponentDir([
             '.two-deployed-commit' => "deadbee\n",
             '.git' => $gitlink,
         ]);
         try {
-            TinyAssert::true(
-                strpos(self::provenanceOf($dir, '2.23.9'), '2.23.9 (deadbee,') === 0,
-                self::provenanceOf($dir, '2.23.9')
-            );
+            $described = self::provenanceOf($dir, '2.23.9');
+            TinyAssert::true(strpos($described, '2.23.9 (aaaaaaaaaaaa,') === 0, $described);
         } finally {
             self::removeComponentDir($dir);
         }
@@ -3760,6 +3760,33 @@ final class BrandConfigSpec
             try {
                 $described = self::provenanceOf($dir, '2.23.9');
                 TinyAssert::true(strpos($described, '2.23.9 (bbbbbbbbbbbb,') === 0, $described);
+            } finally {
+                self::removeComponentDir($dir);
+            }
+        }
+    }
+
+    private static function testGarbageOrEmptyGitlinkFallsThroughToSidecar(): void
+    {
+        // Mirror of the above now that the gitlink is first: a `.git` file
+        // that carries no usable SHA (submodule pointer, plain gitdir, too
+        // few hex chars) must fall through to the sidecar, not to null.
+        $pointers = [
+            "\n",
+            '   ',
+            'gitdir: ../.git/modules/twoinc',
+            'gitdir: /var/sync/worktrees/abcdef',
+            'gitdir: /var/sync/worktrees/' . str_repeat('f', 41),
+            'ref: refs/heads/staging',
+        ];
+        foreach ($pointers as $pointer) {
+            $dir = self::makeComponentDir([
+                '.two-deployed-commit' => "deadbee\n",
+                '.git' => $pointer,
+            ]);
+            try {
+                $described = self::provenanceOf($dir, '2.23.9');
+                TinyAssert::true(strpos($described, '2.23.9 (deadbee,') === 0, $described);
             } finally {
                 self::removeComponentDir($dir);
             }


### PR DESCRIPTION
Linear: [TWO-25196](https://linear.app/two/issue/TWO-25196)

## What

Flip the provenance precedence in `resolve_component_commit()` (`class/WC_Twoinc.php`) so the `.git` **gitlink is consulted FIRST** and `.two-deployed-commit` **LAST**. woocommerce-plugin PR #379 shipped it the other way round.

## Why

The org-wide order — now shared with the PrestaShop and Magento plugins — is gitlink first, build stamp last:

- The **gitlink** reflects what is checked out **right now** on a live git-synced shop.
- The **build stamp** is frozen at the build that produced it. If a stamped tree is later checked out over, the sidecar reports a commit the shop is no longer running.

Released zips and wp.org installs carry no git metadata at all, so the sidecar is still what covers them — it just no longer outranks the live checkout.

## Also

- Widened the gitlink SHA pattern from exactly 40 hex chars (`[0-9a-f]{40}`) to `[0-9a-f]{7,40}`. That is what the sidecar path already accepted and what PrestaShop/Magento use, so a short-SHA gitlink no longer silently resolves to nothing.
- Every source still falls **through** to the next when absent, unreadable, empty or malformed — neither short-circuits to `null`.
- PHPDoc rewritten to document the new order and the staleness rationale.

## Tests (`tests/unit/run.php`)

- `testDeployedCommitSidecarWinsOverGitlink` → `testDeployedCommitGitlinkWinsOverSidecar` (both sources present, gitlink wins).
- `testGarbageOrEmptySidecarFallsThroughToGitlink` kept unchanged.
- **New** `testGarbageOrEmptyGitlinkFallsThroughToSidecar` — the mirror case: submodule pointer, plain gitdir with no SHA, too-few hex chars, 41 hex chars, and a non-`gitdir:` `.git` file all fall through to a valid sidecar rather than to `null`.
- `testNoProvenanceSourcesYieldsBareVersion` and `testClientVersionNeverEmitsTrailingPlus` kept.
- New names registered in the `$tests` array in `runAll()`.

## Overlay (woocommerce-abn-plugin)

No change needed there and none made. The overlay has **no reader of its own** — it only *writes* the sidecar (`make archive` stamps `.two-deployed-commit` and `zip -j`s it into the zip root, i.e. the overlay plugin dir root once installed). Provenance for the overlay row is rendered by this base plugin calling `describe_component_provenance()` on the overlay main file, so both the base row and the overlay row keep resolving a commit under the flipped order.

## Gates run locally

- `php -l class/WC_Twoinc.php tests/unit/run.php` — no syntax errors
- `php tests/unit/run.php` — `All tests passed.`
- `phpcs` (4.0.1, `phpcs.xml`) — **0 errors**, 279 pre-existing line-length warnings, exit 0
- `phpstan analyse --no-progress --memory-limit=4G` (2.2.5, level 2 + baseline, pinned stubs) — `[OK] No errors`
- `pre-commit run` (prettier) — Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)