### PR TITLE
TWO-25268/fix: surcharge grid states the STORE currency, and the cap is gated on it

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -1200,8 +1200,7 @@ if (!class_exists('WC_Twoinc')) {
             // told the grid is denominated in a currency the plugin never
             // reads it as.
             $currency_code = strtoupper((string) get_option('woocommerce_currency'));
-            $active_currency_code = strtoupper((string) get_woocommerce_currency());
-            $fixed_limit_label = $fixed_limit && $fixed_limit['currency'] === $active_currency_code
+            $fixed_limit_label = $fixed_limit && $fixed_limit['currency'] === $currency_code
                 ? $this->format_surcharge_limit_label($fixed_limit)
                 : '';
             // Percentage ceiling. Mirrors Magento's
@@ -1315,9 +1314,14 @@ if (!class_exists('WC_Twoinc')) {
             // Only enforceable when the cap's currency matches the store
             // currency — Woo does no FX conversion (unlike Magento), so on
             // a mismatch the cap is skipped here and the backend enforces.
+            // The posted amounts are STORE-denominated, so the comparison is
+            // against the saved woocommerce_currency option and NOT against
+            // get_woocommerce_currency() (the active request currency), which
+            // would let an admin session in a non-default currency skip the
+            // cap entirely (TWO-25268).
             $max_fixed = null;
             $limit = $this->get_merchant_surcharge_limit(true);
-            if ($limit && $limit['currency'] === strtoupper((string) get_woocommerce_currency())) {
+            if ($limit && $limit['currency'] === strtoupper((string) get_option('woocommerce_currency'))) {
                 $max_fixed = (float) $limit['amount'];
             }
 

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -1191,8 +1191,17 @@ if (!class_exists('WC_Twoinc')) {
             // backend enforces instead. Omitted entirely when no cap
             // exists or on a currency mismatch.
             $fixed_limit = $this->get_merchant_surcharge_limit(true);
-            $currency_code = strtoupper((string) get_woocommerce_currency());
-            $fixed_limit_label = $fixed_limit && $fixed_limit['currency'] === $currency_code
+            // The grid's values are denominated in the STORE currency — the
+            // saved woocommerce_currency option, which is what
+            // WC_Twoinc_Payment_Terms::build_buyer_fee_share() converts FROM.
+            // Deliberately NOT get_woocommerce_currency(), which is the
+            // ACTIVE currency of the current request: under a multicurrency
+            // plugin an admin browsing in a non-default currency would be
+            // told the grid is denominated in a currency the plugin never
+            // reads it as.
+            $currency_code = strtoupper((string) get_option('woocommerce_currency'));
+            $active_currency_code = strtoupper((string) get_woocommerce_currency());
+            $fixed_limit_label = $fixed_limit && $fixed_limit['currency'] === $active_currency_code
                 ? $this->format_surcharge_limit_label($fixed_limit)
                 : '';
             // Percentage ceiling. Mirrors Magento's

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -1723,9 +1723,25 @@ final class BrandConfigSpec
 
         // Store currency differs from the cap's: Woo does no FX conversion,
         // so the cap is skipped here (the backend still enforces).
-        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $GLOBALS['__twoinc_test_store_currency'] = 'NOK';
         $clean = $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['fixed' => '9999']]);
         TinyAssert::same([30 => ['fixed' => '9999']], $clean);
+        unset($GLOBALS['__twoinc_test_store_currency']);
+
+        // Only the ACTIVE currency diverges (multicurrency admin session).
+        // The posted amounts are still store-denominated, so the cap binds
+        // exactly as it does in a single-currency session (TWO-25268).
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $message = '';
+        try {
+            $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['fixed' => '9999']]);
+        } catch (Exception $e) {
+            $message = $e->getMessage();
+        }
+        TinyAssert::true(
+            strpos($message, 'EUR 25') !== false,
+            "the cap must not be skipped when only the active currency differs, got: $message"
+        );
         unset($GLOBALS['__twoinc_test_currency']);
         unset($GLOBALS['test_home_url']);
 
