### PR TITLE
TWO-25269/fix: fail closed when the surcharge currency is unquotable

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -2570,9 +2570,11 @@ if (!class_exists('WC_Twoinc')) {
          * Remove the gateway from checkout when the platform minimum
          * (API-resolved, see get_platform_minimum_order()), the brand's
          * billing-country restriction (availability_gate in the brand
-         * config), or the merchant's own minimum is unmet. Mirrors the
-         * brand availability gate semantics: front-end only, minimum is
-         * inclusive (an exactly-minimum basket passes).
+         * config), the merchant's own minimum is unmet, or the configured
+         * surcharge cannot be quoted in the checkout currency at all
+         * (TWO-25269). Mirrors the brand availability gate semantics:
+         * front-end only, minimum is inclusive (an exactly-minimum basket
+         * passes).
          *
          * @param array $available_gateways
          *
@@ -2581,6 +2583,22 @@ if (!class_exists('WC_Twoinc')) {
         public function apply_brand_availability_gate($available_gateways)
         {
             if (is_admin() || !isset($available_gateways[$this->id])) {
+                return $available_gateways;
+            }
+
+            // Surcharge FX resolvability is judged FIRST, and deliberately
+            // OUTSIDE the $basket_is_judgeable guard further down. That
+            // guard exists because the minimums judge a basket; whether the
+            // store→checkout currency pair has a rate does not depend on
+            // the basket at all, and the order-pay endpoint the guard
+            // excludes is precisely a place a surcharge still gets applied.
+            // It also precedes the "no gate and no minimums configured"
+            // early return below: a shop with neither still charges
+            // surcharges. Fail CLOSED, the same shape as the minimums' own
+            // FX handling — better no Two payment method than a buyer
+            // silently charged no surcharge with nobody told (TWO-25269).
+            if (WC_Twoinc_Payment_Terms::surcharge_currency_unquotable($this)) {
+                unset($available_gateways[$this->id]);
                 return $available_gateways;
             }
             $gate = WC_Twoinc_Brand::get('availability_gate');

--- a/class/WC_Twoinc_FX.php
+++ b/class/WC_Twoinc_FX.php
@@ -45,13 +45,17 @@
  * bug). A failed fetch arms a short retry-throttle transient so a
  * flapping API cannot be hammered once per conversion.
  *
- * Fail semantics (per TWO-25104):
+ * Fail semantics (per TWO-25104; charge semantics revised by TWO-25269):
  *  - Gate conversions (minimum-order availability) use last-known-good and
  *    fail CLOSED only when no table has ever been fetched: get_rate()
  *    returns null and the caller must treat null as "cannot be proven".
  *  - Display conversions fail SOFT: callers fall back to the native value.
- *  - Charge conversions (fixed surcharge/cap) fail SOFT to *no* surcharge:
- *    a wrong-currency amount must never be sent to the pricing API.
+ *  - Charge conversions (fixed surcharge/cap) fail CLOSED. A wrong-currency
+ *    amount must never be sent to the pricing API, but dropping the
+ *    surcharge instead charges the buyer nothing and tells nobody, so an
+ *    unconvertible pair withholds the payment method for the whole
+ *    checkout (WC_Twoinc::apply_brand_availability_gate) rather than
+ *    quietly changing what is charged.
  *
  * The response's as_of date (the staleness floor of the rates used) is
  * stored alongside the table for observability and tests; freshness is
@@ -352,8 +356,8 @@ if (!class_exists('WC_Twoinc_FX')) {
          * in an uncached currency" path) before concluding it is
          * unsupported.
          *
-         * Null means "cannot convert": gate callers must fail closed on
-         * it, display and charge callers fail soft (see the class header).
+         * Null means "cannot convert": gate AND charge callers must fail
+         * closed on it, display callers fail soft (see the class header).
          */
         public static function get_rate($gateway, string $from, string $to): ?float
         {

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -42,6 +42,14 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
         private static $fee_cache = [];
 
         /**
+         * @var bool one fail-CLOSED surcharge-FX report per request. The
+         * gate filter and the per-term quote path can both hit the same
+         * condition several times while rendering one checkout; the
+         * merchant needs to be told once, not once per term.
+         */
+        private static $fx_failure_logged = false;
+
+        /**
          * Whether the term feature is active: at least one term is offered. When
          * true a term is sent on the order and any configured surcharge applies.
          * There is no merchant on/off toggle — the offered-term set is the single
@@ -237,7 +245,9 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
          * percentage component) and, in differential mode, the default term as
          * reference_terms.
          *
-         * @return array|null null when no surcharge is configured (type none)
+         * @return array|null null when no surcharge is configured (type none),
+         *                    or when a monetary component cannot be relayed
+         *                    safely in the checkout currency (TWO-25269)
          */
         public static function build_buyer_fee_share($gateway, int $days): ?array
         {
@@ -260,45 +270,75 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
             // multi-currency setup has them diverge the monetary
             // components are converted via the Two FX layer (TWO-25104 —
             // Magento parity, which converts via the store's own rates).
-            // A wrong-currency amount must never be sent: if the pair
-            // cannot be converted (no rate ever fetched, or an unsupported
-            // currency) the whole surcharge is withheld for this quote —
-            // fail soft to no fee, matching the quote path's
-            // never-block-checkout posture. Same-currency stores never
-            // reach the FX layer. Percentage-based surcharge is
-            // currency-agnostic and unaffected.
-            $fixed = $has_fixed && isset($row['fixed']) && (float) $row['fixed'] > 0 ? (float) $row['fixed'] : null;
-            $cap = $has_percentage && isset($row['limit']) && (float) $row['limit'] > 0 ? (float) $row['limit'] : null;
+            // A wrong-currency amount must never be sent, and neither may
+            // the surcharge silently vanish: an unconvertible pair is
+            // caught EARLIER, by the availability gate, which withholds
+            // the payment method for the whole checkout (TWO-25269 —
+            // surcharge_currency_unquotable(), called from
+            // WC_Twoinc::apply_brand_availability_gate). Returning null
+            // here is the defence-in-depth backstop for the paths the
+            // gate does not run on. Same-currency stores never reach the
+            // FX layer. Percentage-based surcharge is currency-agnostic
+            // and unaffected.
+            $components = self::surcharge_monetary_components($settings, $days);
+            $fixed = $components['fixed'];
+            $cap = $components['cap'];
             if ($fixed !== null || $cap !== null) {
                 $store_currency = strval(get_option('woocommerce_currency'));
                 $active_currency = get_woocommerce_currency();
                 if ($store_currency !== $active_currency) {
                     $rate = WC_Twoinc_FX::get_rate($gateway, $store_currency, $active_currency);
                     if ($rate === null) {
-                        if (function_exists('wc_get_logger')) {
-                            wc_get_logger()->warning(
-                                sprintf(
-                                    'Surcharge withheld: no FX rate to convert configured %s amounts to checkout currency %s',
-                                    $store_currency,
-                                    $active_currency
-                                ),
-                                ['source' => 'twoinc-payment-gateway']
-                            );
-                        }
+                        self::log_surcharge_fx_failure(sprintf(
+                            'no FX rate to convert configured %s amounts'
+                            . ' to checkout currency %s (term %d days)',
+                            $store_currency,
+                            $active_currency,
+                            $days
+                        ));
                         return null;
                     }
                     $converted_fixed = $fixed !== null ? (float) WC_Twoinc_Helper::round_amt($fixed * $rate) : null;
                     $converted_cap = $cap !== null ? (float) WC_Twoinc_Helper::round_amt($cap * $rate) : null;
-                    // A tiny configured amount can round to 0.00 in a much
-                    // stronger currency. Dropping only the cap while
-                    // leaving the percentage component in place would
-                    // send an UNCAPPED fee — the opposite of what the
-                    // merchant configured — so a component that rounds
-                    // away withholds the whole surcharge, same as no rate
-                    // being available at all, rather than silently
-                    // changing what is charged.
-                    if (($fixed !== null && $converted_fixed <= 0) || ($cap !== null && $converted_cap <= 0)) {
+                    // A configured CAP that rounds to 0.00 in a much
+                    // stronger checkout currency fails CLOSED: a zero cap
+                    // is indistinguishable from *no* cap downstream, so
+                    // relaying it would send an UNCAPPED percentage — an
+                    // overcharge, the opposite of what the merchant
+                    // configured. An ABSENT cap is a wholly legitimate
+                    // configuration and is never a failure (see
+                    // surcharge_monetary_components).
+                    if ($cap !== null && $converted_cap <= 0) {
+                        self::log_surcharge_fx_failure(sprintf(
+                            'configured %s cap rounds to 0.00 in checkout'
+                            . ' currency %s, which would relay an UNCAPPED'
+                            . ' percentage (term %d days)',
+                            $store_currency,
+                            $active_currency,
+                            $days
+                        ));
                         return null;
+                    }
+                    // A FIXED amount that rounds to 0.00 is NOT a failure:
+                    // a legitimately tiny configured fee can be genuinely
+                    // negligible in a stronger currency, and 0.00 is the
+                    // arithmetically correct answer. Proceed with it —
+                    // rejecting a 0.001 configured fee would be a wrong
+                    // rejection — but say so, because a surcharge line
+                    // quietly reading 0.00 otherwise looks like a bug.
+                    if ($fixed !== null && $converted_fixed <= 0 && function_exists('wc_get_logger')) {
+                        wc_get_logger()->info(
+                            sprintf(
+                                'Fixed surcharge of %s %s rounds to 0.00 in'
+                                . ' checkout currency %s; charging 0.00'
+                                . ' (term %d days)',
+                                $fixed,
+                                $store_currency,
+                                $active_currency,
+                                $days
+                            ),
+                            ['source' => 'twoinc-payment-gateway']
+                        );
                     }
                     $fixed = $converted_fixed;
                     $cap = $converted_cap;
@@ -323,6 +363,107 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
                 }
             }
             return $buyer_fee_share;
+        }
+
+        /**
+         * The two STORE-currency monetary components of one term's grid
+         * row: the fixed surcharge (fixed/both types) and the cap on the
+         * percentage portion (percentage/both types). Either may be null.
+         *
+         * A null CAP means "no cap configured", which is a completely
+         * legitimate configuration: the percentage surcharge is then
+         * charged uncapped, exactly as the merchant asked. Absence must
+         * never be treated as a failure anywhere — only a cap that IS
+         * configured and cannot be relayed faithfully fails closed.
+         *
+         * @param array{type: string, grid: array<int,array>} $settings
+         * @return array{fixed: float|null, cap: float|null}
+         */
+        private static function surcharge_monetary_components(array $settings, int $days): array
+        {
+            $has_percentage = in_array($settings['type'], ['percentage', 'fixed_and_percentage'], true);
+            $has_fixed = in_array($settings['type'], ['fixed', 'fixed_and_percentage'], true);
+            $row = isset($settings['grid'][$days]) && is_array($settings['grid'][$days]) ? $settings['grid'][$days] : [];
+            return [
+                'fixed' => $has_fixed && isset($row['fixed']) && (float) $row['fixed'] > 0 ? (float) $row['fixed'] : null,
+                'cap' => $has_percentage && isset($row['limit']) && (float) $row['limit'] > 0 ? (float) $row['limit'] : null,
+            ];
+        }
+
+        /**
+         * Whether the configured surcharge cannot be quoted at all in the
+         * active checkout currency, i.e. the fail-CLOSED condition for the
+         * availability gate (TWO-25269). True means: withhold the payment
+         * method rather than let the buyer be charged no surcharge with
+         * nobody told.
+         *
+         * The condition is deliberately TERM-INDEPENDENT. No term is
+         * selected when gateway availability is decided, and it does not
+         * need to be: WC_Twoinc_FX::get_rate() resolves (or fails to
+         * resolve) the store→checkout pair identically for every term, so
+         * "no rate at all" is a property of the currency pair. Gating on
+         * "some offered term is unquotable" instead would over-reject a
+         * shop with one misconfigured term.
+         *
+         * Ordering matters for cost: the cheap local checks (surcharge
+         * enabled, currencies diverge, at least one term actually carries
+         * a monetary component) come before the FX lookup, so a
+         * single-currency or percentage-only shop never touches the FX
+         * layer from the gate.
+         */
+        public static function surcharge_currency_unquotable($gateway): bool
+        {
+            $settings = self::get_surcharge_settings($gateway);
+            if (!$settings['enabled']) {
+                return false;
+            }
+            $store_currency = strval(get_option('woocommerce_currency'));
+            $active_currency = get_woocommerce_currency();
+            if ($store_currency === $active_currency) {
+                return false;
+            }
+            $monetary_term = null;
+            foreach (self::get_available_terms($gateway) as $days) {
+                $components = self::surcharge_monetary_components($settings, $days);
+                if ($components['fixed'] !== null || $components['cap'] !== null) {
+                    $monetary_term = $days;
+                    break;
+                }
+            }
+            if ($monetary_term === null) {
+                // Percentage-only (or empty) grid: currency-agnostic,
+                // nothing to convert, nothing to fail on.
+                return false;
+            }
+            if (WC_Twoinc_FX::get_rate($gateway, $store_currency, $active_currency) !== null) {
+                return false;
+            }
+            self::log_surcharge_fx_failure(sprintf(
+                'no FX rate for the configured %s surcharge amounts in checkout currency %s (e.g. term %d days)',
+                $store_currency,
+                $active_currency,
+                $monetary_term
+            ));
+            return true;
+        }
+
+        /**
+         * Report a fail-CLOSED surcharge FX condition at error level, once
+         * per request. Error, not warning: the outcome is either a
+         * withheld payment method or a withheld surcharge, and both are
+         * invisible to the merchant unless the log says so (the same
+         * rationale as the availability gate's own log).
+         */
+        private static function log_surcharge_fx_failure(string $reason): void
+        {
+            if (self::$fx_failure_logged || !function_exists('wc_get_logger')) {
+                return;
+            }
+            self::$fx_failure_logged = true;
+            wc_get_logger()->error(
+                'Surcharge cannot be quoted in the checkout currency: ' . $reason,
+                ['source' => 'twoinc-payment-gateway']
+            );
         }
 
         /**
@@ -365,8 +506,12 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
 
         /**
          * Quote the buyer's fee share for one term via the pricing endpoint.
-         * Fail-soft: returns null on any error (chip renders without a fee
-         * label; checkout is never blocked on a quote).
+         * A failed or malformed HTTP quote is fail-soft: returns null and
+         * the chip renders without a fee label. That covers transport
+         * errors only — it is NOT a licence to drop a surcharge the
+         * merchant configured. An unquotable currency pair is a
+         * fail-CLOSED condition handled upstream by the availability gate
+         * (TWO-25269), which withholds the payment method outright.
          *
          * @return array{buyer_fee_share: string, total_fee_tax_rate: string|null, currency: string}|null
          */
@@ -381,9 +526,9 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
                 return self::$fee_cache[$days] = null;
             }
 
-            // This quote sits on the checkout render path and is fail-soft, so
-            // cap it well under make_request's 30s default to avoid stalling
-            // checkout on a slow pricing call.
+            // This quote sits on the checkout render path and is fail-soft on
+            // transport errors, so cap it well under make_request's 30s
+            // default to avoid stalling checkout on a slow pricing call.
             $response = $gateway->make_request('/v1/pricing/order/fee', [
                 'currency' => get_woocommerce_currency(),
                 'gross_amount' => strval(WC_Twoinc_Helper::round_amt($gross_amount)),
@@ -729,6 +874,7 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
         public static function reset_fee_cache(): void
         {
             self::$fee_cache = [];
+            self::$fx_failure_logged = false;
         }
     }
 }

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -141,9 +141,14 @@ final class BrandConfigSpec
             'testFxGateUsesLastKnownGoodOnApiFailure',
             'testFxMerchantMinimumJudgedAcrossCurrencies',
             'testBuyerFeeShareConvertsFixedAndCapAcrossCurrencies',
-            'testBuyerFeeShareWithheldWhenNoRateAvailable',
+            'testBuyerFeeShareFailsClosedWhenNoRateAvailable',
+            'testGateWithholdsMethodWhenSurchargeCurrencyUnquotable',
+            'testGateKeepsMethodWhenSurchargeIsPercentageOnly',
+            'testGateFxCheckAppliesOnOrderPayEndpoint',
             'testBuyerFeeShareSameCurrencyNeverTouchesFx',
-            'testBuyerFeeShareCapRoundingToZeroWithholdsWholeSurcharge',
+            'testBuyerFeeShareCapRoundingToZeroFailsClosed',
+            'testBuyerFeeShareFixedRoundingToZeroChargesZero',
+            'testBuyerFeeShareAbsentCapChargesUncappedPercentage',
             'testCartFeeSkippedOnQuoteCurrencyMismatch',
             'testMinimumDescriptionShowsConvertedFloorWhenRateAvailable',
             'testDeployedCommitGitlinkWinsOverSidecar',
@@ -3358,6 +3363,25 @@ final class BrandConfigSpec
         $GLOBALS['__twoinc_test_options'][WC_Twoinc_FX::option_key()] = json_encode($table);
     }
 
+    /**
+     * Assert the StubWcLogger recorded a message at $level containing
+     * $needle. Withholding a payment method (or a surcharge) is invisible
+     * to the merchant, so the LEVEL is part of the contract, not decoration
+     * — an error condition reported at warning is a missed signal.
+     */
+    private static function assertLogged(string $level, string $needle): void
+    {
+        foreach ($GLOBALS['__twoinc_test_logs'] as $entry) {
+            if ($entry['level'] === $level && strpos($entry['message'], $needle) !== false) {
+                return;
+            }
+        }
+        throw new RuntimeException(
+            'Expected a ' . $level . '-level log containing ' . var_export($needle, true)
+            . '; got ' . var_export($GLOBALS['__twoinc_test_logs'], true)
+        );
+    }
+
     private static function assertClose(float $expected, $actual, string $message = ''): void
     {
         TinyAssert::true(
@@ -3698,17 +3722,75 @@ final class BrandConfigSpec
         TinyAssert::same(1.5, $share['percentage']);
     }
 
-    private static function testBuyerFeeShareWithheldWhenNoRateAvailable(): void
+    private static function testBuyerFeeShareFailsClosedWhenNoRateAvailable(): void
     {
-        // No rate ever fetched: a wrong-currency amount must never be
-        // sent, so the whole surcharge is withheld for the quote (fail
-        // soft to no fee — checkout is never blocked).
+        // No rate ever fetched: a wrong-currency amount must never be sent,
+        // so no fee block is produced. This is the defence-in-depth
+        // backstop — TWO-25269's real answer is the availability gate
+        // withholding the method (see the gate tests below) — and it is
+        // reported at ERROR level, because a silently dropped surcharge
+        // charges the buyer nothing and tells nobody.
         $GLOBALS['__twoinc_test_currency'] = 'NOK';
         $gateway = self::fxGateway(null, [new WP_Error()], [
             'surcharge_type' => 'fixed_and_percentage',
             'surcharge_grid' => [30 => ['fixed' => 2.5, 'percentage' => 1.5, 'limit' => 10.0]],
         ]);
         TinyAssert::same(null, WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30));
+        self::assertLogged('error', 'no FX rate to convert configured EUR amounts to checkout currency NOK');
+    }
+
+    private static function testGateWithholdsMethodWhenSurchargeCurrencyUnquotable(): void
+    {
+        // TWO-25269: the fail-CLOSED answer. Surcharge enabled, store
+        // currency (EUR) diverges from checkout (NOK), a term carries a
+        // monetary component, and no rate exists -> the payment method is
+        // withheld outright rather than the surcharge silently vanishing.
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $gateway = self::fxGateway(null, [new WP_Error()], [
+            'payment_terms_days' => [30],
+            'surcharge_type' => 'fixed_and_percentage',
+            'surcharge_grid' => [30 => ['fixed' => 2.5, 'percentage' => 1.5, 'limit' => 10.0]],
+        ]);
+        $result = $gateway->apply_brand_availability_gate(['woocommerce-gateway-tillit' => 'gw']);
+        TinyAssert::true(!isset($result['woocommerce-gateway-tillit']), 'unquotable surcharge withholds the method');
+        self::assertLogged('error', 'no FX rate for the configured EUR surcharge amounts in checkout currency NOK');
+    }
+
+    private static function testGateKeepsMethodWhenSurchargeIsPercentageOnly(): void
+    {
+        // The FX gate must not over-reject: a percentage-only surcharge is
+        // currency-agnostic, so an unavailable rate is irrelevant to it and
+        // the method stays offered even across currencies.
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $gateway = self::fxGateway(null, [new WP_Error()], [
+            'payment_terms_days' => [30],
+            'surcharge_type' => 'percentage',
+            'surcharge_grid' => [30 => ['percentage' => 1.5]],
+        ]);
+        $result = $gateway->apply_brand_availability_gate(['woocommerce-gateway-tillit' => 'gw']);
+        TinyAssert::same('gw', $result['woocommerce-gateway-tillit']);
+        TinyAssert::same(0, $gateway->fx_requests, 'a percentage-only grid must never consult the FX layer');
+    }
+
+    private static function testGateFxCheckAppliesOnOrderPayEndpoint(): void
+    {
+        // The minimums skip the order-pay endpoint (the session cart is not
+        // the basket being paid for), but FX resolvability does not depend
+        // on a basket and order-pay is exactly a place a surcharge still
+        // gets applied — so the FX check sits OUTSIDE that guard.
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $GLOBALS['__twoinc_test_is_order_pay'] = true;
+        try {
+            $gateway = self::fxGateway(null, [new WP_Error()], [
+                'payment_terms_days' => [30],
+                'surcharge_type' => 'fixed',
+                'surcharge_grid' => [30 => ['fixed' => 2.5]],
+            ]);
+            $result = $gateway->apply_brand_availability_gate(['woocommerce-gateway-tillit' => 'gw']);
+            TinyAssert::true(!isset($result['woocommerce-gateway-tillit']), 'order-pay must still be FX-gated');
+        } finally {
+            unset($GLOBALS['__twoinc_test_is_order_pay']);
+        }
     }
 
     private static function testBuyerFeeShareSameCurrencyNeverTouchesFx(): void
@@ -3725,23 +3807,71 @@ final class BrandConfigSpec
         TinyAssert::same(0, $gateway->fx_requests);
     }
 
-    private static function testBuyerFeeShareCapRoundingToZeroWithholdsWholeSurcharge(): void
+    private static function testBuyerFeeShareCapRoundingToZeroFailsClosed(): void
     {
-        // A cap configured in a strong store currency can round to 0.00
-        // once converted into a much weaker checkout currency. Dropping
-        // only the cap (as an earlier version of this code did) would
-        // send the percentage fee UNCAPPED — the opposite of the
-        // merchant's configuration — so the whole surcharge is withheld
-        // instead, same as the no-rate-available case.
+        // A CONFIGURED cap that rounds to 0.00 once converted fails closed:
+        // a zero cap is indistinguishable from *no* cap downstream, so
+        // relaying it would send the percentage fee UNCAPPED — an
+        // overcharge, the opposite of the merchant's configuration. Now
+        // reported at ERROR level (TWO-25269) instead of silently.
         $GLOBALS['__twoinc_test_currency'] = 'JPY';
         $gateway = self::fxGateway(null, [self::fxOk(['JPY' => 1000000.0])], [
-            // Store currency EUR (default in these tests): a cap of 0.001
-            // EUR converts to 1000000 * 0.001 = 1000 JPY... use an
-            // absurdly weak rate the other way so the cap rounds to 0.
+            // Store currency EUR (default in these tests). The fixture
+            // makes 1 JPY worth 1000000 EUR, i.e. an absurdly weak
+            // EUR->JPY rate, so a 0.001 EUR cap rounds away entirely.
             'surcharge_type' => 'fixed_and_percentage',
-            'surcharge_grid' => [30 => ['fixed' => 0.001, 'percentage' => 1.5, 'limit' => 0.001]],
+            'surcharge_grid' => [30 => ['percentage' => 1.5, 'limit' => 0.001]],
         ]);
         TinyAssert::same(null, WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30));
+        self::assertLogged('error', 'cap rounds to 0.00 in checkout currency JPY, which would relay an UNCAPPED');
+    }
+
+    private static function testBuyerFeeShareFixedRoundingToZeroChargesZero(): void
+    {
+        // A FIXED amount rounding to 0.00 is NOT a failure: a legitimately
+        // tiny configured fee can be genuinely negligible in a stronger
+        // currency, and 0.00 is arithmetically correct. Rejecting the
+        // method because a merchant configured 0.001 would be a WRONG
+        // rejection — so the quote proceeds at 0.00, logged at info, and
+        // the method stays offered.
+        $GLOBALS['__twoinc_test_currency'] = 'JPY';
+        $gateway = self::fxGateway(null, [self::fxOk(['JPY' => 1000000.0])], [
+            'payment_terms_days' => [30],
+            'surcharge_type' => 'fixed',
+            'surcharge_grid' => [30 => ['fixed' => 0.001]],
+        ]);
+        $share = WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30);
+        TinyAssert::true(is_array($share), 'a fixed amount rounding to zero must still produce a fee block');
+        TinyAssert::same(0.0, $share['surcharge']);
+        self::assertLogged('info', 'rounds to 0.00 in checkout currency JPY; charging 0.00');
+
+        $result = $gateway->apply_brand_availability_gate(['woocommerce-gateway-tillit' => 'gw']);
+        TinyAssert::same('gw', $result['woocommerce-gateway-tillit'], 'a zero-rounding fixed fee keeps the method');
+    }
+
+    private static function testBuyerFeeShareAbsentCapChargesUncappedPercentage(): void
+    {
+        // THE regression pin for TWO-25269 item 4: "no cap defined" is a
+        // completely legitimate configuration and must keep charging a
+        // non-zero surcharge, uncapped, with the method offered. Only a cap
+        // that IS configured and rounds away fails closed; absence never
+        // does. Cross-currency so the conversion path really runs with
+        // $cap === null.
+        $GLOBALS['__twoinc_test_currency'] = 'NOK';
+        $gateway = self::fxGateway(null, [self::fxOk(self::FX_TABLE)], [
+            'payment_terms_days' => [30],
+            'surcharge_type' => 'fixed_and_percentage',
+            'surcharge_grid' => [30 => ['fixed' => 2.5, 'percentage' => 1.5]],
+        ]);
+        $share = WC_Twoinc_Payment_Terms::build_buyer_fee_share($gateway, 30);
+        TinyAssert::true(is_array($share), 'an absent cap must not withhold the surcharge');
+        TinyAssert::same(29.41, $share['surcharge'], 'fixed 2.50 EUR at 1/0.085 is 29.41 NOK');
+        TinyAssert::same(1.5, $share['percentage']);
+        TinyAssert::true(!isset($share['cap']), 'no cap configured means no cap key — the percentage is uncapped');
+        TinyAssert::same(0, count($GLOBALS['__twoinc_test_logs']), 'an absent cap must not be logged as a failure');
+
+        $result = $gateway->apply_brand_availability_gate(['woocommerce-gateway-tillit' => 'gw']);
+        TinyAssert::same('gw', $result['woocommerce-gateway-tillit'], 'an absent cap must keep the method offered');
     }
 
     private static function testCartFeeSkippedOnQuoteCurrencyMismatch(): void


