### PR TITLE
TWO-25213/fix: canonical intent-approved notice copy with company name

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -35,30 +35,33 @@
   max-height: 32px;
 }
 
-.twoinc-loader::before {
-  width: 1em;
-  height: 1em;
-  display: block;
-  position: relative;
-  margin: auto;
-  content: "";
-  animation: spin 1s ease-in-out infinite;
-  background: url(../images/loader.svg) center center;
-  background-size: cover;
-  line-height: 1;
+/*
+ * Order-intent check in flight. Renders the shared .twoinc-dots pulse (see
+ * below) rather than a rotating image: the dot pulse is the only
+ * Two-owned loading idiom on the other checkout surfaces, and it needs no
+ * asset. Deliberately NOT Magento core's full-screen loading mask, which
+ * the Luma checkout borrows — that is core CSS we do not own, and it
+ * blocks the whole page.
+ */
+.twoinc-loader {
   text-align: center;
-  font-size: 2em;
-  color: rgba(0, 0, 0, 0.75);
-  opacity: 0.5;
 }
 
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+/*
+ * Visually hidden but readable by assistive technology. Defined here rather
+ * than leaning on the theme's .screen-reader-text, which not every theme
+ * ships — a missing rule there would render the text visibly.
+ */
+.twoinc-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .twoinc-source,
@@ -228,27 +231,30 @@
   opacity: 0.85;
 }
 /*
- * Loading dots shown while the fee quote is in flight. Timing mirrors the
- * Magento checkout (.two-term-chip__loading): 1.4s staggered opacity pulse.
+ * The one loading idiom in this plugin: a 1.4s staggered three-dot opacity
+ * pulse, timing mirroring the Magento checkout's .two-term-chip__loading.
+ * Shared by the term-chip fee quote and the order-intent check
+ * (.twoinc-loader) — one element, one keyframes block, no duplication.
+ * Markup: <span class="twoinc-dots" aria-hidden="true"><span>.</span>x3.
  */
