### PR TITLE
ABN-473/fix: default the invoice-email checkout field to enabled

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -3400,7 +3400,7 @@ if (!class_exists('WC_Twoinc')) {
                     'desc_tip'    => true,
                     'label'       => ' ',
                     'type'        => 'checkbox',
-                    'default'     => 'no'
+                    'default'     => 'yes'
                 ],
                 'show_abt_link' => [
                     'title'       => sprintf(__('Show "What is %s" link in checkout', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')),


### PR DESCRIPTION
## What

All four optional checkout fields now default to **enabled**. Three already did; this flips the one that didn't.

| Setting | Default before | Default after |
| -- | -- | -- |
| `add_field_department` | `yes` | `yes` (unchanged) |
| `add_field_project` | `yes` | `yes` (unchanged) |
| `add_field_purchase_order_number` | `yes` | `yes` (unchanged) |
| `add_field_invoice_email` | **`no`** | **`yes`** |

One line in `init_form_fields()` (`class/WC_Twoinc.php`). The `default` key is the only fallback in play — no call site passes a second argument to `get_option()` for any of these four, so `init_settings()`'s form-field default is the whole story.

## Defaults change, stored merchant settings do not

WooCommerce falls back to a form field's `default` **only when the key is absent** from the gateway's stored option blob. So:

- A shop that never touched the setting starts showing the invoice-email field.
- A shop with `add_field_invoice_email` **stored** as `no` keeps it off. That is an explicit merchant choice and this PR does not overwrite it. Some live shops are in exactly that state, deliberately.

This is a change to the out-of-box value, not a migration.

## Not in this PR

- **No field moves.** Department, project, purchase order number and invoice email stay where they are, in the billing address area. Relocating them needs sign-off first.
- **No change to `toggleBusinessFields()`** (`assets/js/twoinc.js`) — the fields still stay hidden until the buyer selects our payment method.
- **No new order-note field.** WooCommerce delegates order notes to core's own `order_comments`; the plugin never filters `$fields['order']`, so core's placement stands. Verified, deliberately untouched.

## Verification

- `make test-unit` — all tests passed.
- `make phpcs` — 0 errors (2 pre-existing line-length warnings in `tests/unit/`, untouched by this diff).
- `make phpstan` — `[OK] No errors`.
- `pre-commit` — prettier and commit-msg hooks pass; `php -l` clean.
