### PR TITLE
TWO-25232/fix: bound company search and split failure from empty

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -272,6 +272,32 @@
   }
 }
 
+/*
+ * Company-search spinner (TWO-25232). Sits inside the select2 search field
+ * itself, not in the results list, so it reads as "this field is working"
+ * and does not fight the results message it would otherwise replace. Same
+ * .twoinc-dots pulse as every other loading state here. Only laid out while
+ * .twoinc-searching is set, so the reserved right-hand gutter appears with
+ * the spinner instead of permanently narrowing the input.
+ */
+.select2-search--dropdown.twoinc-searching {
+  position: relative;
+}
+.twoinc-search-spinner {
+  display: none;
+}
+.select2-search--dropdown.twoinc-searching .twoinc-search-spinner {
+  display: inline-block;
+  position: absolute;
+  top: 50%;
+  right: 14px;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+.select2-search--dropdown.twoinc-searching .select2-search__field {
+  padding-right: 30px;
+}
+
 /* Sole trader toggle (TWO-24754) */
 /*
  * Sole-trader mode chips + signup note. Palette mirrors the Magento

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -43,6 +43,64 @@ let twoincUtilHelper = {
 
 let twoincSelectWooHelper = {
   /**
+   * Hard ceiling on a single company-search request, ms (TWO-25232). Before
+   * this there was no client timeout at all, so a request that never
+   * completed left the dropdown spinning forever. Deliberately wider than
+   * the backend's own retry envelope for the upstream provider lookup, so a
+   * slow-but-arriving response is never cut off client-side — this is the
+   * backstop for a request that does not arrive at all.
+   */
+  companySearchTimeoutMs: 30000,
+
+  /**
+   * Text for a company search that could not be completed. Read lazily
+   * because window.twoinc is populated by the checkout render; the literal
+   * is the last-resort fallback for a page where the localised string is
+   * missing (older cached PHP, brand overlay that trims the text map).
+   */
+  companySearchUnavailableText: function () {
+    return (
+      (window.twoinc && window.twoinc.text && window.twoinc.text.company_search_unavailable) ||
+      "Company search is temporarily unavailable. Please try again."
+    );
+  },
+
+  /**
+   * Toggle the in-field search spinner. Reuses the one loading idiom in
+   * this plugin (.twoinc-dots — shared with the order-intent check and the
+   * term-chip fee quote) rather than introducing a second one.
+   *
+   * The search input lives inside the dropdown, which select2 tears down
+   * and rebuilds on every open, so the spinner node is created lazily on
+   * each search rather than once at init.
+   */
+  toggleCompanySearchSpinner: function (isSearching) {
+    const $search = jQuery('input[aria-owns="select2-billing_company_display-results"]').parent();
+    if ($search.length === 0) return;
+    if ($search.find(".twoinc-search-spinner").length === 0) {
+      $search.append(
+        '<span class="twoinc-search-spinner" aria-hidden="true">' +
+          '<span class="twoinc-dots"><span>.</span><span>.</span><span>.</span></span>' +
+          "</span>"
+      );
+    }
+    $search.toggleClass("twoinc-searching", !!isSearching);
+  },
+
+  /**
+   * Replace the results list with the "search unavailable" message. Goes
+   * through select2's own results:message channel (the results adapter
+   * listens on the container for it) so the message is cleared on the next
+   * query like any other, instead of us hand-managing dropdown DOM.
+   */
+  showCompanySearchUnavailable: function () {
+    const select2 = jQuery("#billing_company_display").data("select2");
+    if (select2 && typeof select2.trigger === "function") {
+      select2.trigger("results:message", { message: "errorLoading" });
+    }
+  },
+
+  /**
    * Generate parameters for selectwoo
    */
   genSelectWooParams: function () {
@@ -63,9 +121,11 @@ let twoincSelectWooHelper = {
       },
       language: {
         errorLoading: function () {
-          // return wc_country_select_params.i18n_ajax_error
-          // Should not show ajax error if request is cancelled
-          return wc_country_select_params.i18n_searching;
+          // Only ever reached deliberately now: the custom ajax transport
+          // below suppresses the cancelled-request case (which is why this
+          // used to masquerade as "searching…") and raises this message
+          // only for a timeout, a transport error, or a degraded response.
+          return twoincSelectWooHelper.companySearchUnavailableText();
         },
         inputTooShort: function (t) {
           t = t.minimum - t.input.length;
@@ -82,7 +142,54 @@ let twoincSelectWooHelper = {
       },
       ajax: {
         dataType: "json",
-        delay: 200,
+        // 300ms across all three plugin checkouts (was 200 here).
+        delay: 300,
+        /**
+         * Replaces select2's default transport so the request carries a
+         * timeout and so failures can be told apart. select2's own failure
+         * handler cannot make that distinction — it treats any jqXHR with
+         * status 0 as a cancellation, and a jQuery timeout also reports
+         * status 0 — which is why failure() is not called from here at all
+         * and this code owns the messaging.
+         */
+        transport: function (params, success) {
+          twoincSelectWooHelper.toggleCompanySearchSpinner(true);
+
+          const request = jQuery.ajax(
+            jQuery.extend({}, params, {
+              timeout: twoincSelectWooHelper.companySearchTimeoutMs
+            })
+          );
+
+          request.done(function (data) {
+            // `degraded` marks an HTTP 200 whose (near-empty) result set is
+            // unreliable because the upstream provider lookup timed out.
+            // The field may not be deployed yet, so absent must read as not
+            // degraded — hence the explicit === true rather than truthiness.
+            if (data && data.degraded === true) {
+              success({ items: [] });
+              twoincSelectWooHelper.showCompanySearchUnavailable();
+              return;
+            }
+            success(data);
+          });
+
+          request.fail(function (jqXHR, textStatus) {
+            // A cancelled request is routine: select2 aborts the in-flight
+            // search on every keystroke, and the widget is re-created on
+            // country change. Those must stay silent. A timeout or a real
+            // transport error must not — left silent it renders as "no
+            // companies found", which is a wrong answer, not a missing one.
+            if (textStatus === "abort") return;
+            twoincSelectWooHelper.showCompanySearchUnavailable();
+          });
+
+          request.always(function () {
+            twoincSelectWooHelper.toggleCompanySearchSpinner(false);
+          });
+
+          return request;
+        },
         url: function (params) {
           const searchParams = new URLSearchParams({
             country: country,
@@ -97,8 +204,11 @@ let twoincSelectWooHelper = {
         },
         processResults: function (response, params) {
           const items = [];
-          for (let i = 0; i < response.items.length; i++) {
-            const item = response.items[i];
+          // A degraded response is fed through here with a synthesised
+          // empty payload, and a malformed body must not throw either.
+          const rawItems = response && Array.isArray(response.items) ? response.items : [];
+          for (let i = 0; i < rawItems.length; i++) {
+            const item = rawItems[i];
             items.push({
               id: item.name,
               text: item.name,

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -173,6 +173,9 @@ let twoincSelectWooHelper = {
           );
 
           request.done(function (data) {
+            // Same supersession rule as the failure path: a stale response
+            // must not repopulate the list under a newer search.
+            if (seq !== twoincSelectWooHelper.companySearchSeq) return;
             // `degraded` marks an HTTP 200 whose (near-empty) result set is
             // unreliable because the upstream provider lookup timed out.
             // The field may not be deployed yet, so absent must read as not

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -58,6 +58,16 @@ let twoincSelectWooHelper = {
    * is the last-resort fallback for a page where the localised string is
    * missing (older cached PHP, brand overlay that trims the text map).
    */
+  /**
+   * Sequence number of the most recently dispatched company-search request.
+   * A superseded request must not act on the shared spinner: select2 does
+   * abort the previous request before dispatching the next, so today the
+   * hide always lands before the next show — but that ordering is an
+   * internal detail of select2's ajax adapter, and a stuck-hidden spinner
+   * would be a silent regression if it ever changed.
+   */
+  companySearchSeq: 0,
+
   companySearchUnavailableText: function () {
     return (
       (window.twoinc && window.twoinc.text && window.twoinc.text.company_search_unavailable) ||
@@ -153,6 +163,7 @@ let twoincSelectWooHelper = {
          * and this code owns the messaging.
          */
         transport: function (params, success) {
+          const seq = ++twoincSelectWooHelper.companySearchSeq;
           twoincSelectWooHelper.toggleCompanySearchSpinner(true);
 
           const request = jQuery.ajax(
@@ -181,10 +192,14 @@ let twoincSelectWooHelper = {
             // transport error must not — left silent it renders as "no
             // companies found", which is a wrong answer, not a missing one.
             if (textStatus === "abort") return;
+            // A superseded request must not paint over a newer one's results.
+            if (seq !== twoincSelectWooHelper.companySearchSeq) return;
             twoincSelectWooHelper.showCompanySearchUnavailable();
           });
 
           request.always(function () {
+            // Only the newest request owns the spinner (see companySearchSeq).
+            if (seq !== twoincSelectWooHelper.companySearchSeq) return;
             twoincSelectWooHelper.toggleCompanySearchSpinner(false);
           });
 

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -246,6 +246,10 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                 'text' => [
                     'tooltip_phone' => __('We require your phone number so we can verify your purchase.', 'twoinc-payment-gateway'),
                     'tooltip_company' => __('We use your company name to automatically populate your address and register the company that made the purchase.', 'twoinc-payment-gateway'),
+                    // Shown in the company-search dropdown when the lookup
+                    // times out or comes back degraded (TWO-25232) — never
+                    // for a search that simply matched nothing.
+                    'company_search_unavailable' => __('Company search is temporarily unavailable. Please try again.', 'twoinc-payment-gateway'),
                 ],
                 'twoinc_checkout_host' => $this->wc_twoinc->get_twoinc_checkout_host(),
                 'enable_company_search' => $this->wc_twoinc->get_enable_company_search(),


### PR DESCRIPTION
## Why

Company search had **no client-side timeout at all**, so a request that never completed left the dropdown spinning forever. Worse, `language.errorLoading` deliberately returned the "searching…" string, so every real failure was indistinguishable from an in-flight search — and once the widget re-rendered, from "no matches". A buyer whose lookup fails is told, in effect, that their company does not exist.

## What

- **30s request timeout** (`companySearchTimeoutMs`). Deliberately wider than the backend's own retry envelope for the upstream provider lookup, so a slow-but-arriving response is never cut off client-side; this is the backstop for a request that does not arrive at all.
- **Custom select2 ajax `transport`.** select2's stock failure handler cannot tell a cancelled request from a timed-out one — it treats any `jqXHR` with `status === 0` as a cancellation, and a jQuery timeout also reports `status 0`. So the transport owns the messaging: `textStatus === "abort"` stays **silent** (select2 aborts the in-flight search on every keystroke, and the widget is re-created on country change), everything else raises "Company search is temporarily unavailable. Please try again."
- **`degraded` response flag consumed.** An HTTP 200 whose near-empty result set is unreliable because the upstream lookup timed out gets the same unavailable message rather than reading as "no companies found". Coded defensively — `data.degraded === true`, so an absent field (backend not yet deployed) reads as not degraded. `processResults` also no longer assumes `response.items` is an array.
- **Spinner inside the search field**, reusing the one loading idiom in this plugin (`.twoinc-dots`, shared with the order-intent check and the term-chip fee quote) rather than inventing a second one. Cleared on every outcome via `always()`.
- **Debounce 200ms → 300ms**, aligning all three plugin checkouts.
- New localised string `text.company_search_unavailable`, with a hardcoded fallback in JS for a page served by older cached PHP.

## Verification

- `phpcs` (4.0.1, `phpcs.xml`) — 0 errors.
- `phpstan` (2.2.5, level 2, with the pinned WP/WC stubs) — `[OK] No errors`.
- `php tests/unit/run.php` — all tests passed.
- `prettier@3.1.0 --check` on both touched assets — clean.
- **There is no JS test harness in this repo** (no `package.json` at the root, no unit coverage for `assets/js/`), so the JS changes carry no automated test. Stating that plainly rather than inventing a harness.
- **No browser was available: the spinner and the unavailable-message UX are visually unverified.** On the staging shop, worth looking at (a) the three-dot pulse appearing at the right-hand edge *inside* the company-search field while a query is in flight, and not clipping or overlapping typed text, (b) throttling/blocking `/companies/v2/company` to confirm the unavailable message replaces the results list instead of "no matches", and (c) typing quickly to confirm cancelled requests still produce no message at all.

## Overlay

The private brand overlay does **not** mirror any of this — its JS touches only the terms checkbox, its CSS has no select2 or loader rules, and it does not override the checkout text map. **No companion PR needed.**

## Adjacent pre-existing bugs — verified still on `staging`, NOT fixed here

Left alone as out of scope; filing/fixing is a separate call:

1. `assets/js/twoinc.js:1658` — the `#search_company_btn` handler restores `window.twoinc.enable_company_search` to a hardcoded `"yes"`, ignoring the merchant setting.
2. `twoincDomHelper.clearSelectedCompany()` (`:516`) re-wires `selectWoo` unconditionally on country change, with no `enable_company_search` gate — so it can resurrect the widget on a shop where search is off.
3. `assets/js/twoinc.js:1922` — `invalidFields.append("billing_phone_field")` calls `.append()` on a plain array; the invalid-phone path throws `TypeError`.

Ticket: [TWO-25232](https://linear.app/two-inc/issue/TWO-25232)

🤖 Generated with [Claude Code](https://claude.com/claude-code)