-.twoinc-term-chip__loading {
+.twoinc-dots {
   display: inline-block;
   letter-spacing: 2px;
   font-size: 12px;
   font-weight: 700;
   color: inherit;
 }
-.twoinc-term-chip__loading > span {
+.twoinc-dots > span {
   display: inline-block;
-  animation: twoinc-term-chip-dot 1.4s infinite ease-in-out both;
+  animation: twoinc-dot-pulse 1.4s infinite ease-in-out both;
 }
-.twoinc-term-chip__loading > span:nth-child(2) {
+.twoinc-dots > span:nth-child(2) {
   animation-delay: 0.2s;
 }
-.twoinc-term-chip__loading > span:nth-child(3) {
+.twoinc-dots > span:nth-child(3) {
   animation-delay: 0.4s;
 }
-@keyframes twoinc-term-chip-dot {
+@keyframes twoinc-dot-pulse {
   0%,
   80%,
   100% {

--- a/assets/images/loader.svg
+++ b/assets/images/loader.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 91.3 91.1"><circle cx="45.7" cy="45.7" r="45.7"/><circle fill="#FFF" cx="45.7" cy="24.4" r="12.5"/></svg>

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -436,7 +436,25 @@ let twoincDomHelper = {
       if (action === "checking-intent") {
         jQuery(".twoinc-pay-box.twoinc-loader").removeClass("hidden");
       } else if (action === "intent-approved") {
-        jQuery(".twoinc-pay-box.twoinc-intent-approved").removeClass("hidden");
+        // The notice ships the no-company sentence as its text and the
+        // company-name variant as a template on data-company-template
+        // (only the browser knows the buyer's company). Substitute here,
+        // always from the template, so a later company change re-renders
+        // and an emptied company falls back to the served sentence.
+        // Suppressed by the brand => the div is absent and every call
+        // below is a no-op on an empty jQuery set.
+        let intentBox = jQuery(".twoinc-pay-box.twoinc-intent-approved");
+        if (intentBox.data("twoincDefaultText") === undefined) {
+          intentBox.data("twoincDefaultText", intentBox.text());
+        }
+        let companyTemplate = intentBox.attr("data-company-template");
+        let companyName = (twoincDomHelper.getCompanyName() || "").trim();
+        if (companyTemplate && companyName) {
+          intentBox.text(companyTemplate.replace("{company}", companyName));
+        } else {
+          intentBox.text(intentBox.data("twoincDefaultText"));
+        }
+        intentBox.removeClass("hidden");
       } else if (action === "errored") {
         jQuery(".twoinc-pay-box" + errSelector).removeClass("hidden");
       }

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -973,8 +973,11 @@ let twoincTermChips = {
         // Fee quote in flight: show animated loading dots instead of a
         // blank chip. Never render the configured rate — only the real
         // quoted amount once it arrives.
+        // twoinc-dots carries the shared dot-pulse styling (also used by
+        // the order-intent loader); the BEM class stays as the chip-scoped
+        // hook. Appearance is unchanged.
         const $loading = jQuery("<span>", {
-          class: "twoinc-term-chip__loading",
+          class: "twoinc-term-chip__loading twoinc-dots",
           "aria-hidden": "true"
         });
         for (let i = 0; i < 3; i++) {

--- a/brands/two.php
+++ b/brands/two.php
@@ -70,8 +70,12 @@ return [
     // reader. A brand overlay substitutes its own support address.
     'production_key_contact_email' => 'integration@two.inc',
     // Buyer-facing notice shown once order intent is approved, pending
-    // final checks. sprintf'd with the brand product_name (one %s). ''
-    // renders nothing. WC_Twoinc::get_pay_box_description is the only
-    // reader.
-    'intent_approved_notice' => 'Your invoice purchase with %s is likely to be accepted subject to additional checks.',
+    // final checks. Three states, shared with the other platforms:
+    // null = the platform default translated copy in
+    // WC_Twoinc::get_intent_approved_notice (where it lives so WordPress
+    // i18n tooling can extract it); '' = suppressed entirely, no markup;
+    // a non-empty string = that sprintf template verbatim, with %1$s the
+    // brand product_name and %2$s the buyer's company name.
+    // WC_Twoinc::get_intent_approved_notice is the only reader.
+    'intent_approved_notice' => null,
 ];

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -712,9 +712,33 @@ if (!class_exists('WC_Twoinc')) {
         }
 
         /**
+         * Placeholder the buyer's company name is substituted for, in the
+         * browser, inside the intent-approved notice's company variant.
+         * Must match the token assets/js/twoinc.js replaces.
+         */
+        private const INTENT_NOTICE_COMPANY_TOKEN = '{company}';
+
+        /**
          * Buyer-facing notice shown once order intent is approved, pending
-         * final checks. A brand overlay may set 'intent_approved_notice'
-         * to '' to suppress it entirely.
+         * final checks — the whole `.twoinc-intent-approved` block, or ''.
+         *
+         * Three-state brand contract, shared verbatim with the other
+         * platforms' checkout renderers:
+         *   - 'intent_approved_notice' absent or null -> the platform
+         *     default copy below, notice shown;
+         *   - ''                                      -> suppressed
+         *     entirely, no markup emitted at all (an empty notice must not
+         *     leave an empty div behind, same as an empty tagline);
+         *   - non-empty string                        -> used verbatim as
+         *     the company-name variant's sprintf template.
+         *
+         * Two placeholders, in this order: %1$s is the brand product name,
+         * substituted here; %2$s is the buyer's company name, which only
+         * the browser knows, so it is emitted as a token on
+         * data-company-template for the checkout JS to substitute at
+         * unhide time. The div's own text is the no-company variant, so a
+         * buyer whose company is unknown (or whose JS never runs) still
+         * reads a complete sentence.
          */
         private function get_intent_approved_notice(): string
         {
@@ -722,7 +746,29 @@ if (!class_exists('WC_Twoinc')) {
             if ($template === '') {
                 return '';
             }
-            return sprintf(__($template, 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name'));
+            if ($template === null) {
+                $template = __(
+                    'Your invoice with %1$s is likely to be accepted for %2$s, subject to additional checks.',
+                    'twoinc-payment-gateway'
+                );
+            }
+
+            $product_name = WC_Twoinc_Brand::get('product_name');
+            $with_company = sprintf($template, $product_name, self::INTENT_NOTICE_COMPANY_TOKEN);
+            // The no-company fallback is always the platform default copy:
+            // a brand overriding the notice overrides the company variant
+            // only, since dropping a clause out of arbitrary brand copy is
+            // not something this layer can do safely.
+            $without_company = sprintf(
+                __('Your invoice with %1$s is likely to be accepted, subject to additional checks.', 'twoinc-payment-gateway'),
+                $product_name
+            );
+
+            return sprintf(
+                '<div class="twoinc-pay-box twoinc-intent-approved hidden" data-company-template="%s">%s</div>',
+                esc_attr($with_company),
+                esc_html($without_company)
+            );
         }
 
         /**
@@ -764,7 +810,7 @@ if (!class_exists('WC_Twoinc')) {
                     <div class="twoinc-term-chips hidden" role="radiogroup"></div>
                     <div class="twoinc-sole-trader-toggle hidden" role="radiogroup"></div>
                     <div class="twoinc-pay-box twoinc-loader hidden"></div>
-                    <div class="twoinc-pay-box twoinc-intent-approved hidden">%s</div>
+                    %s
                     <div class="twoinc-pay-box twoinc-err-payment-default hidden">%s</div>
                     <div class="twoinc-pay-box twoinc-err-phone-number hidden">%s</div>
                 </div>',

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -712,6 +712,31 @@ if (!class_exists('WC_Twoinc')) {
         }
 
         /**
+         * The order-intent check's loading state: the same three-dot pulse
+         * the term chips use for their fee quote (.twoinc-dots), which is
+         * the only Two-owned loading idiom across the checkout surfaces.
+         * It replaces a rotating SVG spinner — no image, no dependency on a
+         * theme's spinner, and nothing borrowed from another platform's
+         * core (notably not a full-screen blocking mask).
+         *
+         * The dots are decorative, so aria-hidden; the accessible name is
+         * the visually hidden sentence, and role="status" lets assistive
+         * technology announce the wait when the box is unhidden. The old
+         * spinner was a CSS ::before with content "" and no role, so it
+         * announced nothing at all.
+         */
+        private function get_intent_loader_html(): string
+        {
+            return sprintf(
+                '<div class="twoinc-pay-box twoinc-loader hidden" role="status">'
+                . '<span class="twoinc-sr-only">%s</span>'
+                . '<span class="twoinc-dots" aria-hidden="true"><span>.</span><span>.</span><span>.</span></span>'
+                . '</div>',
+                esc_html(__('Checking your order, one moment.', 'twoinc-payment-gateway'))
+            );
+        }
+
+        /**
          * Placeholder the buyer's company name is substituted for, in the
          * browser, inside the intent-approved notice's company variant.
          * Must match the token assets/js/twoinc.js replaces.
@@ -809,12 +834,13 @@ if (!class_exists('WC_Twoinc')) {
                     %s
                     <div class="twoinc-term-chips hidden" role="radiogroup"></div>
                     <div class="twoinc-sole-trader-toggle hidden" role="radiogroup"></div>
-                    <div class="twoinc-pay-box twoinc-loader hidden"></div>
+                    %s
                     %s
                     <div class="twoinc-pay-box twoinc-err-payment-default hidden">%s</div>
                     <div class="twoinc-pay-box twoinc-err-phone-number hidden">%s</div>
                 </div>',
                 $term_input,
+                $this->get_intent_loader_html(),
                 $this->get_intent_approved_notice(),
                 sprintf(__('Invoice purchase with %s is not available for this order.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')),
                 __('Phone number is invalid.', 'twoinc-payment-gateway')

--- a/tests/unit/fixtures/customnoticebrand.php
+++ b/tests/unit/fixtures/customnoticebrand.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Brand fixture for the intent-approved notice's override state: a
+ * non-empty 'intent_approved_notice' is the company-variant sprintf
+ * template, used verbatim, with %1$s the brand product name and %2$s the
+ * buyer's company name.
+ */
+
+return [
+    'code' => 'customnoticebrand',
+    'product_name' => 'Customnoticebrand',
+    'gateway_id' => 'woocommerce-gateway-customnoticebrand',
+    'meta_prefix' => 'customnoticebrand',
+    'intent_approved_notice' => 'Brand copy: %1$s may accept this for %2$s.',
+];

--- a/tests/unit/fixtures/suppressednoticebrand.php
+++ b/tests/unit/fixtures/suppressednoticebrand.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Brand fixture for the intent-approved notice's suppressed state: a brand
+ * that sets 'intent_approved_notice' to '' must emit no notice markup at
+ * all, not an empty div. Kept separate from testbrand.php, which other
+ * specs assert the exact merge result of.
+ */
+
+return [
+    'code' => 'suppressednoticebrand',
+    'product_name' => 'Suppressednoticebrand',
+    'gateway_id' => 'woocommerce-gateway-suppressednoticebrand',
+    'meta_prefix' => 'suppressednoticebrand',
+    'intent_approved_notice' => '',
+];

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -156,6 +156,7 @@ final class BrandConfigSpec
             'testIntentApprovedNoticeSuppressedBrandEmitsNoBlock',
             'testIntentApprovedNoticeDefaultBrandCarriesBothVariants',
             'testIntentApprovedNoticeBrandTemplateUsedVerbatim',
+            'testIntentLoaderRendersTheOneSharedDotPulse',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -3989,6 +3990,43 @@ final class BrandConfigSpec
         TinyAssert::true(
             strpos($html, 'Your invoice with Customnoticebrand is likely to be accepted, subject to additional checks.') !== false,
             'the no-company fallback stays the platform default copy'
+        );
+    }
+
+    /**
+     * The order-intent loading state renders the shared three-dot pulse,
+     * decorative dots plus an announced accessible name — not the old
+     * rotating image, and not a second copy of the dot animation. The CSS
+     * assertions are the point of the refactor: one .twoinc-dots rule and
+     * one keyframes block serve both the term chips and this loader.
+     */
+    private static function testIntentLoaderRendersTheOneSharedDotPulse(): void
+    {
+        $html = self::gateway()->build_payment_description();
+        TinyAssert::true(
+            strpos($html, '<div class="twoinc-pay-box twoinc-loader hidden" role="status">') !== false,
+            'the loader keeps its pay-box state class and announces itself'
+        );
+        TinyAssert::true(
+            strpos($html, '<span class="twoinc-dots" aria-hidden="true"><span>.</span><span>.</span><span>.</span></span>')
+                !== false,
+            'the loader must render the shared dot markup, dots hidden from assistive technology'
+        );
+
+        $css = (string) file_get_contents(dirname(__DIR__, 2) . '/assets/css/twoinc.css');
+        TinyAssert::true(
+            strpos($css, '.twoinc-dots {') !== false,
+            'the shared dot rule must exist'
+        );
+        TinyAssert::same(
+            1,
+            preg_match_all('/@keyframes\s+twoinc-dot-pulse/', $css),
+            'exactly one dot animation may be declared'
+        );
+        TinyAssert::same(
+            0,
+            preg_match_all('/@keyframes\s+spin|loader\.svg/', $css),
+            'the retired rotating spinner must be gone from the stylesheet'
         );
     }
 }

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -153,6 +153,9 @@ final class BrandConfigSpec
             'testPaymentBoxOrdersTaglineChipsThenSoleTrader',
             'testSelectedTermInputPrecedesChipsContainer',
             'testBrandWithoutTaglineEmitsNoTaglineBlock',
+            'testIntentApprovedNoticeSuppressedBrandEmitsNoBlock',
+            'testIntentApprovedNoticeDefaultBrandCarriesBothVariants',
+            'testIntentApprovedNoticeBrandTemplateUsedVerbatim',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -3915,6 +3918,77 @@ final class BrandConfigSpec
         TinyAssert::true(
             strpos($html, 'twoinc-payment-subtitle') === false,
             'a brand with no tagline must emit no tagline block'
+        );
+    }
+
+    /**
+     * State two of the intent-approved notice's brand contract: '' means
+     * suppressed, and suppressed means no markup at all — an empty div
+     * would still occupy the payment box's spacing.
+     */
+    private static function testIntentApprovedNoticeSuppressedBrandEmitsNoBlock(): void
+    {
+        add_filter('twoinc_brand_file', static function ($file) {
+            return __DIR__ . '/fixtures/suppressednoticebrand.php';
+        });
+        TinyAssert::same('', WC_Twoinc_Brand::get('intent_approved_notice'));
+
+        $html = self::gateway()->build_payment_description();
+        TinyAssert::true(
+            strpos($html, 'twoinc-intent-approved') === false,
+            'a brand suppressing the notice must emit no notice block'
+        );
+    }
+
+    /**
+     * State one: no brand override (the Two default, now null) renders the
+     * platform default copy. The div's text is the no-company sentence and
+     * data-company-template carries the company variant with the brand
+     * name already resolved and the company name left as a token — the
+     * server cannot know the buyer's company, so the JS substitutes it.
+     */
+    private static function testIntentApprovedNoticeDefaultBrandCarriesBothVariants(): void
+    {
+        TinyAssert::same(null, WC_Twoinc_Brand::get('intent_approved_notice'));
+
+        $html = self::gateway()->build_payment_description();
+        TinyAssert::true(
+            strpos($html, 'twoinc-pay-box twoinc-intent-approved hidden') !== false,
+            'the default brand must emit the notice block'
+        );
+        TinyAssert::true(
+            strpos($html, 'Your invoice with Two is likely to be accepted, subject to additional checks.') !== false,
+            'the notice text must be the no-company variant'
+        );
+        TinyAssert::true(
+            strpos(
+                $html,
+                'data-company-template="Your invoice with Two is likely to be accepted for {company},'
+                . ' subject to additional checks."'
+            ) !== false,
+            'the notice must carry the company variant, brand name resolved, company name tokenised'
+        );
+    }
+
+    /**
+     * State three: a non-empty brand string is the company-variant
+     * template, used verbatim. The no-company fallback stays the platform
+     * default — this layer cannot drop a clause out of arbitrary copy.
+     */
+    private static function testIntentApprovedNoticeBrandTemplateUsedVerbatim(): void
+    {
+        add_filter('twoinc_brand_file', static function ($file) {
+            return __DIR__ . '/fixtures/customnoticebrand.php';
+        });
+
+        $html = self::gateway()->build_payment_description();
+        TinyAssert::true(
+            strpos($html, 'data-company-template="Brand copy: Customnoticebrand may accept this for {company}."') !== false,
+            'a brand template must be used verbatim for the company variant'
+        );
+        TinyAssert::true(
+            strpos($html, 'Your invoice with Customnoticebrand is likely to be accepted, subject to additional checks.') !== false,
+            'the no-company fallback stays the platform default copy'
         );
     }
 }


### PR DESCRIPTION
## Stacked PR — base is NOT staging

This PR targets **`doug/TWO-25213-intent-approved-notice` → `doug/ABN-468-tile-order`**, the head of open PR #382, deliberately: #382 rewrites the exact payment-box assembly this change edits. **Retarget this PR to `staging` once #382 merges.** Do not merge #382 from here.

Ticket: TWO-25213 (child of TWO-24739, cross-platform parity).

## What changed

The "order intent approved" reassurance notice exists on four checkout surfaces, rendered four ways with three different copy strings. This converges WooCommerce on the canonical copy and makes its brand contract explicit. Sibling PRs implement the identical contract on the other platforms; PrestaShop's persistent inline notice is the reference.

**Buyer-facing copy change.** Two variants, canonical across all platforms:

- company known: `Your invoice with %1$s is likely to be accepted for %2$s, subject to additional checks.`
- company unknown: `Your invoice with %1$s is likely to be accepted, subject to additional checks.`

(`%1$s` = brand product name, `%2$s` = buyer company name.) The previous WooCommerce copy was `Your invoice purchase with %s is likely to be accepted subject to additional checks.`

**Company-name interpolation.** WooCommerce renders the payment box server-side and cannot know the buyer's company, so PHP emits both resolved strings: the no-company sentence as the div's text, and the company template — brand name already substituted, company name left as a `{company}` token — on `data-company-template` (`esc_attr`'d). `togglePaySubtitleDesc('intent-approved')` substitutes from `twoincDomHelper.getCompanyName()` at unhide time, via `.text()` so the company name can never inject markup. It re-derives from the template on every call, so a changed company re-renders and an emptied company falls back to the served sentence. No company, or no JS at all, degrades to the no-company sentence.

**Three-state brand contract** (uniform across platforms):

| `intent_approved_notice` | behaviour |
| --- | --- |
| absent or `null` | platform default translated copy, notice shown |
| `''` | notice suppressed entirely — no markup at all |
| non-empty string | used verbatim as the company-variant template |

`brands/two.php` now declares `null`; the default copy moved into `WC_Twoinc::get_intent_approved_notice()`. Verified `WC_Twoinc_Brand::get()` returns `null` (not `''`) for an absent or null-valued key — it is `array_key_exists() ? $config[$key] : null`, and a declared `null` merges through `array_merge` unchanged. A brand overlay setting `''` keeps working: suppressed.

**i18n extraction bug fixed.** The old code called `__($template, 'twoinc-payment-gateway')` on a *variable* read from the brand file. WordPress i18n tooling only extracts literals, so the string has not been extractable since TWO-25049 moved it out of code (it was a literal in `class/WC_Twoinc.php` before that, which is why the `.po` files still carry a translation of the old wording). Both variants are now real literal `__()` calls.

**Empty means emit nothing.** A suppressed notice previously still emitted `<div class="twoinc-pay-box twoinc-intent-approved hidden"></div>`, whereas an empty `checkout_subtitle` omits its wrapper entirely. Now consistent: suppressed emits no div. `removeClass('hidden')` and `.text()` on the absent selector are no-ops on an empty jQuery set.

## Also in scope: the order-intent spinner (same ticket)

The intent check showed a rotating `loader.svg` at `font-size: 2em`/`opacity: 0.5`, driven by `.twoinc-loader::before` and `@keyframes spin`. It now shows the three-dot pulse instead. Findings behind that choice, verified in the Magento repos:

- **Magento Luma** wraps its intent call in Magento **core's** full-screen loader (`Magento_Checkout/js/model/full-screen-loader`, `startLoader()`/`stopLoader()` around `placeOrderIntent()` in `gateway_method.js`). That is core's `.loading-mask` dim overlay and core's spinner asset — **CSS we do not own**, and a page-blocking overlay. Not ported, deliberately.
- **Magento Hyvä** shows **nothing at all** during the intent call — `placeOrderIntent()` has no loader start/stop. **Luma vs Hyvä is therefore a real parity gap in the Magento plugin: full-page blocking mask on one, silence on the other.** Flagged, not fixed here.
- The only **Two-owned** spinner in the Magento plugins is the three-dot pulse (`.two-term-chip__loading` + `@keyframes two-term-chip-dot`), used for term-chip surcharge loading. WooCommerce already vendored it as `.twoinc-term-chip__loading` + `@keyframes twoinc-term-chip-dot` for the same purpose.

So "the same spinner Magento uses" resolves to the dot pulse, which this repo already had. What changed:

- The dot animation is extracted to a shared `.twoinc-dots` element and a single `@keyframes twoinc-dot-pulse`. Both the term chips and the intent loader use it — **exactly one dot animation in the stylesheet**. The chip keeps `twoinc-term-chip__loading` as its hook and renders byte-identically (the shared rule carries the same declarations the chip rule did); this is a pure refactor for the chips, a behaviour change only for the intent loader.
- `.twoinc-loader::before` and `@keyframes spin` are gone; the loader div is server-rendered with the dot markup by a new `get_intent_loader_html()`.
- `assets/images/loader.svg` had exactly one consumer, that `::before` rule. Grepped the tree (css/js/php/ts/json/md, minus `node_modules`): no remaining reference to it or to `spin`. Removed in its own commit (`TWO-25213/chore: remove the now-orphaned loader.svg`).
- **No fifth state, no second loader, no blocking overlay.** The four mutually-exclusive `.twoinc-pay-box` states and `togglePaySubtitleDesc()` are untouched.

**Accessibility.** The dots are decorative (`aria-hidden="true"`); the loader box carries `role="status"` and a visually hidden sentence ("Checking your order, one moment.") as its accessible name, styled by our own `.twoinc-sr-only` rule rather than a theme-provided `.screen-reader-text`, which not every theme ships. The old spinner was a CSS `::before` with `content: ""` and no role, so it announced nothing — this is strictly better, though whether a given screen reader announces a live region that transitions out of `display: none` varies, and that was not tested with real assistive technology.

**Both surfaces.** The pay box is the gateway's `description`, built once in the constructor, and WooCommerce renders it from the same `payment_methods` template on the checkout page and the order-pay page; `twoinc.css` and `twoinc.js` are enqueued unconditionally on `wp_enqueue_scripts`, so both surfaces get the rule and the toggle, and `twoinc.js` explicitly handles the order-pay form (`saveCheckoutInputs()` falls back to `div.checkout.woocommerce-checkout.custom-checkout`, and the intent flow bails only when `#order_review` is absent). **This is a structural verification only — there is no staging shop available to this branch, so neither surface was viewed in a browser and there is no screenshot of the dots rendering.**

Out of scope, noted: the gateway icon's `mollie-gateway-icon` class is copy-paste debris from another gateway. Not renamed, not imitated.

## Tests

Four added to `tests/unit/run.php` (registered in `runAll()`) — one per contract state plus one for the loader — and two brand fixtures:

- `testIntentApprovedNoticeSuppressedBrandEmitsNoBlock` — `''` emits no `twoinc-intent-approved` div.
- `testIntentApprovedNoticeDefaultBrandCarriesBothVariants` — default brand emits the div with the no-company text and the `data-company-template` company variant.
- `testIntentApprovedNoticeBrandTemplateUsedVerbatim` — a non-empty brand string is used verbatim for the company variant.
- `testIntentLoaderRendersTheOneSharedDotPulse` — the loader emits the `role="status"` box with the `aria-hidden` dot markup, and the stylesheet declares `.twoinc-dots` with exactly one `@keyframes twoinc-dot-pulse` and no surviving `spin`/`loader.svg`.

Each was mutation-checked — the code was broken and the corresponding test confirmed failing:

| mutation | test killed |
| --- | --- |
| drop the `$template === ''` early return | `...SuppressedBrandEmitsNoBlock` |
| reword the no-company default copy | `...DefaultBrandCarriesBothVariants` |
| swap the `sprintf` argument order (`%1$s`/`%2$s`) | `...DefaultBrandCarriesBothVariants` |
| ignore a brand-supplied template, always use the default | `...BrandTemplateUsedVerbatim` |
| strip the dot markup out of the loader div | `...RendersTheOneSharedDotPulse` |
| append a second `@keyframes twoinc-dot-pulse` to the stylesheet | `...RendersTheOneSharedDotPulse` |

## Gates, run locally

```
$ php tests/unit/run.php
...
PASS BrandConfigSpec::testIntentApprovedNoticeSuppressedBrandEmitsNoBlock
PASS BrandConfigSpec::testIntentApprovedNoticeDefaultBrandCarriesBothVariants
PASS BrandConfigSpec::testIntentApprovedNoticeBrandTemplateUsedVerbatim
PASS BrandConfigSpec::testIntentLoaderRendersTheOneSharedDotPulse
All tests passed.

$ make phpcs          # phpcs 4.0.1, PSR-12
0 ERRORS in every file (line-length warnings only, ungated by phpcs.xml); exit=0

$ make phpstan        # phpstan 2.2.5, level 2 + baseline
Note: Using configuration file /app/phpstan.neon.
 [OK] No errors

$ pre-commit run --files <the six changed files>
prettier.................................................................Passed
```

Leak gate run clean over the filesystem, this branch's commit messages, the branch name, this PR body, commit author emails and remote branches.

## Not verified

- **No screenshot / live checkout render, on either surface.** There is no staging shop available to this change, so neither the notice nor the new loader was observed in a real payment box on the checkout page or the order-pay page — only asserted at the HTML/CSS level and by reading the JS. The client-side company substitution in particular has no automated coverage (the unit harness is PHP-only, there is no JS test suite).
- **Screen-reader announcement** of the `role="status"` loader was not tested with real assistive technology.
- **Translations.** The two new msgids are not in `languages/*.pot` / `*.po`. The old wording *is* translated in `nb_NO`, `nl_NL` and `sv_SE`, so those locales will show English until the catalogues are regenerated and re-translated — worth a follow-up ticket, and unavoidable regardless since the copy itself changed.

## Note, out of scope

`class/WC_Twoinc.php` carries one pre-existing partner-brand name in a comment near the `about_url` gate (`get_abt_twoinc_html`). Left untouched — not this ticket — but it should be scrubbed; this is a public repo.
