### PR TITLE
TWO-25218/feat: separate the intent-approved notice's on/off switch from its copy

### DIFF
--- a/brands/two.php
+++ b/brands/two.php
@@ -69,13 +69,25 @@ return [
     // obtaining production keys. WC_Twoinc::init_form_fields is the only
     // reader. A brand overlay substitutes its own support address.
     'production_key_contact_email' => 'integration@two.inc',
-    // Buyer-facing notice shown once order intent is approved, pending
-    // final checks. Three states, shared with the other platforms:
-    // null = the platform default translated copy in
+    // On/off switch for the buyer-facing notice shown once order intent
+    // is approved, pending final checks. Explicit boolean ONLY, shared
+    // with the other platforms: true = notice shown; false = suppressed
+    // entirely, no markup emitted at all. Absent or null = the
+    // documented default true, which is what keeps a third-party overlay
+    // that declares nothing on ON. Any other value ('', 0, 'yes', an
+    // array) is a logged error and the default true is used — never a
+    // silent third behaviour.
+    // WC_Twoinc::is_intent_approved_notice_enabled is the only reader.
+    'intent_approved_notice_enabled' => true,
+    // Copy override for that notice — WORDING ONLY. It carried the
+    // on/off meaning too until TWO-25218; it no longer does. null, ''
+    // and whitespace-only are all INERT and mean the same thing: the
+    // platform default translated copy in
     // WC_Twoinc::get_intent_approved_notice (where it lives so WordPress
-    // i18n tooling can extract it); '' = suppressed entirely, no markup;
-    // a non-empty string = that sprintf template verbatim, with %1$s the
-    // brand product_name and %2$s the buyer's company name.
+    // i18n tooling can extract it). An empty string is NOT an off
+    // switch — use 'intent_approved_notice_enabled' => false for that.
+    // A non-empty string is that sprintf template verbatim, with %1$s
+    // the brand product_name and %2$s the buyer's company name.
     // WC_Twoinc::get_intent_approved_notice is the only reader.
     'intent_approved_notice' => null,
 ];

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -744,17 +744,63 @@ if (!class_exists('WC_Twoinc')) {
         private const INTENT_NOTICE_COMPANY_TOKEN = '{company}';
 
         /**
+         * Whether the brand wants the intent-approved notice at all.
+         *
+         * 'intent_approved_notice_enabled' is an explicit boolean and
+         * nothing else, shared verbatim with the other platforms:
+         *   - true            -> notice shown;
+         *   - false           -> suppressed entirely;
+         *   - absent / null   -> the documented default, true. This is
+         *     what keeps a third-party overlay that declares neither
+         *     notice key on ON;
+         *   - anything else   -> a clear logged error naming the key, the
+         *     offending value's type and the brand code, and then the
+         *     documented default true.
+         *
+         * The invalid case deliberately does NOT throw: this runs on a
+         * buyer-facing checkout render, where a white screen is a worse
+         * failure than a notice that stays on. Erring to ON is also the
+         * fail-safe direction — a brand that wanted it off gets a visible,
+         * reported wrong state and nobody loses a sale.
+         */
+        private function is_intent_approved_notice_enabled(): bool
+        {
+            $enabled = WC_Twoinc_Brand::get('intent_approved_notice_enabled');
+            if (is_bool($enabled)) {
+                return $enabled;
+            }
+            if ($enabled === null) {
+                return true;
+            }
+
+            $message = sprintf(
+                'Brand "%s" declares intent_approved_notice_enabled as %s; an explicit bool is required.'
+                . ' Falling back to the documented default true (notice shown).',
+                (string) WC_Twoinc_Brand::get('code'),
+                gettype($enabled)
+            );
+            if (function_exists('wc_get_logger')) {
+                wc_get_logger()->error($message, ['source' => 'twoinc-payment-gateway']);
+            } else {
+                error_log('Twoinc: ' . $message);
+            }
+            return true;
+        }
+
+        /**
          * Buyer-facing notice shown once order intent is approved, pending
          * final checks — the whole `.twoinc-intent-approved` block, or ''.
          *
-         * Three-state brand contract, shared verbatim with the other
-         * platforms' checkout renderers:
-         *   - 'intent_approved_notice' absent or null -> the platform
-         *     default copy below, notice shown;
-         *   - ''                                      -> suppressed
-         *     entirely, no markup emitted at all (an empty notice must not
-         *     leave an empty div behind, same as an empty tagline);
-         *   - non-empty string                        -> used verbatim as
+         * Two independent brand keys, shared verbatim with the other
+         * platforms' checkout renderers. On/off is
+         * 'intent_approved_notice_enabled' (see above); this method owns
+         * only the wording, from 'intent_approved_notice':
+         *   - absent / null / '' / whitespace-only -> the platform default
+         *     copy below. An empty override is INERT — it used to mean
+         *     "suppressed" (TWO-25213) and no longer does, so a stale
+         *     overlay still carrying one renders the default copy rather
+         *     than breaking the checkout;
+         *   - non-empty string                     -> used verbatim as
          *     the company-name variant's sprintf template.
          *
          * Two placeholders, in this order: %1$s is the brand product name,
@@ -767,11 +813,12 @@ if (!class_exists('WC_Twoinc')) {
          */
         private function get_intent_approved_notice(): string
         {
-            $template = WC_Twoinc_Brand::get('intent_approved_notice');
-            if ($template === '') {
+            if (!$this->is_intent_approved_notice_enabled()) {
                 return '';
             }
-            if ($template === null) {
+
+            $template = WC_Twoinc_Brand::get('intent_approved_notice');
+            if (!is_string($template) || trim($template) === '') {
                 $template = __(
                     'Your invoice with %1$s is likely to be accepted for %2$s, subject to additional checks.',
                     'twoinc-payment-gateway'

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -48,6 +48,35 @@ function remove_all_filters($tag)
     return true;
 }
 
+// ── WooCommerce logger ──────────────────────────────────────────────
+// The plugin logs through wc_get_logger() behind function_exists(), so a
+// stub here is what makes "the error was reported" assertable. Every call
+// is recorded as ['level' => …, 'message' => …, 'context' => …] in
+// $GLOBALS['__twoinc_test_logs'] (cleared per test).
+
+$GLOBALS['__twoinc_test_logs'] = [];
+
+class StubWcLogger
+{
+    public function __call($level, $args)
+    {
+        $GLOBALS['__twoinc_test_logs'][] = [
+            'level' => $level,
+            'message' => (string) ($args[0] ?? ''),
+            'context' => $args[1] ?? [],
+        ];
+    }
+}
+
+function wc_get_logger()
+{
+    static $logger = null;
+    if ($logger === null) {
+        $logger = new StubWcLogger();
+    }
+    return $logger;
+}
+
 // ── WP/WC function stubs ────────────────────────────────────────────
 
 function __($text, $domain = 'default')

--- a/tests/unit/fixtures/blanknoticecopybrand.php
+++ b/tests/unit/fixtures/blanknoticecopybrand.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Brand fixture for a whitespace-only 'intent_approved_notice' — an
+ * unfinished copy override. It is inert exactly like '': the platform
+ * default copy renders, rather than a notice reading as blank space.
+ */
+
+return [
+    'code' => 'blanknoticecopybrand',
+    'product_name' => 'Blanknoticecopybrand',
+    'gateway_id' => 'woocommerce-gateway-blanknoticecopybrand',
+    'meta_prefix' => 'blanknoticecopybrand',
+    'intent_approved_notice' => "  \t ",
+];

--- a/tests/unit/fixtures/customnoticebrand.php
+++ b/tests/unit/fixtures/customnoticebrand.php
@@ -1,10 +1,12 @@
 <?php
 
 /**
- * Brand fixture for the intent-approved notice's override state: a
+ * Brand fixture for the intent-approved notice's copy override: a
  * non-empty 'intent_approved_notice' is the company-variant sprintf
  * template, used verbatim, with %1$s the brand product name and %2$s the
- * buyer's company name.
+ * buyer's company name. The switch is declared explicitly true so the
+ * fixture reads as "notice on, wording overridden" — the two keys are
+ * independent (TWO-25218).
  */
 
 return [
@@ -12,5 +14,6 @@ return [
     'product_name' => 'Customnoticebrand',
     'gateway_id' => 'woocommerce-gateway-customnoticebrand',
     'meta_prefix' => 'customnoticebrand',
+    'intent_approved_notice_enabled' => true,
     'intent_approved_notice' => 'Brand copy: %1$s may accept this for %2$s.',
 ];

--- a/tests/unit/fixtures/inertemptynoticebrand.php
+++ b/tests/unit/fixtures/inertemptynoticebrand.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Brand fixture for the migration hazard TWO-25218 documents: a stale
+ * overlay still carrying the pre-TWO-25218 empty 'intent_approved_notice'
+ * and no switch. Empty copy is now INERT, so this renders the platform
+ * default copy with the notice ON — wrong for that brand, but not a
+ * broken store. There is deliberately no legacy-compat path resurrecting
+ * empty-means-off.
+ */
+
+return [
+    'code' => 'inertemptynoticebrand',
+    'product_name' => 'Inertemptynoticebrand',
+    'gateway_id' => 'woocommerce-gateway-inertemptynoticebrand',
+    'meta_prefix' => 'inertemptynoticebrand',
+    'intent_approved_notice' => '',
+];

--- a/tests/unit/fixtures/invalidnoticeswitchbrand.php
+++ b/tests/unit/fixtures/invalidnoticeswitchbrand.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Brand fixture for an INVALID intent-approved notice switch: the key is
+ * declared as an empty string, which under the pre-TWO-25218 contract was
+ * how "off" was expressed. It is not a bool, so it must be reported as an
+ * error and fall back to the documented default true — never silently
+ * treated as a third behaviour.
+ */
+
+return [
+    'code' => 'invalidnoticeswitchbrand',
+    'product_name' => 'Invalidnoticeswitchbrand',
+    'gateway_id' => 'woocommerce-gateway-invalidnoticeswitchbrand',
+    'meta_prefix' => 'invalidnoticeswitchbrand',
+    'intent_approved_notice_enabled' => '',
+];

--- a/tests/unit/fixtures/silentnoticebrand.php
+++ b/tests/unit/fixtures/silentnoticebrand.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Brand fixture for a third-party overlay that has no opinion about the
+ * intent-approved notice: it declares NEITHER
+ * 'intent_approved_notice_enabled' NOR 'intent_approved_notice'. Absent
+ * means the documented default, so the notice stays ON with the platform
+ * default copy — the must-not-regress case that absent-means-true exists
+ * for (TWO-25218).
+ */
+
+return [
+    'code' => 'silentnoticebrand',
+    'product_name' => 'Silentnoticebrand',
+    'gateway_id' => 'woocommerce-gateway-silentnoticebrand',
+    'meta_prefix' => 'silentnoticebrand',
+];

--- a/tests/unit/fixtures/suppressednoticebrand.php
+++ b/tests/unit/fixtures/suppressednoticebrand.php
@@ -1,10 +1,11 @@
 <?php
 
 /**
- * Brand fixture for the intent-approved notice's suppressed state: a brand
- * that sets 'intent_approved_notice' to '' must emit no notice markup at
- * all, not an empty div. Kept separate from testbrand.php, which other
- * specs assert the exact merge result of.
+ * Brand fixture for the intent-approved notice's off switch: a brand that
+ * sets 'intent_approved_notice_enabled' to false must emit no notice
+ * markup at all, not an empty div. It declares no copy override — the
+ * switch alone turns the notice off (TWO-25218). Kept separate from
+ * testbrand.php, which other specs assert the exact merge result of.
  */
 
 return [
@@ -12,5 +13,5 @@ return [
     'product_name' => 'Suppressednoticebrand',
     'gateway_id' => 'woocommerce-gateway-suppressednoticebrand',
     'meta_prefix' => 'suppressednoticebrand',
-    'intent_approved_notice' => '',
+    'intent_approved_notice_enabled' => false,
 ];

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -154,9 +154,13 @@ final class BrandConfigSpec
             'testPaymentBoxOrdersTaglineChipsThenSoleTrader',
             'testSelectedTermInputPrecedesChipsContainer',
             'testBrandWithoutTaglineEmitsNoTaglineBlock',
-            'testIntentApprovedNoticeSuppressedBrandEmitsNoBlock',
+            'testIntentApprovedNoticeDisabledBrandEmitsNoBlock',
             'testIntentApprovedNoticeDefaultBrandCarriesBothVariants',
             'testIntentApprovedNoticeBrandTemplateUsedVerbatim',
+            'testIntentApprovedNoticeEmptyCopyOverrideIsInert',
+            'testIntentApprovedNoticeSwitchAbsentDefaultsOn',
+            'testIntentApprovedNoticeOverlayDeclaringNothingKeepsNoticeOn',
+            'testIntentApprovedNoticeInvalidSwitchReportsAndDefaultsOn',
             'testIntentLoaderRendersTheOneSharedDotPulse',
         ];
         foreach ($tests as $test) {
@@ -179,6 +183,7 @@ final class BrandConfigSpec
         WC_Twoinc::reset_merchant_record_memo();
         WC_Twoinc_FX::reset_request_cache();
         $GLOBALS['__twoinc_test_transients'] = [];
+        $GLOBALS['__twoinc_test_logs'] = [];
         $GLOBALS['__twoinc_test_as_scheduled'] = [];
         $GLOBALS['__twoinc_test_as_schedule_calls'] = [];
         WC()->cart = null;
@@ -3950,33 +3955,37 @@ final class BrandConfigSpec
     }
 
     /**
-     * State two of the intent-approved notice's brand contract: '' means
-     * suppressed, and suppressed means no markup at all — an empty div
-     * would still occupy the payment box's spacing.
+     * The off switch: 'intent_approved_notice_enabled' => false suppresses
+     * the notice entirely — no markup at all, since an empty div would
+     * still occupy the payment box's spacing. Also pins that a `false`
+     * overlay value survives the brand merge: array_merge keeps it, but a
+     * falsy-means-absent filter anywhere in the loader would silently
+     * turn the switch back on.
      */
-    private static function testIntentApprovedNoticeSuppressedBrandEmitsNoBlock(): void
+    private static function testIntentApprovedNoticeDisabledBrandEmitsNoBlock(): void
     {
         add_filter('twoinc_brand_file', static function ($file) {
             return __DIR__ . '/fixtures/suppressednoticebrand.php';
         });
-        TinyAssert::same('', WC_Twoinc_Brand::get('intent_approved_notice'));
+        TinyAssert::same(false, WC_Twoinc_Brand::get('intent_approved_notice_enabled'));
 
         $html = self::gateway()->build_payment_description();
         TinyAssert::true(
             strpos($html, 'twoinc-intent-approved') === false,
-            'a brand suppressing the notice must emit no notice block'
+            'a brand disabling the notice must emit no notice block'
         );
     }
 
     /**
-     * State one: no brand override (the Two default, now null) renders the
-     * platform default copy. The div's text is the no-company sentence and
+     * Switch on, no copy override (the Two defaults): the platform default
+     * copy renders. The div's text is the no-company sentence and
      * data-company-template carries the company variant with the brand
      * name already resolved and the company name left as a token — the
      * server cannot know the buyer's company, so the JS substitutes it.
      */
     private static function testIntentApprovedNoticeDefaultBrandCarriesBothVariants(): void
     {
+        TinyAssert::same(true, WC_Twoinc_Brand::get('intent_approved_notice_enabled'));
         TinyAssert::same(null, WC_Twoinc_Brand::get('intent_approved_notice'));
 
         $html = self::gateway()->build_payment_description();
@@ -3999,7 +4008,7 @@ final class BrandConfigSpec
     }
 
     /**
-     * State three: a non-empty brand string is the company-variant
+     * The copy override: a non-empty brand string is the company-variant
      * template, used verbatim. The no-company fallback stays the platform
      * default — this layer cannot drop a clause out of arbitrary copy.
      */
@@ -4017,6 +4026,125 @@ final class BrandConfigSpec
         TinyAssert::true(
             strpos($html, 'Your invoice with Customnoticebrand is likely to be accepted, subject to additional checks.') !== false,
             'the no-company fallback stays the platform default copy'
+        );
+    }
+
+    /**
+     * Empty and whitespace-only copy overrides are INERT (TWO-25218): both
+     * render the platform default copy with the notice ON. '' used to mean
+     * "suppressed"; a stale overlay still carrying one must degrade to the
+     * default wording, not to a broken store and not to a silent off.
+     */
+    private static function testIntentApprovedNoticeEmptyCopyOverrideIsInert(): void
+    {
+        foreach (['inertemptynoticebrand', 'blanknoticecopybrand'] as $fixture) {
+            WC_Twoinc_Brand::reset();
+            remove_all_filters('twoinc_brand_file');
+            add_filter('twoinc_brand_file', static function ($file) use ($fixture) {
+                return __DIR__ . '/fixtures/' . $fixture . '.php';
+            });
+
+            $product = WC_Twoinc_Brand::get('product_name');
+            $html = self::gateway()->build_payment_description();
+            TinyAssert::true(
+                strpos($html, 'twoinc-pay-box twoinc-intent-approved hidden') !== false,
+                $fixture . ': an inert copy override must still emit the notice block'
+            );
+            TinyAssert::true(
+                strpos($html, 'Your invoice with ' . $product . ' is likely to be accepted, subject to additional checks.') !== false,
+                $fixture . ': an inert copy override must render the platform default copy'
+            );
+            TinyAssert::true(
+                strpos(
+                    $html,
+                    'data-company-template="Your invoice with ' . $product
+                    . ' is likely to be accepted for {company}, subject to additional checks."'
+                ) !== false,
+                $fixture . ': the company variant must be the platform default copy too'
+            );
+        }
+    }
+
+    /**
+     * Absent switch means the documented default true. Unreachable through
+     * a brand file (brands/two.php always declares the key), so the
+     * resolved config is reflected into the loader with the key removed —
+     * which is the shape a brand overlay predating the key resolves to
+     * against a stale base.
+     */
+    private static function testIntentApprovedNoticeSwitchAbsentDefaultsOn(): void
+    {
+        $config = WC_Twoinc_Brand::config();
+        unset($config['intent_approved_notice_enabled']);
+        $cache = new ReflectionProperty(WC_Twoinc_Brand::class, 'config');
+        $cache->setAccessible(true);
+        $cache->setValue(null, $config);
+
+        TinyAssert::same(null, WC_Twoinc_Brand::get('intent_approved_notice_enabled'));
+        TinyAssert::true(
+            strpos(self::gateway()->build_payment_description(), 'twoinc-intent-approved') !== false,
+            'an absent switch must default to the notice being shown'
+        );
+        TinyAssert::same([], $GLOBALS['__twoinc_test_logs'], 'absent is the documented default, not an error');
+    }
+
+    /**
+     * Must not regress: a third-party overlay declaring NEITHER notice key
+     * keeps the notice ON, with the platform default copy.
+     */
+    private static function testIntentApprovedNoticeOverlayDeclaringNothingKeepsNoticeOn(): void
+    {
+        add_filter('twoinc_brand_file', static function ($file) {
+            return __DIR__ . '/fixtures/silentnoticebrand.php';
+        });
+        TinyAssert::same('silentnoticebrand', WC_Twoinc_Brand::get('code'));
+
+        $html = self::gateway()->build_payment_description();
+        TinyAssert::true(
+            strpos($html, 'twoinc-pay-box twoinc-intent-approved hidden') !== false,
+            'an overlay with no notice opinion must keep the notice on'
+        );
+        TinyAssert::true(
+            strpos($html, 'Your invoice with Silentnoticebrand is likely to be accepted, subject to additional checks.') !== false,
+            'and must render the platform default copy'
+        );
+    }
+
+    /**
+     * A non-bool switch is a reported error and then the documented
+     * default true — never a silent third behaviour, and never a throw on
+     * a buyer-facing render. The log line has to name the key, the
+     * offending value's type and the brand code, or a store operator
+     * cannot act on it.
+     */
+    private static function testIntentApprovedNoticeInvalidSwitchReportsAndDefaultsOn(): void
+    {
+        add_filter('twoinc_brand_file', static function ($file) {
+            return __DIR__ . '/fixtures/invalidnoticeswitchbrand.php';
+        });
+        TinyAssert::same('', WC_Twoinc_Brand::get('intent_approved_notice_enabled'));
+
+        $html = self::gateway()->build_payment_description();
+        TinyAssert::true(
+            strpos($html, 'twoinc-pay-box twoinc-intent-approved hidden') !== false,
+            'an invalid switch must fall back to the notice being shown'
+        );
+
+        TinyAssert::same(1, count($GLOBALS['__twoinc_test_logs']), 'the invalid switch must be reported exactly once');
+        $entry = $GLOBALS['__twoinc_test_logs'][0];
+        TinyAssert::same('error', $entry['level']);
+        TinyAssert::same('twoinc-payment-gateway', $entry['context']['source'] ?? null);
+        TinyAssert::true(
+            strpos($entry['message'], 'intent_approved_notice_enabled') !== false,
+            'the log line must name the offending key'
+        );
+        TinyAssert::true(
+            strpos($entry['message'], 'string') !== false,
+            'the log line must name the offending value type'
+        );
+        TinyAssert::true(
+            strpos($entry['message'], 'invalidnoticeswitchbrand') !== false,
+            'the log line must name the brand code'
         );
     }
 


### PR DESCRIPTION
## TWO-25218 — explicit boolean switch for the order-intent-approved notice

Supersedes the three-state design shipped in #383 (TWO-25213). Part of a six-repo batch across the plugin platforms.

### Design decision

TWO-25213 put **two unrelated meanings in one key**: `intent_approved_notice` was absent = default copy + notice on, `''` = suppressed, non-empty = copy template. "Off" was expressed as the *absence of content* rather than as a decision, so a reader cannot tell an intentional off switch from an unfinished string, and any tidy-up that deletes an "empty, unused" declaration silently turns the notice back on.

The switch and the copy are now **two independent keys**. Do not overload one key with both meanings again.

### Accepted values

`intent_approved_notice_enabled` — the on/off switch, explicit PHP `bool` only:

| value | behaviour |
|---|---|
| `true` | notice ON (base plugin declares this explicitly) |
| `false` | suppressed entirely — no element in the DOM, not an empty wrapper |
| absent / `null` | **documented default `true`** (notice ON) |
| anything else (`''`, `0`, `'yes'`, array) | **clear logged error**, then the documented default `true` — never a silent third behaviour |

`intent_approved_notice` — copy override ONLY, keeps its name, loses the switch meaning:

| value | behaviour |
|---|---|
| absent / `null` / `''` / whitespace-only | platform default translated copy |
| non-empty string | used verbatim as the company-variant sprintf template (`%1$s` = brand product name, `%2$s` = buyer company name, substituted client-side via the existing `{company}` token) |

Empty is now **inert**. It is no longer an off switch — the brand-file comment and the method docblock both say so explicitly, because the previous meaning is what a reader will remember.

### Absent and invalid behaviour

* **Absent → `true`.** This is what keeps a third-party overlay that declares neither key on ON (must-not-regress #1), covered by two specs: an overlay declaring nothing, and the resolved config with the key removed outright.
* **Invalid → logged error + `true`.** `WC_Twoinc::is_intent_approved_notice_enabled()` logs through `wc_get_logger()->error()` (the repo's existing idiom, `error_log('Twoinc: …')` fallback when WooCommerce's logger is absent), naming **the key, the offending value's type and the brand code**.
* Deliberately **not a throw**: this runs on a buyer-facing checkout render, where a white screen is a worse failure than a notice that stays on. ON is also the fail-safe direction — a brand that wanted it off gets a visible, reported wrong state and nobody loses a sale. (Magento gets the loud treatment instead: XSD enumeration + `\DomainException` in the loader.)

### Migration hazard — documented, not "fixed"

New parent + stale overlay (still carrying an empty `intent_approved_notice`, no switch) resolves to notice **ON** — wrong for that brand, but not a broken store. Making an empty copy value a hard error would convert that deploy-order window from "wrong notice" into "broken store". So empty copy is inert, there is **no legacy-compat path resurrecting empty-means-off**, and the merge order below is the mitigation. `tests/unit/fixtures/inertemptynoticebrand.php` pins exactly this shape.

### Magento merge order (batch-wide, restated here)

**parent `magento-plugin` → the brand overlay repo → `magento-hyva-extension`.** The parent owns the parsing. Out of order there is a window in which Hyvä renders the notice for a brand that asked for it off.

### Brand merge preserves `false`

`WC_Twoinc_Brand::config()` merges the overlay with a plain `array_merge($defaults, (array) require $real)` and `get()` uses `array_key_exists`, so a `false` overlay value survives — **no falsy-means-absent filtering anywhere in the loader**, no bug to fix. `testIntentApprovedNoticeDisabledBrandEmitsNoBlock` asserts the resolved value is `=== false` before asserting the render, so a future falsy filter would fail the suite rather than silently re-enable the notice.

### i18n

**No user-visible string changed** — the default copy and both variants are byte-identical to #383; the only new string is a log line, which is not translated. This repo's `.pot`/`.po` are **deliberately not maintained** (Magento's `i18n/*.csv` are); that asymmetry is unchanged and nothing under `languages/` is touched.

### Tests

`tests/unit/` — three-state specs replaced by seven:

* `testIntentApprovedNoticeDisabledBrandEmitsNoBlock` — switch `false`, no markup, `false` survives the merge
* `testIntentApprovedNoticeDefaultBrandCarriesBothVariants` — switch `true` + no copy override
* `testIntentApprovedNoticeBrandTemplateUsedVerbatim` — copy override
* `testIntentApprovedNoticeEmptyCopyOverrideIsInert` — `''` and whitespace-only both render the default copy
* `testIntentApprovedNoticeSwitchAbsentDefaultsOn` — key absent from the resolved config, notice on, nothing logged
* `testIntentApprovedNoticeOverlayDeclaringNothingKeepsNoticeOn` — overlay with no opinion
* `testIntentApprovedNoticeInvalidSwitchReportsAndDefaultsOn` — notice on, exactly one `error`-level log naming key + type + brand code

New fixtures: `invalidnoticeswitchbrand`, `silentnoticebrand`, `inertemptynoticebrand`, `blanknoticecopybrand`. `suppressednoticebrand` reworked to the boolean switch; `customnoticebrand` now declares the switch explicitly `true`. `bootstrap.php` gains a recording `wc_get_logger()` stub so "the error was reported" is assertable (cleared per test).

**Mutation-checked** — every new spec, break-then-restore:

| mutation | killed by |
|---|---|
| drop the `is_intent_approved_notice_enabled()` guard | `…DisabledBrandEmitsNoBlock` |
| invalid switch returns `false` | `…InvalidSwitchReportsAndDefaultsOn` |
| remove the logging entirely | `…InvalidSwitchReportsAndDefaultsOn` |
| drop `trim()` from the copy check | `…EmptyCopyOverrideIsInert` |
| absent switch returns `false` | `…SwitchAbsentDefaultsOn` |

### Gate output (local, exactly as CI runs them)

`php tests/unit/run.php`:

```
PASS BrandConfigSpec::testIntentApprovedNoticeDisabledBrandEmitsNoBlock
PASS BrandConfigSpec::testIntentApprovedNoticeDefaultBrandCarriesBothVariants
PASS BrandConfigSpec::testIntentApprovedNoticeBrandTemplateUsedVerbatim
PASS BrandConfigSpec::testIntentApprovedNoticeEmptyCopyOverrideIsInert
PASS BrandConfigSpec::testIntentApprovedNoticeSwitchAbsentDefaultsOn
PASS BrandConfigSpec::testIntentApprovedNoticeOverlayDeclaringNothingKeepsNoticeOn
PASS BrandConfigSpec::testIntentApprovedNoticeInvalidSwitchReportsAndDefaultsOn
PASS BrandConfigSpec::testIntentLoaderRendersTheOneSharedDotPulse
All tests passed.
```

`php dev/stubs/phpcs.phar` (4.0.1, PSR-12) — exit 0:

```
A TOTAL OF 0 ERRORS AND 286 WARNINGS WERE FOUND IN 12 FILES
```

(warnings are the pre-existing 120-char soft limit; `phpcs.xml` sets `ignore_warnings_on_exit`)

`php dev/stubs/phpstan.phar analyse --no-progress --memory-limit=4G` (2.2.5, level 2, pinned stub SHAs):

```
Note: Using configuration file .../phpstan.neon.

 [OK] No errors
```

`php -l` on every changed PHP file — no syntax errors. `pre-commit run --all-files` — prettier reformats `AGENTS.md`, pre-existing drift on `staging` and untouched by this branch; reverted, no files in this diff are prettier-owned.

### Docs

No repo doc described the three-state contract (`grep` over `docs/`, `README.md`, `readme.txt`, `AGENTS.md` — no hits); the contract lives in the `brands/two.php` comment and the `get_intent_approved_notice()` docblock, both rewritten here.

Do **not** squash-merge.