### PR DESCRIPTION
## Problem

On an unresolvable store→checkout FX pair, `build_buyer_fee_share()` returned `null` and the **whole surcharge silently vanished** — the buyer was charged nothing, behind a `warning`-level log and, for the rounds-to-zero case, no log at all. Silently changing what is charged is the worst available outcome.

## Fix: fail CLOSED — withhold the payment method

The check reuses the **existing** gate, `apply_brand_availability_gate()` on `woocommerce_available_payment_gateways`, which already fails closed on FX for the minimum-order gates. No second mechanism.

**Condition** (`WC_Twoinc_Payment_Terms::surcharge_currency_unquotable()`):

> surcharge enabled **AND** store currency !== active checkout currency **AND** at least one offered term carries a `fixed` or `cap` component **AND** `WC_Twoinc_FX::get_rate()` returns `null`

It is deliberately **term-independent**. No term is selected when gateway availability is decided, and it does not need to be — `get_rate()` resolves (or fails to resolve) the pair identically for every term, so "no rate at all" is a property of the currency pair. Gating on "some offered term is unquotable" instead would over-reject a shop with one misconfigured term.

**Placement** is deliberately **outside** the `$basket_is_judgeable` guard and **before** the no-gate-and-no-minimums early return: FX resolvability does not depend on a basket, and the `order-pay` endpoint that guard excludes is exactly a place a surcharge still gets applied. A shop with neither a brand gate nor a minimum still charges surcharges.

