### PR TITLE
TWO-25230/ci: automate the staging patch bump, take level from the convention

### DIFF
--- a/.github/scripts/decide-bump-level.sh
+++ b/.github/scripts/decide-bump-level.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+#
+# Decide the semantic-version bump level for a version-bump / release run.
+#
+# Convention:
+#   patch  — change landing anywhere other than `main` (i.e. `staging`)
+#   minor  — change landing on `main`
+#   major  — escape hatch. Two independent signals, the higher wins:
+#
+#     Declared  a root `.next-major` file whose first whitespace-delimited
+#               token is the target major, with a short human reason on the
+#               same line. Human-editable and reviewable in the PR that
+#               decides it, so a *planned* major with no single breaking
+#               commit still lands as a major:
+#
+#                   3  # overlay migration, 3.0.0 release
+#
+#     Discovered  a `!` on a conventional-commit type (`feat!:`,
+#                 `TWO-1/fix(scope)!:`) or a `BREAKING CHANGE:` footer in the
+#                 commits under consideration. Covers a break that actually
+#                 happened.
+#
+#   target = max(declared, current_major + (breaking ? 1 : 0))
+#   target > current_major  ->  major, new version is exactly <target>.0.0
+#   otherwise               ->  the branch rule above
+#
+# `.next-major` is deliberately NEVER cleared by CI. The `target >
+# current_major` condition disarms it on its own once the major has shipped,
+# and leaving the file in place keeps the declared intent reviewable. The one
+# thing this scheme can still get wrong is a declaration that has fallen
+# BEHIND the current major, so that is a hard failure (see below) rather than
+# a silent no-op.
+#
+# Usage:  decide-bump-level.sh <branch> [<git-rev-range>]
+#
+# With no range, it is derived as "everything not already accounted for" — see
+# the anchor list below. Deriving it carefully matters: a naive
+# `<last-tag>..HEAD` would re-discover the same breaking commit on every single
+# staging PR and major-bump over and over, because `staging` is only tagged
+# when it reaches `main`.
+#
+# Writes `level=`, `set_version=` and `reason=` to stdout as `key=value`
+# lines, and appends the same to $GITHUB_OUTPUT when running under Actions.
+# The full decision — including the declared reason string — is logged on
+# every run, so a stale `.next-major` is visible without digging.
+set -euo pipefail
+
+branch="${1:?usage: decide-bump-level.sh <branch> [<git-rev-range>]}"
+range="${2:-}"
+
+repo_root=$(git rev-parse --show-toplevel)
+toml="${repo_root}/bumpver.toml"
+[ -f "$toml" ] || { echo "::error::no bumpver.toml at ${toml}" >&2; exit 1; }
+
+current=$(sed -n 's/^[[:space:]]*current_version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$toml" | head -1)
+[ -n "$current" ] || { echo "::error::could not read current_version from ${toml}" >&2; exit 1; }
+current_major=${current%%.*}
+case "$current_major" in
+    '' | *[!0-9]*) echo "::error::unparseable current_version '${current}' in ${toml}" >&2; exit 1 ;;
+esac
+
+# --- derive the range, if not given ------------------------------------------
+#
+# The base is the closest-to-HEAD of three anchors, each meaning "everything
+# before this is already accounted for":
+#
+#   1. the last version-bump commit — the normal steady-state anchor;
+#   2. the newest semver tag reachable from HEAD — covers a release cut
+#      without a bump commit on this branch;
+#   3. the commit that first added THIS script — the activation floor.
+#
+# (3) is what stops the very first run from re-discovering years of already
+# shipped `feat!:` commits and jumping several majors. Without it, four of the
+# six plugin repos would have gone straight to 3.0.0 the moment this landed.
+# It costs nothing afterwards: once a bump commit exists it is always closer
+# to HEAD, so (1) takes over and (3) never binds again.
+if [ -z "$range" ]; then
+    # Subject prefix of a bump commit, taken from bumpver's own configured
+    # commit_message so the two can't drift — the capitalisation of "bump"
+    # is not consistent across repos, so it must not be hardcoded here.
+    bump_msg=$(sed -n 's/^[[:space:]]*commit_message[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$toml" | head -1)
+    bump_prefix=${bump_msg%%\{*}
+    bump_prefix=${bump_prefix%% }
+    [ -n "$bump_prefix" ] || bump_prefix="chore: Bump version"
+
+    self_rel=".github/scripts/decide-bump-level.sh"
+
+    candidates=""
+    add_candidate() {
+        [ -n "$1" ] || return 1
+        # Only anchors on this history are usable as a range base.
+        git merge-base --is-ancestor "$1" HEAD 2>/dev/null || return 1
+        candidates="${candidates}${1}
+"
+    }
+
+    add_candidate "$(git log -1 --format='%H' --fixed-strings --grep="$bump_prefix" HEAD || true)" || true
+    # Version-sorted, so the first tag that is actually reachable is the newest.
+    for t in $(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true); do
+        if add_candidate "$(git rev-parse -q --verify "refs/tags/${t}^{commit}" || true)"; then
+            break
+        fi
+    done
+    add_candidate "$(git -C "$repo_root" log --diff-filter=A --format='%H' -1 -- "$self_rel" || true)" || true
+
+    # Closest to HEAD wins — fewest commits between it and HEAD.
+    base=""
+    best=""
+    while IFS= read -r c; do
+        [ -n "$c" ] || continue
+        n=$(git rev-list --count "${c}..HEAD")
+        if [ -z "$best" ] || [ "$n" -lt "$best" ]; then
+            best="$n"
+            base="$c"
+        fi
+    done <<EOF
+${candidates}
+EOF
+
+    if [ -n "$base" ]; then
+        range="${base}..HEAD"
+    else
+        range="HEAD"
+    fi
+fi
+
+# --- signal 1: declared major -------------------------------------------------
+declared=0
+declared_reason=""
+next_major_file="${repo_root}/.next-major"
+if [ -f "$next_major_file" ]; then
+    raw=$(head -1 "$next_major_file")
+    declared=$(printf '%s' "$raw" | awk '{print $1}')
+    declared_reason=$(printf '%s' "$raw" | sed 's/^[^[:space:]]*[[:space:]]*//; s/^#[[:space:]]*//')
+    case "$declared" in
+        '' | *[!0-9]*)
+            echo "::error::.next-major must start with the target major version as a bare integer; got '${raw}'" >&2
+            exit 1
+            ;;
+    esac
+    # The failure mode this scheme can still get wrong: a declaration left
+    # behind by a major that has already shipped some other way. Silently
+    # ignoring it would let it rot; regressing to it would be worse. Fail.
+    if [ "$declared" -lt "$current_major" ]; then
+        echo "::error::.next-major declares major ${declared} but the current version is ${current} (major ${current_major}). A declaration below the current major is always stale — delete or raise it." >&2
+        exit 1
+    fi
+fi
+
+# --- signal 2: discovered breaking change ------------------------------------
+breaking=0
+breaking_reason=""
+subject_re='^([A-Z]+-[0-9]+/)?[a-z]+(\([^)]+\))?!:'
+footer_re='^BREAKING[ -]CHANGE:'
+
+while IFS= read -r subject; do
+    if printf '%s' "$subject" | grep -qE "$subject_re"; then
+        breaking=1
+        breaking_reason="$subject"
+        break
+    fi
+done < <(git log "$range" --no-merges --format='%s')
+
+if [ "$breaking" -eq 0 ]; then
+    footer=$(git log "$range" --no-merges --format='%B' | grep -m1 -E "$footer_re" || true)
+    if [ -n "$footer" ]; then
+        breaking=1
+        breaking_reason="$footer"
+    fi
+fi
+
+# --- combine ------------------------------------------------------------------
+discovered=$current_major
+[ "$breaking" -eq 1 ] && discovered=$((current_major + 1))
+
+target=$declared
+[ "$discovered" -gt "$target" ] && target=$discovered
+
+set_version=""
+if [ "$target" -gt "$current_major" ]; then
+    level=major
+    # `--set-version` rather than `--major`: a declaration may skip more than
+    # one major (current 2, declared 4), which `bumpver --major` cannot express.
+    set_version="${target}.0.0"
+    if [ "$declared" -ge "$target" ]; then
+        why="declared .next-major=${declared}"
+        [ -n "$declared_reason" ] && why="${why} (${declared_reason})"
+    else
+        why="discovered breaking change: ${breaking_reason}"
+    fi
+elif [ "$branch" = "main" ]; then
+    level=minor
+    why="branch rule: main -> minor"
+else
+    level=patch
+    why="branch rule: ${branch} -> patch"
+fi
+
+reason=$(printf '%s' "$why" | tr '\n' ' ')
+
+# Always log the whole decision, not just the outcome — a stale declaration or
+# an unexpected breaking commit is only visible if the inputs are printed too.
+{
+    echo "----- bump level decision -----"
+    echo "branch          : ${branch}"
+    echo "range           : ${range}"
+    echo "current version : ${current} (major ${current_major})"
+    if [ -f "$next_major_file" ]; then
+        echo "declared major  : ${declared}${declared_reason:+  — ${declared_reason}}"
+    else
+        echo "declared major  : (no .next-major)"
+    fi
+    echo "breaking commit : ${breaking_reason:-none}"
+    echo "target major    : ${target}"
+    echo "level           : ${level}${set_version:+  -> ${set_version}}"
+    echo "reason          : ${reason}"
+    echo "-------------------------------"
+} >&2
+
+echo "level=${level}"
+echo "set_version=${set_version}"
+echo "reason=${reason}"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "level=${level}"
+        echo "set_version=${set_version}"
+        echo "reason=${reason}"
+    } >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,87 @@
+name: Version bump
+
+# Automates the staging half of the version-bump convention (TWO-25230):
+# patch on merge to `staging`, minor on merge to `main`, major via the
+# escape hatch in .github/scripts/decide-bump-level.sh.
+#
+# `main` is deliberately NOT automated here — it stays on the manual
+# `make minor` path in the Makefile, which also cuts the GitHub Release.
+# Only the staging patch cadence is automated, because that is the one that
+# was silently not happening: the last hand-run bump was 2025-11-18.
+#
+# Why `push` and not `workflow_run`: for `push` events GitHub resolves the
+# workflow file from the branch that was pushed, so this is live the moment
+# the PR lands on `staging`. `workflow_run` resolves the workflow from the
+# repository's DEFAULT branch, which is `main` here, so a staging-based
+# change would sit inert until it was promoted.
+on:
+  push:
+    branches: [staging]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: version-bump-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Bump version on staging
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    timeout-minutes: 10
+    # Skip our own bump commit. Strictly belt-and-braces: the push below goes
+    # out under the default GITHUB_TOKEN, and GITHUB_TOKEN pushes do not
+    # trigger workflows, so the loop cannot form in the first place. The guard
+    # stays because that is a property of the token, not of this file, and it
+    # would be an unpleasant way to find out it had changed. The subject must
+    # match `commit_message` in bumpver.toml.
+    # (quoted: the literal `chore: Bump version` contains ": ", which YAML
+    # would otherwise read as a nested mapping)
+    if: "${{ !startsWith(github.event.head_commit.message, 'chore: Bump version') }}"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Check out the branch, not the SHA, so HEAD is on `staging` and
+          # bumpver's commit advances the branch — otherwise the push below
+          # would have nothing to push.
+          ref: staging
+          # Full history: the level decision reads the commit range back to
+          # the last bump / tag, and needs tags present.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install bumpver
+        run: pip install bumpver
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Decide bump level
+        id: level
+        run: .github/scripts/decide-bump-level.sh staging
+
+      - name: Bump version (files + commit only)
+        env:
+          LEVEL: ${{ steps.level.outputs.level }}
+          SET_VERSION: ${{ steps.level.outputs.set_version }}
+        run: |
+          set -euo pipefail
+          # --no-tag-commit --no-push override tag/push in bumpver.toml: the
+          # push is done explicitly below, and staging is never tagged — tags
+          # and Releases belong to `main`.
+          if [ -n "$SET_VERSION" ]; then
+            # --set-version rather than --major: a declared `.next-major` may
+            # skip more than one major, which --major cannot express.
+            bumpver update --set-version "$SET_VERSION" --no-tag-commit --no-push
+          else
+            bumpver update "--${LEVEL}" --no-tag-commit --no-push
+          fi
+
+      - name: Push
+        run: git push origin staging

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Copy .env.example to .env first; docker compose reads it natively.
 
 .PHONY: help install configure run debug proxy stop clean logs logs-wpcli \
