### PR TITLE
TWO-25221: match Magento's term-chip padding and corner radius

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -197,14 +197,21 @@
  * text on a white fill for the unselected state, solid brand blue with
  * white text when selected. Set an explicit colour so the chip text never
  * inherits a theme's light-on-light foreground (white-on-white bug).
+ *
+ * Geometry mirrors the same rule: 8px/16px padding and an 8px radius, i.e.
+ * a rounded rectangle rather than the pill a radius at half the chip
+ * height would give. Keep both in step with Magento's style.css. The
+ * --selected and --single variants restyle colour only, so they inherit
+ * the padding and radius and need no duplicate declarations; the same is
+ * true of the brand overlays' chip rules.
  */
 .twoinc-term-chip {
   display: inline-flex;
   flex-direction: column;
   align-items: center;
-  padding: 6px 14px;
+  padding: 8px 16px;
   border: 1px solid #c4c9e8;
-  border-radius: 16px;
+  border-radius: 8px;
   background: #fff;
   color: #3043d1;
   cursor: pointer;


### PR DESCRIPTION
## What

Payment-terms chips on the checkout picked up the wrong geometry. Bring them to the values the Magento checkout already uses (`view/frontend/web/css/style.css`, `.two-term-chip`):

| | before | after |
| -- | -- | -- |
| `padding` | `6px 14px` | `8px 16px` |
| `border-radius` | `16px` | `8px` |

At the chip's rendered height (~56px for the two-line term + fee layout) a 16px radius is close to half of it, so the chips read as pills rather than the rounded rectangles the reference implementation draws. The tighter padding also left the two-line chips looking cramped.

## Why one rule is enough

Only `.twoinc-term-chip` declares padding and radius. The `--selected` and `--single` variants restyle colour only, and the brand overlays' chip rules likewise override colour only — so a single edit moves every chip state together with no duplicated declarations. The in-flight loading-dots span sits inside the same flex column and takes its box from the chip, so it follows too. Added a comment recording that, so the next person doesn't add per-variant copies.

## Verification

Gates run locally exactly as CI does:

- `php tests/unit/run.php` — all tests passed
- `phpcs` (4.0.1, as pinned in `static-analysis.yaml`) — 0 errors, exit 0 (284 warnings, all pre-existing and untouched by this diff)
- `phpstan analyse --no-progress --memory-limit=4G` (2.2.5, with the two stub files CI fetches) — `[OK] No errors`
- `pre-commit run --files assets/css/twoinc.css` — prettier passed

Verified **visually**, not only in source: rendered the real payment-box DOM ancestry (taken from the markup the deployed shop actually serves) against this branch's stylesheet in headless Chrome, covering all three states — multi-term, single-term `--single` (the disabled span), and the fee-quote-in-flight loading dots. Read the values back from the live CSSOM rather than trusting the file: every chip in every state computes `padding: 8px 16px`, `border-radius: 8px`.

No PHP, no markup, no template change — CSS values plus a comment.

## Notes

- Follow-up visual polish on the tile reorder in #382, from review of the deployed result.
- The tagline indent seen in the same review is **not** from this repo — `.twoinc-payment-subtitle` has no rule here at all, and the default brand ships an empty checkout subtitle so the tagline never renders on the vanilla edition. That one is fixed at its source in the brand overlay repo, on the same ticket.
- Spotted, not fixed (out of scope): `assets/css/twoinc.css` still carries a dead `.twoinc-subtitle` rule. That class has not been emitted since the brand-seam work renamed it. Worth a separate cleanup.

Ticket: TWO-25221 (parent TWO-24739)