## The three rounds-to-zero cases, no longer conflated

| Case | Treatment |
| --- | --- |
| No rate resolvable | **FAIL CLOSED** — gate withholds the method; `error` log |
| `cap` **is** configured and its converted value rounds to `0.00` | **FAIL CLOSED** — no fee block; `error` log. A zero cap is indistinguishable from *no* cap downstream, so relaying it would send an **UNCAPPED** percentage — an overcharge, the opposite of what the merchant configured. |
| `fixed` converted value rounds to `0.00` | **NOT a failure.** Proceeds at `0.00`; `info` log. A legitimately tiny configured fee can be genuinely negligible in a stronger currency and `0.00` is arithmetically correct — rejecting a `0.001` configured fee would be a wrong rejection. |

## An absent cap is still fully legitimate

"No cap defined" continues to charge a non-zero **uncapped** percentage surcharge with the method offered. The fail-closed guard fires only when `$cap !== null` **and** the converted value rounds away. Pinned by `testBuyerFeeShareAbsentCapChargesUncappedPercentage`, which runs the cross-currency conversion path with `$cap === null` and asserts: `surcharge` present, `percentage` present, **no** `cap` key, nothing logged as a failure, method still offered.

## Signals

Every fail-closed path logs at **`error`** level (once per request, matching the gate's own convention — removing a payment method is invisible to the merchant), naming the currency pair and the term. Previously: no-rate logged at `warning`, rounds-to-zero logged nothing.

## Comments and docblocks reversed

- `class/WC_Twoinc_FX.php` — class-header "Fail semantics" block: charge conversions now documented as fail **CLOSED**, pointing at the gate.
- `class/WC_Twoinc_FX.php` — `get_rate()` docblock: "gate **and charge** callers must fail closed on it, display callers fail soft".
- `class/WC_Twoinc_Payment_Terms.php` — the fail-soft rationale block above the conversion; the withheld-surcharge log string; the rounds-to-zero rationale comment (now split into the cap and fixed cases); `fetch_term_fee()`'s "checkout is never blocked" claim and the matching inline comment, both now scoped to **transport errors only**.
- `class/WC_Twoinc.php`'s existing fail-CLOSED gate comment was already correct and is untouched; the method docblock gains the new condition.

## Tests

`tests/unit/run.php` — two existing tests updated to the new semantics and renamed; five added; one shared `assertLogged($level, $needle)` helper, because the log **level** is part of the contract when the failure mode is an invisible removal.

- `testBuyerFeeShareFailsClosedWhenNoRateAvailable` (was `…WithheldWhenNoRateAvailable`) — now also asserts the `error` log
- `testGateWithholdsMethodWhenSurchargeCurrencyUnquotable` — the gate itself
- `testGateKeepsMethodWhenSurchargeIsPercentageOnly` — over-rejection guard; also asserts the FX layer is never consulted
- `testGateFxCheckAppliesOnOrderPayEndpoint` — the `order-pay` placement
- `testBuyerFeeShareCapRoundingToZeroFailsClosed` (was `…WithholdsWholeSurcharge`) — cap-only fixture, asserts the `error` log
- `testBuyerFeeShareFixedRoundingToZeroChargesZero` — `0.00` charged, `info` logged, method still offered
- `testBuyerFeeShareAbsentCapChargesUncappedPercentage` — the item-4 regression pin

`testCartFeeSkippedOnQuoteCurrencyMismatch` was checked and needs no change — it asserts on a pricing **response** echoing the wrong currency, which is unrelated to the FX request-side conversion.

## Gates

`make test-unit`, `make phpcs` (0 errors) and `make phpstan` (no errors) all pass locally.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