-	test-unit test format archive patch minor major \
+	test-unit test format archive bump patch minor major \
 	e2e-install e2e-test e2e-test-headed phpcs phpstan
 
 .DEFAULT_GOAL := help
@@ -93,6 +93,16 @@ phpstan:
 ## Create a versioned zip archive
 archive:
 	git archive --format zip HEAD > tillit-payment-gateway.zip
+# Version-bump convention (TWO-25230): patch on staging, minor on main, major
+# via the escape hatch. The staging half is automated in
+# .github/workflows/version-bump.yml, so DO NOT hand-run a bump on staging —
+# it would double-bump when the workflow fires on the same push. These targets
+# are the `main` half, which stays manual because it also cuts the Release.
+#
+# Prefer `make bump`: it asks .github/scripts/decide-bump-level.sh for the
+# level instead of leaving it to whoever is at the keyboard, which is how the
+# level used to be chosen. The explicit patch/minor/major targets remain for
+# the case where you genuinely mean to override it.
 bumpver-%:
 	@if [ "$$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then \
 		echo "Error: Version bumping is only allowed on the main branch. Current branch: $$(git rev-parse --abbrev-ref HEAD)"; \
@@ -104,11 +114,37 @@ bumpver-%:
 	fi
 	SKIP=commit-msg bumpver update --$*
 	gh release create --latest --generate-notes
-## Bump patch version (main branch only)
+
+## Bump the version at the level the convention says (main branch only)
+bump:
+	@branch="$$(git rev-parse --abbrev-ref HEAD)"; \
+	out="$$(.github/scripts/decide-bump-level.sh "$$branch")"; \
+	level="$$(printf '%s\n' "$$out" | sed -n 's/^level=//p')"; \
+	set_version="$$(printf '%s\n' "$$out" | sed -n 's/^set_version=//p')"; \
+	reason="$$(printf '%s\n' "$$out" | sed -n 's/^reason=//p')"; \
+	if [ -n "$$set_version" ]; then \
+		echo "Convention says major -> $$set_version ($$reason)"; \
+		$(MAKE) bumpver-set-version SET_VERSION="$$set_version"; \
+	else \
+		echo "Convention says $$level ($$reason)"; \
+		$(MAKE) "bumpver-$$level"; \
+	fi
+
+# --set-version rather than --major: a declared `.next-major` may skip more
+# than one major, which --major cannot express.
+bumpver-set-version:
+	@if [ "$$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then \
+		echo "Error: Version bumping is only allowed on the main branch. Current branch: $$(git rev-parse --abbrev-ref HEAD)"; \
+		exit 1; \
+	fi
+	SKIP=commit-msg bumpver update --set-version "$(SET_VERSION)"
+	gh release create --latest --generate-notes
+
+## Bump patch version (main branch only; prefer `make bump`)
 patch: bumpver-patch
-## Bump minor version (main branch only)
+## Bump minor version (main branch only; prefer `make bump`)
 minor: bumpver-minor
-## Bump major version (main branch only)
+## Bump major version (main branch only; prefer `make bump`)
 major: bumpver-major
 
 e2e-install:

--- a/README.md
+++ b/README.md
@@ -22,17 +22,52 @@ This produces `tillit-payment-gateway.zip`, which can be uploaded to your Wordpr
 wp plugin install tillit-payment-gateway --activate
 ```
 
-## Releasing a new version
+## Versioning and releasing
 
-Ensure that you have `bumpver` installed.
+The version-bump level is decided by convention, not by hand:
+
+| Change lands on | Level | Who does it                                      |
+| --------------- | ----- | ------------------------------------------------ |
+| `staging`       | patch | Automatic — `.github/workflows/version-bump.yml` |
+| `main`          | minor | Manual — `make bump`                             |
+| either          | major | Escape hatch, see below                          |
+
+**Do not hand-run a bump on `staging`.** It is automated, and a manual bump on
+the same push would double-bump.
+
+A major is not chosen by hand either. Two independent signals are considered
+and the higher wins:
+
+- **Declared** — a root `.next-major` file whose first token is the target
+  major, with a short reason on the same line:
+
+      3  # dropped PHP 7.4, 3.0.0 release
+
+  This covers a _planned_ major that no single commit happens to mark. It is
+  reviewable in the PR that decides it, and it is not cleared afterwards — it
+  disarms itself once the major it names has shipped. A `.next-major` naming a
+  major _below_ the current version is a hard failure, not a no-op.
+
+- **Discovered** — a `!` on a conventional-commit type (`feat!:`) or a
+  `BREAKING CHANGE:` footer, in the commits since the last bump.
+
+`.github/scripts/decide-bump-level.sh` implements all of this and logs its full
+reasoning on every run. It is identical in every Two plugin repository.
+
+### Releasing
+
+Ensure that you have `bumpver` installed:
 
     pip install -r dev-requirements.txt
 
-To bump version:
+Then, on `main`:
 
-    bumpver update --major | --minor | --patch
+    make bump
 
-Now, go to Github to create a new release which triggers publication of the new version to Wordpress plugin directory.
+That bumps the version at the level the convention dictates and creates the
+GitHub Release, which triggers publication to the WordPress plugin directory.
+`make patch` / `make minor` / `make major` remain available for the case where
+you genuinely mean to override the convention.
 
 ## Set up Wordpress for local development
 


### PR DESCRIPTION
Implements the plugin-wide version-bump convention from
[TWO-25230](https://linear.app/two-inc/issue/TWO-25230) (parent TWO-24739).

**Patch bump on merge to `staging`; minor bump on merge to `main`; major via an escape hatch.**

## Why

`staging` had not been version-bumped since **2025-11-18** — 186 commits — because
the only bump path was a hand-run `make patch/minor/major` hard-gated to `main`.
Nothing was broken; it just never happened, and nothing noticed.

## What changed

**`.github/scripts/decide-bump-level.sh`** (new, identical byte-for-byte in all six
Two plugin repos). Dependency-free shell. Takes a branch, emits
`level=` / `set_version=` / `reason=` on stdout and to `$GITHUB_OUTPUT`, and logs its
full reasoning to stderr on every run so a stale declaration is visible without digging.

The major escape hatch takes two independent signals, higher wins:

- **Declared** — a root `.next-major` file whose first token is the target major, with a
  reason on the same line (`3  # dropped PHP 7.4, 3.0.0 release`). Covers a *planned*
  major that no single commit marks. Reviewable in the PR that decides it. Deliberately
  never cleared — the `target > current_major` condition disarms it by itself.
- **Discovered** — a `!` on a conventional-commit type or a `BREAKING CHANGE:` footer.

`target = max(declared, current_major + (breaking ? 1 : 0))`. A `.next-major` naming a
major *below* the current version is a **hard job failure**, not a silent no-op — that is
the one thing this scheme can still get wrong, so it fails loudly. The bump uses
`--set-version <target>.0.0` rather than `--major`, because a declaration may skip more
than one major and `--major` cannot express that.

One subtlety worth reviewing: the script derives its own commit range, as the
closest-to-HEAD of three anchors — last bump commit, newest reachable semver tag, and
**the commit that first added the script itself**. That third anchor is the activation
floor. Without it the first run would re-discover years of already-shipped `feat!:`
commits and jump straight to 4.0.0 here. It stops binding as soon as the first real bump
commit exists.

**`.github/workflows/version-bump.yml`** (new). Bumps patch on every push to `staging`.
No tag, no Release — those stay on `main`.

Uses a `push` trigger rather than `workflow_run` deliberately: for `push` events GitHub
resolves the workflow file from the pushed branch, so this is live the moment it lands on
`staging`. `workflow_run` resolves from the **default** branch, which is `main` here, so a
staging-based change would sit inert until a promotion.

The push goes out under the default `GITHUB_TOKEN`, whose pushes do not trigger workflows,
so no bump loop can form. The `if:` guard skipping our own bump commit is belt-and-braces
on top of that.

**`Makefile`** — `main` stays manual and still cuts the Release; that is deliberate and
unchanged. What changed is that the *level* is no longer chosen at the keyboard: new
`make bump` asks the script. `make patch/minor/major` remain as explicit overrides.

**`README.md`** — documents the convention where someone would actually look.

## Verification

Real local output, no paraphrase.

Level selection, all three:

```
$ .github/scripts/decide-bump-level.sh staging
level=patch      reason=branch rule: staging -> patch
$ .github/scripts/decide-bump-level.sh main
level=minor      reason=branch rule: main -> minor
$ printf '4  # dropped PHP 7.4, 4.0.0 release\n' > .next-major
$ .github/scripts/decide-bump-level.sh staging
level=major  set_version=4.0.0
reason=declared .next-major=4 (dropped PHP 7.4, 4.0.0 release)
```

The stale-declaration guard bites:

```
$ printf '1  # stale\n' > .next-major
$ .github/scripts/decide-bump-level.sh staging; echo "exit=$?"
::error::.next-major declares major 1 but the current version is 2.23.9 (major 2).
A declaration below the current major is always stale — delete or raise it.
exit=1
```

`bumpver --dry` at each level, showing the real file edits (2.23.9 base):

```
--patch              -> 2.23.10   readme.txt + tillit-payment-gateway.php + bumpver.toml
--minor              -> 2.24.0    same three files
--set-version 4.0.0  -> 4.0.0     same three files
```

Gates, run the way CI runs them:

```
$ php tests/unit/run.php     -> All tests passed.
$ make phpcs                 -> exit 0
$ pre-commit run --files ... -> prettier Passed
```

No `.next-major` is seeded in this repo, and none is committed — the temporary ones above
were deleted. No tag was created and no release was cut while testing.

---
Raised by Claude.
