### PR TITLE
TWO-25224/fix: suppress the order-intent loading state with the notice

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -434,6 +434,10 @@ let twoincDomHelper = {
     jQuery(".twoinc-pay-box").addClass("hidden");
     if (["checking-intent", "intent-approved", "errored"].includes(action)) {
       if (action === "checking-intent") {
+        // Suppressed by the brand => the loader div is absent too
+        // (TWO-25224: the notice switch covers the whole reassurance
+        // pass, loading state included), so this is a no-op on an empty
+        // jQuery set. The error branches below are never suppressed.
         jQuery(".twoinc-pay-box.twoinc-loader").removeClass("hidden");
       } else if (action === "intent-approved") {
         // The notice ships the no-company sentence as its text and the

--- a/brands/two.php
+++ b/brands/two.php
@@ -69,15 +69,21 @@ return [
     // obtaining production keys. WC_Twoinc::init_form_fields is the only
     // reader. A brand overlay substitutes its own support address.
     'production_key_contact_email' => 'integration@two.inc',
-    // On/off switch for the buyer-facing notice shown once order intent
-    // is approved, pending final checks. Explicit boolean ONLY, shared
+    // On/off switch for the buyer-facing reassurance messaging around the
+    // order-intent pre-check: the notice shown once intent is approved
+    // (pending final checks) AND the loading state shown while the check
+    // runs (TWO-25224 — both carry our own copy about the check, so they
+    // switch together). The pre-check's two ERROR boxes are NOT covered:
+    // a brand that wants no reassurance still needs failures surfaced.
+    // Explicit boolean ONLY, shared
     // with the other platforms: true = notice shown; false = suppressed
     // entirely, no markup emitted at all. Absent or null = the
     // documented default true, which is what keeps a third-party overlay
     // that declares nothing on ON. Any other value ('', 0, 'yes', an
     // array) is a logged error and the default true is used — never a
     // silent third behaviour.
-    // WC_Twoinc::is_intent_approved_notice_enabled is the only reader.
+    // WC_Twoinc::is_intent_approved_notice_enabled is the only reader; it
+    // resolves once per render and both consumers take the result.
     'intent_approved_notice_enabled' => true,
     // Copy override for that notice — WORDING ONLY. It carried the
     // on/off meaning too until TWO-25218; it no longer does. null, ''

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -724,9 +724,29 @@ if (!class_exists('WC_Twoinc')) {
          * technology announce the wait when the box is unhidden. The old
          * spinner was a CSS ::before with content "" and no role, so it
          * announced nothing at all.
+         *
+         * Returns '' when the brand suppressed the intent-approved notice
+         * (TWO-25224). That switch turns off the *reassurance messaging*
+         * around the order-intent pre-check, and this loader is part of it —
+         * it carries our own sentence about the check being in progress, so
+         * a brand that declined the approval sentence was still announcing
+         * the check. The two error boxes are NOT gated on the switch: a
+         * merchant who wants no reassurance still needs failures surfaced.
+         *
+         * With the div absent, assets/js/twoinc.js's "checking-intent"
+         * branch unhides an empty jQuery set — a no-op, no JS-side gate
+         * needed.
+         *
+         * @param bool $notice_enabled resolved once per render by the caller,
+         *                             so an invalid brand value is reported
+         *                             once rather than once per consumer.
          */
-        private function get_intent_loader_html(): string
+        private function get_intent_loader_html(bool $notice_enabled): string
         {
+            if (!$notice_enabled) {
+                return '';
+            }
+
             return sprintf(
                 '<div class="twoinc-pay-box twoinc-loader hidden" role="status">'
                 . '<span class="twoinc-sr-only">%s</span>'
@@ -810,10 +830,13 @@ if (!class_exists('WC_Twoinc')) {
          * unhide time. The div's own text is the no-company variant, so a
          * buyer whose company is unknown (or whose JS never runs) still
          * reads a complete sentence.
+         *
+         * @param bool $notice_enabled resolved once per render by the caller
+         *                             (see get_intent_loader_html()).
          */
-        private function get_intent_approved_notice(): string
+        private function get_intent_approved_notice(bool $notice_enabled): string
         {
-            if (!$this->is_intent_approved_notice_enabled()) {
+            if (!$notice_enabled) {
                 return '';
             }
 
@@ -876,6 +899,13 @@ if (!class_exists('WC_Twoinc')) {
             // container, and the later element wins the POST. Moving this
             // one after the container would let the stale server-rendered
             // term override the buyer's chip selection.
+            //
+            // One resolution of the brand's notice switch feeds both the
+            // loading state and the approved notice (TWO-25224): they are two
+            // halves of the same reassurance messaging, and resolving it twice
+            // would report an invalid brand value twice per render.
+            $notice_enabled = $this->is_intent_approved_notice_enabled();
+
             return sprintf(
                 '<div>
                     %s
@@ -887,8 +917,8 @@ if (!class_exists('WC_Twoinc')) {
                     <div class="twoinc-pay-box twoinc-err-phone-number hidden">%s</div>
                 </div>',
                 $term_input,
-                $this->get_intent_loader_html(),
-                $this->get_intent_approved_notice(),
+                $this->get_intent_loader_html($notice_enabled),
+                $this->get_intent_approved_notice($notice_enabled),
                 sprintf(__('Invoice purchase with %s is not available for this order.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')),
                 __('Phone number is invalid.', 'twoinc-payment-gateway')
             );

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -162,6 +162,7 @@ final class BrandConfigSpec
             'testIntentApprovedNoticeOverlayDeclaringNothingKeepsNoticeOn',
             'testIntentApprovedNoticeInvalidSwitchReportsAndDefaultsOn',
             'testIntentLoaderRendersTheOneSharedDotPulse',
+            'testIntentLoaderSuppressedWithTheNoticeButErrorBoxesSurvive',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -4182,6 +4183,43 @@ final class BrandConfigSpec
             0,
             preg_match_all('/@keyframes\s+spin|loader\.svg/', $css),
             'the retired rotating spinner must be gone from the stylesheet'
+        );
+    }
+
+    /**
+     * TWO-25224: the switch governs the reassurance messaging around the
+     * order-intent pre-check, and the loading state is part of that — a
+     * brand that declined the approval sentence was still announcing
+     * "Checking your order, one moment." while the check ran.
+     *
+     * The two ERROR boxes are deliberately NOT gated: a merchant who wants
+     * no reassurance still needs failures surfaced, or a declined buyer
+     * sees nothing at all. This test fails if either half regresses — the
+     * loader coming back, or the error boxes disappearing with it.
+     */
+    private static function testIntentLoaderSuppressedWithTheNoticeButErrorBoxesSurvive(): void
+    {
+        add_filter('twoinc_brand_file', static function ($file) {
+            return __DIR__ . '/fixtures/suppressednoticebrand.php';
+        });
+        TinyAssert::same(false, WC_Twoinc_Brand::get('intent_approved_notice_enabled'));
+
+        $html = self::gateway()->build_payment_description();
+        TinyAssert::true(
+            strpos($html, 'twoinc-loader') === false,
+            'a brand disabling the notice must emit no order-intent loading state'
+        );
+        TinyAssert::true(
+            strpos($html, 'Checking your order') === false,
+            'and none of the loading copy either, not even as a screen-reader name'
+        );
+        TinyAssert::true(
+            strpos($html, 'twoinc-pay-box twoinc-err-payment-default hidden') !== false,
+            'the default payment error box must survive the notice being off'
+        );
+        TinyAssert::true(
+            strpos($html, 'twoinc-pay-box twoinc-err-phone-number hidden') !== false,
+            'the phone-number error box must survive the notice being off'
         );
     }
 }


### PR DESCRIPTION
Linear: [TWO-25224](https://linear.app/two-inc/issue/TWO-25224) (child of TWO-24739)

## Bug

Observed on a staging shop. With the brand switch `intent_approved_notice_enabled => false` (TWO-25218), the intent-approved notice is correctly suppressed — but the loading state that runs *ahead* of it is not. A brand that opted out of the reassurance messaging was still telling the buyer "Checking your order, one moment." while the order-intent pre-check ran.

## Scope decision — please correct me if this is the wrong line

"If the notice is disabled, hide the spinner too" can mean two things. I read the switch as governing the **reassurance messaging** around the order-intent pre-check, not the pre-check's error reporting, so:

- **Suppressed:** the pre-approval loading state (`.twoinc-pay-box.twoinc-loader`). It carries our own sentence about the check being in progress, so it is part of the same messaging pass as the approval notice.
- **Kept:** both error boxes (`.twoinc-err-payment-default`, `.twoinc-err-phone-number`). A merchant who does not want the reassurance sentence still needs failures surfaced — otherwise a declined buyer sees nothing at all.

If the intent was actually "suppress the whole pre-check state, errors included", this is a one-line change to make; say so and I'll flip it.

## Change

- `get_intent_loader_html()` returns `''` when the notice is off. With the div absent, the JS `checking-intent` branch unhides an empty jQuery set — a no-op, so no JS-side gate is needed.
- The switch is resolved **once** per render in `get_pay_box_description()` and passed to both consumers. Without that, an invalid brand value would be reported twice per render (there is a test pinning "exactly once").
- Brand-key documentation in `brands/two.php` updated to describe what the switch now covers.

## Test

New `testIntentLoaderSuppressedWithTheNoticeButErrorBoxesSurvive` asserts, against the suppressed-notice fixture, that no loader markup and no loading copy is emitted **and** that both error boxes still are — so it fails if either half regresses.

Mutation-checked: removing the guard makes only the new test fail.

## Gates run locally

- `make test-unit` — all pass (19 brand-config specs)
- `make phpcs` — 0 errors (pre-existing warnings only)
- `make phpstan` — `[OK] No errors`
- `pre-commit run` on the changed files — prettier passed

## Other platforms

Same defect audited across the surfaces the switch shipped on; PrestaShop has it too and is fixed in its own PR. Magento Luma leans on the platform's own generic full-screen mask (no Two copy in it) and Hyvä shows nothing at all — left alone deliberately, so as not to deepen the existing Luma/Hyvä in-flight parity gap.

## Verification

Source and unit tests only — not verified visually on a shop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)