### PR TITLE
refactor(checkout): drop the unused term-selector visibility helper (ABN-468)

### DIFF
--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -235,8 +235,8 @@ if (!class_exists('WC_Twoinc_Checkout')) {
 
             // Checkout render is the sanctioned refresh point for the
             // backend term list (TWO-24812) — refresh once here; the
-            // cache-only seam reads below (is_selector_visible,
-            // get_selected_term, …) then see the fresh list.
+            // cache-only seam reads below (is_enabled, get_selected_term,
+            // …) then see the fresh list.
             $offered_terms = WC_Twoinc_Payment_Terms::get_available_terms($this->wc_twoinc, true);
 
             // TODO: Make this dynamic based on active merchant payee accounts

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -53,16 +53,6 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
         }
 
         /**
-         * Whether the buyer sees a term chooser: only when more than one term is
-         * offered. A single offered term is applied silently (no chip selector),
-         * so selection is implicitly disabled when just one term is configured.
-         */
-        public static function is_selector_visible($gateway): bool
-        {
-            return count(self::get_available_terms($gateway)) > 1;
-        }
-
-        /**
          * The terms offered at checkout, ascending. THE availability seam —
          * see the file header before adding another term-list read.
          *

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -67,7 +67,6 @@ final class BrandConfigSpec
             'testLegacyDaysOnInvoiceOptionRowsDropped',
             'testPaymentTermsValidationNonDestructiveOnUnresolvedOrNarrowedList',
             'testSurchargeGridPreservesRowsNotOnTheForm',
-            'testPaymentTermsSelectorVisibleOnlyWithMultiple',
             'testChipFeeAmountCarriesCurrencySymbolNotCode',
             'testPaymentTermsDefaultFallsBackToShortest',
             'testBuyerFeeShareShapes',
@@ -1407,23 +1406,6 @@ final class BrandConfigSpec
                 return $this->merchant_terms;
             }
         };
-    }
-
-    private static function testPaymentTermsSelectorVisibleOnlyWithMultiple(): void
-    {
-        // One offered term: feature active but applied silently (no chooser)
-        $gateway = self::termsGateway(['payment_terms_days' => ['30']]);
-        TinyAssert::true(WC_Twoinc_Payment_Terms::is_enabled($gateway));
-        TinyAssert::same(false, WC_Twoinc_Payment_Terms::is_selector_visible($gateway));
-
-        // Two offered terms: chooser visible
-        $gateway = self::termsGateway(['payment_terms_days' => ['30', '60']]);
-        TinyAssert::true(WC_Twoinc_Payment_Terms::is_selector_visible($gateway));
-
-        // No terms: neither active nor visible
-        $gateway = self::termsGateway([]);
-        TinyAssert::same(false, WC_Twoinc_Payment_Terms::is_enabled($gateway));
-        TinyAssert::same(false, WC_Twoinc_Payment_Terms::is_selector_visible($gateway));
     }
 
     /**


### PR DESCRIPTION
ABN-468 follow-up.

`WC_Twoinc_Payment_Terms::is_selector_visible()` has had no production caller since the chip bootstrap stopped sending a selectable flag — `render()` derives whether the buyer can choose from the term list it is handed, because the fees response can revise that list after the bootstrap is written. The only reference left was its own unit test.

- remove the method
- remove `testPaymentTermsSelectorVisibleOnlyWithMultiple` and its registration; the `is_enabled()` assertions it also carried are already covered by the existing terms test, so no coverage is lost
- de-stale the refresh comment in `prepare_twoinc_object()`, which named the removed helper as an example cache-only seam reader

No behaviour change. `php tests/unit/run.php` passes.

Casing check (same ticket): the shipped chip heading is `Selected payment terms`, lower-case after the first word, matching the Luma renderer. No change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)