### PR TITLE
fix(admin): wrap surcharge grid help text to the grid width

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -40,3 +40,20 @@ a.setting-dropdown {
     max-width: 300px;
   }
 }
+
+/*
+ * Surcharge grid: the container is the SINGLE width source for the grid
+ * and for the notes/help paragraphs that sit below it. The table is
+ * width:100% of the container and the paragraphs are its children, so
+ * the help text wraps at exactly the grid's width instead of running out
+ * to the page margin of the wide <td class="forminp">. Mirrors Magento's
+ * #surcharge-grid-container (.surcharge-grid is width:100%, .note
+ * paragraphs are siblings in the same box). Change the width here only.
+ */
+.twoinc-surcharge-grid-container {
+  max-width: 620px;
+}
+
+.twoinc-surcharge-grid-container .twoinc-surcharge-grid {
+  width: 100%;
+}

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -1245,8 +1245,19 @@ if (!class_exists('WC_Twoinc')) {
             <tr valign="top" class="twoinc-surcharge-grid-field">
                 <th scope="row" class="titledesc"><label><?php echo wp_kses_post($data['title']); ?></label></th>
                 <td class="forminp">
+                    <?php // Grid, notes and help text share ONE width source: the
+                    // container. The grid table is width:100% of it and the
+                    // paragraphs are its children, so the help text below the
+                    // grid wraps at exactly the grid's width and stays locked
+                    // to it if that width ever changes. Mirrors Magento's
+                    // #surcharge-grid-container, where .surcharge-grid is
+                    // width:100% and the .note paragraphs are siblings inside
+                    // the same box. Without the container the paragraphs are
+                    // laid out against the full <td class="forminp">, which in
+                    // a WooCommerce settings table runs to the page margin. ?>
+                    <div class="twoinc-surcharge-grid-container">
                     <p class="twoinc-surcharge-grid-empty"<?php echo empty($terms) ? '' : ' style="display:none"'; ?>><?php esc_html_e('No payment terms are offered yet — configure the offered terms above first.', 'twoinc-payment-gateway'); ?></p>
-                    <table class="widefat twoinc-surcharge-grid" data-field-key="<?php echo esc_attr($field_key); ?>" style="max-width:620px<?php echo empty($terms) ? ';display:none' : ''; ?>">
+                    <table class="widefat twoinc-surcharge-grid" data-field-key="<?php echo esc_attr($field_key); ?>"<?php echo empty($terms) ? ' style="display:none"' : ''; ?>>
                         <thead><tr>
                             <th><?php esc_html_e('Term (days)', 'twoinc-payment-gateway'); ?></th>
                             <th class="twoinc-col-fixed"><?php esc_html_e('Fixed', 'twoinc-payment-gateway'); ?></th>
@@ -1276,6 +1287,7 @@ if (!class_exists('WC_Twoinc')) {
                     <?php foreach ($help_text as $method => $sentence) : ?>
                         <p class="description twoinc-surcharge-grid-help twoinc-surcharge-grid-help--<?php echo esc_attr($method); ?>" style="display:none"><?php echo esc_html($sentence); ?></p>
                     <?php endforeach; ?>
+                    </div>
                 </td>
             </tr>
             <?php

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -78,6 +78,7 @@ final class BrandConfigSpec
             'testSurchargeGridEnforcesMerchantFixedCap',
             'testSurchargeCapZeroAmountFromApiMeansNoLimit',
             'testSurchargeGridHelpTextOmitsMaxOnCurrencyMismatch',
+            'testSurchargeGridNotesShareTheGridsWidthContainer',
             'testSurchargeFeeStandardModeUnchanged',
             'testSurchargeFeeCustomClassTaxedAtSelectedClassRates',
             'testSurchargeFeeAlwaysZeroNeverTaxed',
@@ -1808,6 +1809,34 @@ final class BrandConfigSpec
         TinyAssert::true(strpos($html, 'Max: 100%.') !== false, 'percentage ceiling is always claimable');
         unset($GLOBALS['__twoinc_test_currency']);
         unset($GLOBALS['test_home_url']);
+    }
+
+    /**
+     * The grid table and the notes/help paragraphs below it must sit inside
+     * ONE width container (.twoinc-surcharge-grid-container, max-width in
+     * admin.css) so the help text wraps at the grid's width rather than the
+     * full width of the WooCommerce settings cell. The table therefore
+     * carries no width of its own — admin.css makes it 100% of the
+     * container. Mirrors Magento's #surcharge-grid-container (ABN-476).
+     */
+    private static function testSurchargeGridNotesShareTheGridsWidthContainer(): void
+    {
+        $gateway = self::validationGateway(['payment_terms_days' => [30]], [30]);
+        $html = $gateway->generate_two_surcharge_grid_html('surcharge_grid', []);
+
+        $open = strpos($html, '<div class="twoinc-surcharge-grid-container">');
+        TinyAssert::true($open !== false, 'expected a single width container around the grid');
+        $close = strrpos($html, '</div>');
+        TinyAssert::true($close !== false && $close > $open, 'container must be closed after its contents');
+
+        // Grid and every note/help paragraph live inside that container.
+        foreach (['<table class="widefat twoinc-surcharge-grid"', 'twoinc-surcharge-grid-currency-note', 'twoinc-surcharge-grid-help--percentage', 'twoinc-surcharge-grid-empty'] as $needle) {
+            $at = strpos($html, $needle);
+            TinyAssert::true($at !== false && $at > $open && $at < $close, $needle . ' must render inside the width container');
+        }
+
+        // No competing width on the table itself — the container owns it.
+        TinyAssert::true(strpos($html, 'max-width:620px') === false, 'the table must not carry its own width');
     }
 
     // ── Surcharge tax treatment (TWO-25070) ────────────────────────────


### PR DESCRIPTION
ABN-476 follow-up.

## Problem

The per-term surcharge grid's help text and currency note sit below the grid (as of PR #395), but they were laid out against the full `<td class="forminp">` of the WooCommerce settings table. That cell runs to the right page margin, so the paragraphs did too, while the grid itself stopped at 620px.

## Fix

Grid, notes and help paragraphs now share **one** width container, `.twoinc-surcharge-grid-container`. The `max-width` lives on the container (`assets/css/admin.css`) and the grid table is `width: 100%` of it, so the container is the single width source and the two cannot drift apart.

This is the mechanism the Magento gateway already uses: `#surcharge-grid-container` in `view/adminhtml/templates/system/config/field/surcharge-grid.phtml`, with `.surcharge-grid { width: 100% }` in `_surcharge-grid.less` and the `.note` paragraphs as siblings inside the same box. Copied rather than reinvented.

## Verification

Headless Chromium render of the real `generate_two_surcharge_grid_html()` output plus the real `admin.css`, inside a `.form-table` harness, 1440px viewport:

| element | before | after |
|---|---|---|
| settings cell (`td.forminp`) | 1050px, right edge 1260 | unchanged |
| grid table | 620px, right edge 840 | 620px, right edge 840 |
| help paragraph | 1030px, right edge 1250 | **620px, right edge 840** |
| currency note | 1030px, right edge 1250 | **620px, right edge 840** |

The help block's right edge now lands exactly on the grid's. Note this is a local harness approximating wp-admin's `.form-table` rules, not the live staging admin — the branch is not deployed there.

New unit test `testSurchargeGridNotesShareTheGridsWidthContainer` asserts the container wraps the grid and every note/help paragraph, and that the table carries no width of its own. Full `php tests/unit/run.php` suite passes.