@@ -1825,7 +1841,7 @@ final class BrandConfigSpec
         $GLOBALS['__twoinc_test_options'][$limit_option] = json_encode(['amount' => 25.0, 'currency' => 'EUR']);
 
         // Matching store currency: the grid claims the enforced maximum.
-        $GLOBALS['__twoinc_test_currency'] = 'EUR';
+        $GLOBALS['__twoinc_test_store_currency'] = 'EUR';
         $gateway = self::validationGateway(['payment_terms_days' => [30]], [30]);
         $html = $gateway->generate_two_surcharge_grid_html('surcharge_grid', []);
         TinyAssert::true(strpos($html, 'Max EUR 25.') !== false, 'expected Max sentence for matching currency');
@@ -1836,7 +1852,7 @@ final class BrandConfigSpec
         // paragraph disappears entirely and the combined variant degrades
         // to the percentage-only wording (ABN-476) — the percentage
         // ceiling itself is always enforced, so "Max: 100%" stays.
-        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $GLOBALS['__twoinc_test_store_currency'] = 'NOK';
         $html = $gateway->generate_two_surcharge_grid_html('surcharge_grid', []);
         TinyAssert::true(strpos($html, 'Max EUR') === false, 'fixed Max sentence must be omitted on currency mismatch');
         TinyAssert::true(strpos($html, 'Max NOK') === false, 'no fixed maximum may be claimed on currency mismatch');
@@ -1845,6 +1861,17 @@ final class BrandConfigSpec
             'the fixed-only help paragraph must not render without an enforceable cap'
         );
         TinyAssert::true(strpos($html, 'Max: 100%.') !== false, 'percentage ceiling is always claimable');
+        unset($GLOBALS['__twoinc_test_store_currency']);
+
+        // An active-currency-only divergence is NOT a mismatch: the cap is
+        // enforced against store-denominated amounts, so the Max sentence
+        // must still be claimed (TWO-25268).
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $html = $gateway->generate_two_surcharge_grid_html('surcharge_grid', []);
+        TinyAssert::true(
+            strpos($html, 'Max EUR 25.') !== false,
+            'the Max sentence must survive an active-currency-only divergence'
+        );
         unset($GLOBALS['__twoinc_test_currency']);
         unset($GLOBALS['test_home_url']);
     }

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -77,6 +77,7 @@ final class BrandConfigSpec
             'testSurchargeGridValidationNormalisesAndRejects',
             'testSurchargeGridEnforcesMerchantFixedCap',
             'testSurchargeCapZeroAmountFromApiMeansNoLimit',
+            'testSurchargeGridCurrencyNoteNamesTheStoreCurrency',
             'testSurchargeGridHelpTextOmitsMaxOnCurrencyMismatch',
             'testSurchargeGridNotesShareTheGridsWidthContainer',
             'testSurchargeFeeStandardModeUnchanged',
@@ -1779,6 +1780,43 @@ final class BrandConfigSpec
         // ...and save-validation applies no cap.
         $clean = $gateway->validate_two_surcharge_grid_field('surcharge_grid', [30 => ['fixed' => '9999']]);
         TinyAssert::same([30 => ['fixed' => '9999']], $clean);
