### PR TITLE
TWO-25249/fix: guard company-search rendering and send client attribution

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -14,13 +14,25 @@ let twoincUtilHelper = {
   },
 
   /**
-   * Construct url to Twoinc checkout api
+   * Construct url to Twoinc checkout api.
+   *
+   * `client` / `client_v` identify this plugin and its version to the API, and
+   * are the only attribution the company-search endpoint can get: the widget
+   * runs in the buyer's browser, so the user-agent is the shopper's. They go
+   * in the query string rather than a header on purpose — a custom header
+   * makes the request non-simple and buys a CORS preflight per keystroke.
+   *
+   * `params` may be a plain object or a URLSearchParams. It used to be
+   * assigned to as an object either way, which silently dropped both fields
+   * for every URLSearchParams caller (the company search): `new
+   * URLSearchParams(existing)` copies entries, not JS properties. Normalising
+   * first, and going through set(), covers both shapes and mutates neither.
    */
   constructTwoincUrl: function (path, params) {
-    if (!params) params = {};
-    params["client"] = window.twoinc.client_name;
-    params["client_v"] = window.twoinc.client_version;
-    return window.twoinc.twoinc_checkout_host + path + "?" + new URLSearchParams(params).toString();
+    const searchParams = new URLSearchParams(params || {});
+    searchParams.set("client", window.twoinc.client_name);
+    searchParams.set("client_v", window.twoinc.client_version);
+    return window.twoinc.twoinc_checkout_host + path + "?" + searchParams.toString();
   },
 
   /**
@@ -227,11 +239,26 @@ let twoincSelectWooHelper = {
           const rawItems = response && Array.isArray(response.items) ? response.items : [];
           for (let i = 0; i < rawItems.length; i++) {
             const item = rawItems[i];
+            // `national_identifier` is optional in the search response — the
+            // company may have none in its home registry, and its `id` may be
+            // null or empty. Reading it unguarded threw here, and a throw in
+            // this callback happens inside select2's query pipeline: it kills
+            // the whole result list, not just this hit, leaving the dropdown
+            // stuck on "Searching…". So render the company with whatever it
+            // has: the identifier is the buyer's disambiguator between two
+            // similarly-named companies, but dropping the hit entirely would
+            // remove a selectable company. Without one the buyer sees the
+            // company name alone and types the organisation number into the
+            // (still required) company_id field themselves.
+            const identifier =
+              item.national_identifier && item.national_identifier.id
+                ? String(item.national_identifier.id)
+                : "";
             items.push({
               id: item.name,
               text: item.name,
-              html: item.highlight + " (" + item.national_identifier.id + ")",
-              company_id: item.national_identifier.id,
+              html: identifier ? item.highlight + " (" + identifier + ")" : item.highlight,
+              company_id: identifier,
               lookup_id: item.lookup_id,
               approved: false
             });

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -120,9 +120,12 @@ about the company-search helper, so the bootstrap is left to no-op.
   body, and `items` as null/object/string/number, each yield no results and do not throw.
   A throw here would not surface as an error message — it happens inside select2's query
   pipeline, leaving the dropdown stuck on "Searching…".
+- a hit whose `national_identifier` is absent, null, or carries a null/empty `id` renders as
+  the company name alone with an empty `company_id`, and does not cost the buyer the other
+  hits in the same response.
 - request url: the configured host and `/companies/v2/company` path, the country from the
-  checkout form, `limit`/`offset` bounding and paging by that same bound, and the term
-  decoded exactly once.
+  checkout form, `limit`/`offset` bounding and paging by that same bound, the term decoded
+  exactly once, and `client`/`client_v` alongside the search params rather than replacing them.
 - the country is captured when `genSelectWooParams()` runs, not per keystroke — which is
   why a country change has to re-run `selectWoo()` with fresh params.
 - widget params: the 3-character minimum, the 300ms debounce shared with the other plugin
@@ -130,19 +133,25 @@ about the company-search helper, so the bootstrap is left to no-op.
   `templateSelection` uses plain text, and the non-error messages borrowing WooCommerce
   core's own copy.
 
-### Two characterisation tests, marked as such
+### Two defects these tests found, now fixed
 
-These pin current behaviour that is arguably wrong. They are recorded so that changing it is
-a deliberate decision with a test that flips, not a silent drift — neither is endorsed here,
-and neither is fixed in this test-only PR:
+Both were pinned as characterisation tests when this suite landed, and both were fixed
+immediately afterwards; the tests now assert the corrected behaviour:
 
-- **`processResults` throws on an item with no `national_identifier`.** `item.national_identifier.id`
-  is read unguarded. The body-level guard above it stops a malformed _body_, not a malformed
-  _hit_.
-- **`client` / `client_v` never reach the company-search query string.** `constructTwoincUrl()`
-  sets them as properties on the object it is handed; the search's `url()` callback hands it
-  a `URLSearchParams`, and `new URLSearchParams(params)` copies entries, not properties, so
-  both are dropped. Other call sites pass a plain object and do send them.
+- **a hit with no usable `national_identifier` no longer throws.** `item.national_identifier.id`
+  was read unguarded, and the body-level guard above it stops a malformed _body_, not a
+  malformed _hit_. `national_identifier` is optional in the search response, so a throw inside
+  select2's query pipeline took the whole result list down and left the dropdown on
+  "Searching…". Such a hit now renders as the company name with no identifier suffix and an
+  empty `company_id`, so the company stays selectable and the other hits survive.
+- **`client` / `client_v` reach the company-search query string.** `constructTwoincUrl()` set
+  them as properties on the object it was handed; the search's `url()` callback hands it a
+  `URLSearchParams`, and `new URLSearchParams(params)` copies entries, not properties, so both
+  were dropped for that one caller. They now go through `set()` on a normalised
+  `URLSearchParams`, which covers both shapes. Query string rather than a header on purpose —
+  a custom header makes the request non-simple and costs a CORS preflight per keystroke, and
+  this is the only platform attribution the endpoint can get, since the widget is client-side
+  and the user-agent is the shopper's browser.
 
 ## Known gaps
 
@@ -172,7 +181,8 @@ through `stubAjax()`. Out-of-order responses, aborts and timeouts are the subjec
 here, so controlling the timing is the point rather than a shortcut.
 
 Before trusting a new test, break the line it is supposed to pin and watch it fail. Every
-assertion in this suite was checked that way; seven separate mutations of
+assertion in this suite was checked that way; nine separate mutations of
 `assets/js/twoinc.js` (silencing the abort branch, dropping either supersession guard,
 dropping the `always` guard, weakening `degraded === true` to truthiness, removing the
-`Array.isArray` guard, removing the request timeout) each fail at least one test.
+`Array.isArray` guard, removing the request timeout, dropping the `national_identifier`
+guard, reverting `constructTwoincUrl()` to property assignment) each fail at least one test.

--- a/tests/js/company-search-results.test.js
+++ b/tests/js/company-search-results.test.js
@@ -105,14 +105,61 @@ describe("company search results", () => {
     });
   });
 
-  describe("malformed items", () => {
-    test("an item missing national_identifier throws", () => {
-      // Characterisation, not endorsement. `item.national_identifier.id`
-      // is read unguarded, so a hit without that object throws inside
-      // select2's query pipeline and the dropdown stays on "Searching…"
-      // rather than showing an error. Pinned so that a future guard
-      // (or its absence) is a deliberate decision — see README gaps.
-      expect(() => processResults()({ items: [{ name: "Example Co" }] }, {})).toThrow();
+  describe("a hit with no usable national_identifier", () => {
+    // `national_identifier` is optional in the search response and its `id`
+    // may be null or empty, so every one of these shapes is reachable. A
+    // throw here happens inside select2's query pipeline, which would take
+    // the whole result list down with it and leave the dropdown on
+    // "Searching…" — so the hit renders with whatever it has instead.
+    test.each([
+      ["national_identifier absent", { name: "Example Co", highlight: "<em>Example Co</em>" }],
+      [
+        "national_identifier null",
+        { name: "Example Co", highlight: "<em>Example Co</em>", national_identifier: null }
+      ],
+      [
+        "id null",
+        {
+          name: "Example Co",
+          highlight: "<em>Example Co</em>",
+          national_identifier: { id: null }
+        }
+      ],
+      [
+        "id empty",
+        { name: "Example Co", highlight: "<em>Example Co</em>", national_identifier: { id: "" } }
+      ]
+    ])("%s renders the company without an identifier suffix", (_label, item) => {
+      const run = () => processResults()({ items: [item] }, {});
+
+      expect(run).not.toThrow();
+      expect(run().results).toEqual([
+        {
+          id: "Example Co",
+          text: "Example Co",
+          html: "<em>Example Co</em>",
+          company_id: "",
+          lookup_id: undefined,
+          approved: false
+        }
+      ]);
+    });
+
+    test("does not take the rest of the result list down with it", () => {
+      // The point of the guard: one unusable hit must not cost the buyer
+      // every other company that matched.
+      const out = processResults()(
+        {
+          items: [
+            { name: "Example Co", highlight: "<em>Example Co</em>" },
+            hit("Other Example Co", "22222222")
+          ]
+        },
+        {}
+      );
+
+      expect(out.results.map((r) => r.text)).toEqual(["Example Co", "Other Example Co"]);
+      expect(out.results.map((r) => r.company_id)).toEqual(["", "22222222"]);
     });
   });
 
@@ -166,17 +213,27 @@ describe("company search results", () => {
       expect(new URL(url({ term: "exampleco" })).searchParams.get("country")).toBe("GB");
     });
 
-    test("client identification does not reach the query string", () => {
-      // Characterisation, not endorsement. constructTwoincUrl() sets
-      // `client` / `client_v` as PROPERTIES on the object it is handed;
-      // the caller here hands it a URLSearchParams, whose entries are
-      // what `new URLSearchParams(params)` copies — so both are dropped.
-      // Other callers pass a plain object and do send them. Pinned so
-      // that fixing it is a deliberate change with a test that flips.
+    test("identifies the plugin and its version to the API", () => {
+      // The only attribution this endpoint can get: the widget runs in the
+      // buyer's browser, so the user-agent is the shopper's. In the query
+      // string rather than a header on purpose — a custom header would make
+      // the request non-simple and cost a CORS preflight per keystroke.
+      // This caller hands constructTwoincUrl() a URLSearchParams, which is
+      // the shape that used to lose both fields.
       const url = urlFor();
 
-      expect(url.searchParams.get("client")).toBeNull();
-      expect(url.searchParams.get("client_v")).toBeNull();
+      expect(url.searchParams.get("client")).toBe("woocommerce");
+      expect(url.searchParams.get("client_v")).toBe("0.0.0-test");
+    });
+
+    test("keeps the search params it was given alongside them", () => {
+      // Guards against a fix that replaces the params instead of adding to
+      // them, which would lose the query itself.
+      const url = urlFor({ term: "exampleco" });
+
+      expect(url.searchParams.get("q")).toBe("exampleco");
+      expect(url.searchParams.get("country")).toBe("GB");
+      expect(url.searchParams.get("client")).toBe("woocommerce");
     });
   });
 


### PR DESCRIPTION
Closes TWO-25249. Fixes the two defects the Jest suite (#392) pinned as characterisation tests and deliberately left unfixed.

## 1. `processResults` threw on a hit with no `national_identifier`

`item.national_identifier.id` was read unguarded. That field is `CompanyIdentifier | None` in the search response schema, so a company with no identifier in its home registry is a normal hit, not a malformed one — and the `id` inside it can be null or empty. The body-level `Array.isArray` guard above only covers a malformed *body*.

The throw happened inside select2's query pipeline, which is the expensive part: it took the **whole result list** down and left the dropdown on "Searching…" rather than surfacing an error.

Such a hit now renders as the company name / highlight alone, with `company_id: ""`. Rationale: the identifier is what the buyer uses to tell two similarly-named companies apart, so losing it is a real cost — but skipping the hit removes a company the buyer may need to select, which is worse. `company_id` remains a required checkout field, so the buyer types the organisation number themselves; `.val("")` is what jQuery already did with the old `undefined`.

## 2. `client` / `client_v` never reached the company-search query string

`constructTwoincUrl()` set them as plain properties on the object it was handed. The search's `url()` callback hands it a `URLSearchParams`, and `new URLSearchParams(params)` copies entries, not JS properties — so both were silently dropped for that one caller. Every plain-object caller did send them.

Now normalised to a `URLSearchParams` and written through `set()`, which handles both shapes and mutates neither.

Query string, not a header, on purpose: a custom header makes the request non-simple and buys a CORS preflight on **every keystroke**. And this is the only platform attribution available for this endpoint — the widget is client-side, so the user-agent is the shopper's browser.

**Are the extra params safe?** Yes. `GET /companies/v2/company` binds its query into a pydantic model that does not set `extra="forbid"`, so unmodelled query params are ignored rather than rejected. No 400 risk.

## Tests

`Jest (Node 20)`, 65 tests, all green. The two characterisation tests now assert the corrected behaviour, plus: the null and empty-`id` variants, that one unusable hit does not cost the buyer the other results in the same response, and that the attribution params are *added to* the search params rather than replacing them. The characterisation framing is gone from `tests/js/README.md`.

Mutation-checked — reverting each fix independently turns the corresponding tests red:

```
revert the national_identifier guard  -> 5 failed, 60 passed
  a hit with no usable national_identifier > national_identifier absent / null / id null / id empty
  a hit with no usable national_identifier > does not take the rest of the result list down with it

revert constructTwoincUrl             -> 2 failed, 63 passed
  request url > identifies the plugin and its version to the API
  request url > keeps the search params it was given alongside them
```

## Not in scope

- The same unguarded `national_identifier.id` read exists in `magento-plugin` (`address-autocomplete.js`, `gateway_method.js`) and needs its own ticket.
- `/autofill/v1/buyer/current` sends no client attribution either, but via a raw `fetch()` that never went through `constructTwoincUrl()` — a separate omission.

Generated with [Claude Code](https://claude.com/claude-code)