### PR TITLE
TWO-25209/docs: refer to branding overlays generically, not by partner brand

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -680,8 +680,8 @@ if (!class_exists('WC_Twoinc')) {
         private function get_abt_twoinc_html()
         {
             $abt_url = WC_Twoinc_Brand::get('about_url');
-            // A brand with no about page ('' — e.g. ABN, whose subtitle
-            // already carries its own "lees meer" link) renders nothing
+            // A brand with no about page ('' — e.g. a partner edition whose
+            // subtitle already carries its own inline "read more" link) renders nothing
             // here, regardless of the merchant's show_abt_link setting.
             if ($this->get_option('show_abt_link') === 'yes' && $abt_url !== '') {
                 $product_name = WC_Twoinc_Brand::get('product_name');
@@ -1383,7 +1383,8 @@ if (!class_exists('WC_Twoinc')) {
         {
             $subtitle = WC_Twoinc_Brand::get('checkout_subtitle');
             // wp_kses_post, not esc_html: a brand's subtitle may carry an
-            // inline link (e.g. ABN's "lees meer") — esc_html stripped it.
+            // inline link (e.g. a partner edition's localised "read more"
+            // link) — esc_html stripped it.
             $subtitle_html = $subtitle
                 ? sprintf(
                     '<div class="twoinc-payment-subtitle">%s</div>',


### PR DESCRIPTION
## Why

This is a **PUBLIC** repository. The partner brand overlay is **private** and will never be public. Naming the partner in comments is a leak — public repos are indexed by GitHub code search.

Filed as [TWO-25209](https://linear.app/two-inc/issue/TWO-25209) under [TWO-24739](https://linear.app/two-inc/issue/TWO-24739), which covers the same sweep across all four public plugin repos.

## What changed

Two comments in `class/WC_Twoinc.php`, both of which used the partner as the worked example for a brand-agnostic mechanism. Reworded to "a partner edition", and the partner's localised link text replaced with a generic equivalent. The technical point of each comment — why an empty `about_url` renders nothing, and why the subtitle uses `wp_kses_post` rather than `esc_html` — is preserved exactly.

**Comments only. No behaviour, config key, class name or method name changes.** The diff contains no non-comment lines.

## Scope note

`staging` had 2 hits and `main` had **0**, so unlike the Magento repos this one has no already-public exposure to reason about — the strings were introduced on `staging` and have not been promoted. Fixing before the next promotion means they never reach `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