+    }
+
+    /**
+     * The grid's amounts are denominated in the STORE currency, so the note
+     * that states the denomination — and the symbol in the limit sentence —
+     * must come from the saved woocommerce_currency option, never from the
+     * ACTIVE currency of the request. Under a multicurrency plugin an admin
+     * browsing in USD was told "Amounts are shown in USD" for numbers the
+     * plugin reads as EUR (TWO-25268).
+     */
+    private static function testSurchargeGridCurrencyNoteNamesTheStoreCurrency(): void
+    {
+        // Active currency diverges from the store currency, as a
+        // multicurrency admin session does.
+        $GLOBALS['__twoinc_test_store_currency'] = 'EUR';
+        $GLOBALS['__twoinc_test_currency'] = 'USD';
+        $gateway = self::validationGateway(['payment_terms_days' => [30]], [30]);
+        $html = $gateway->generate_two_surcharge_grid_html('surcharge_grid', []);
+
+        TinyAssert::true(
+            strpos($html, 'Amounts are shown in EUR.') !== false,
+            'the currency note must name the store currency'
+        );
+        TinyAssert::true(
+            strpos($html, 'Amounts are shown in USD.') === false,
+            'the currency note must not name the active currency'
+        );
+        // Same source for the symbol in the limit sentence. The stub
+        // get_woocommerce_currency_symbol() echoes the code back.
+        TinyAssert::true(
+            strpos($html, 'Enter a limit amount (in EUR )') !== false,
+            'the limit sentence symbol must derive from the store currency'
+        );
+
+        unset($GLOBALS['__twoinc_test_store_currency']);
+        unset($GLOBALS['__twoinc_test_currency']);
+        unset($GLOBALS['test_home_url']);
     }
 
     private static function testSurchargeGridHelpTextOmitsMaxOnCurrencyMismatch(): void

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -179,6 +179,14 @@ final class BrandConfigSpec
         WC_Twoinc_Brand::reset();
         putenv('TWO_BRAND_CODE');
         unset($GLOBALS['__twoinc_test_currency']);
+        // The STORE currency is a separate global from the ACTIVE one
+        // (bootstrap.php stubs get_option('woocommerce_currency') and
+        // get_woocommerce_currency() independently), and it was never reset
+        // here. The whole suite runs in one process, so a test that set it
+        // and then failed an assertion before its own unset leaked a
+        // non-default store currency into every test after it — turning one
+        // failure into a cascade in unrelated specs. Reset both together.
+        unset($GLOBALS['__twoinc_test_store_currency']);
         unset($GLOBALS['test_home_url']);
         $GLOBALS['__twoinc_test_options'] = [];
         unset($_POST[WC_Twoinc_Payment_Terms::SESSION_KEY]);


### PR DESCRIPTION
## Why

The surcharge grid's amounts are denominated in the **store** currency — the saved `woocommerce_currency` option, which is what `WC_Twoinc_Payment_Terms::build_buyer_fee_share()` converts *from* via the Two FX layer.

Two places read the **active** currency of the request (`get_woocommerce_currency()`) instead. Under a multicurrency plugin, an admin session in a non-default currency therefore saw:

1. "Amounts are shown in USD" above a grid the plugin reads as EUR — the one sentence whose entire job is stating the denomination, wrong.
2. The funding-partner cap silently not enforced, and its "Max EUR 25" sentence gone.

## Two commits, deliberately separate

**1 — display only, no behaviour change.** The currency note and the symbol in the limit sentence now derive from `get_option('woocommerce_currency')`. The cap comparison is explicitly pinned to the active currency in this commit so it stays byte-identical in behaviour.

**2 — the behaviour-bearing change.** The cap comparison moves to the store currency in both the grid render and the save-validation. This is a **pre-existing** bug, not one introduced by commit 1, which is why it is split out.

The store currency is the right answer because the amounts the cap bounds are the ones typed into the grid, and those are store-denominated. The in-code comment on both sites *already* said "when the cap's currency differs from the **store** currency" — the code contradicted its own documented intent. The old behaviour was fail-open on the value that actually gets saved.

A genuine store-currency mismatch still skips the cap and defers to the backend. Unchanged.

## Tests

- New: the note and the limit-sentence symbol name the store currency while the active currency diverges.
- Updated: the two existing mismatch tests asserted the mismatch by moving the *active* currency while calling it the store currency. They now move the store currency, and each gains an active-currency-only case asserting the cap survives it.
- Both new assertions were confirmed to fail against pre-fix code, not just pass against the fix.

`make test-unit` green, `make phpcs` exit 0.

## Scope

Admin-facing. No buyer-visible change. No migration, no config key, no version bump.

Fail-closed FX harmonisation (TWO-25269) is deliberately a separate PR so this one-line-class fix is not held behind its design work.