### PR TITLE
TWO-25292/ci(i18n): fail when a compiled .mo disagrees with its .po

### DIFF
--- a/.github/scripts/check-catalogues.sh
+++ b/.github/scripts/check-catalogues.sh
@@ -56,7 +56,7 @@ shopt -u nullglob
 
 echo "checking ${#po_files[@]} catalogue(s)"
 
-tmp=$(mktemp -d)
+tmp=$(mktemp -d) || fail "could not create a temporary directory"
 trap 'rm -rf "$tmp"' EXIT
 
 status=0
@@ -97,8 +97,22 @@ for po in "${po_files[@]}"; do
         continue
     fi
 
-    if diff -u --label "$mo (committed)" --label "$po (recompiled)" \
-        "$tmp/committed.po" "$tmp/generated.po" >"$tmp/diff.txt"; then
+    # diff exits 0 for identical, 1 for differing, 2 for trouble. Folding 2
+    # into 1 would report a broken diff as a catalogue mismatch and send the
+    # developer to recompile a catalogue that was fine.
+    diff_status=0
+    diff -u --label "$mo (committed)" --label "$po (recompiled)" \
+        "$tmp/committed.po" "$tmp/generated.po" >"$tmp/diff.txt" 2>"$tmp/diff.err" ||
+        diff_status=$?
+
+    if [ "$diff_status" -gt 1 ]; then
+        echo "::error file=$mo::could not diff this catalogue against its source"
+        sed 's/^/  /' "$tmp/diff.err"
+        status=1
+        continue
+    fi
+
+    if [ "$diff_status" -eq 0 ]; then
         # Byte equality is not required, but its loss is the only warning that
         # the runner's gettext has started encoding differently, so say so.
         if cmp -s "$mo" "$tmp/generated.mo"; then

--- a/.github/scripts/check-catalogues.sh
+++ b/.github/scripts/check-catalogues.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Every committed .mo must agree with its sibling .po (TWO-25292).
+#
+# WordPress reads only the compiled .mo, so a .mo that has drifted from its
+# .po ships wrong copy — or silently reverts to English — on a translated
+# shop, and no other gate can see it. The drift is not hypothetical: .po is
+# text and auto-merges on rebase, while .mo is binary and cannot merge, so
+# resolving a catalogue conflict by keeping either side is wrong in one
+# direction or the other. Keeping "ours" resurrects a msgid the other side
+# deleted; keeping "theirs" drops one this side added.
+#
+# WHY DECODED CATALOGUES RATHER THAN BYTES
+#
+# Byte-comparing the committed .mo against a fresh msgfmt run is the simpler
+# check, and today every committed .mo in this repo is byte-reproducible. But
+# the .mo encoder is free to change between gettext releases (string order,
+# hash table sizing), the CI runners are self-hosted images this repo does not
+# pin, and a byte check would then fail on every unrelated pull request — far
+# worse than no check at all. So the comparison decodes both sides with the
+# same msgunfmt binary in the same job and diffs the result: whatever gettext
+# version the runner carries is applied identically to both sides, and cannot
+# on its own produce a mismatch. `msgfmt --version` is printed so a real
+# toolchain change is still visible in the log.
+#
+# Fuzzy and obsolete entries need no special handling for the same reason:
+# msgfmt drops them, and it drops them from both sides.
+#
+# Usage: .github/scripts/check-catalogues.sh   (run from anywhere)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail() {
+    echo "::error::$*"
+    exit 1
+}
+
+for tool in msgfmt msgunfmt; do
+    command -v "$tool" >/dev/null 2>&1 ||
+        fail "$tool not found — install GNU gettext (apt-get install gettext)"
+done
+
+echo "gettext: $(msgfmt --version | head -1)"
+
+shopt -s nullglob
+po_files=(languages/*.po)
+mo_files=(languages/*.mo)
+shopt -u nullglob
+
+# A glob that matched nothing would make this script vacuously green, which is
+# the one failure mode a guard must not have.
+[ ${#po_files[@]} -gt 0 ] ||
+    fail "no .po files found under languages/ — this check would pass vacuously"
+
+echo "checking ${#po_files[@]} catalogue(s)"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+status=0
+
+for po in "${po_files[@]}"; do
+    mo="${po%.po}.mo"
+
+    if [ ! -f "$mo" ]; then
+        echo "::error file=$po::no compiled catalogue for this source"
+        echo "  fix: msgfmt -o $mo $po"
+        status=1
+        continue
+    fi
+
+    # Compile the source the way a developer would, then decode both sides.
+    if ! msgfmt -o "$tmp/generated.mo" "$po" 2>"$tmp/msgfmt.err"; then
+        echo "::error file=$po::msgfmt cannot compile this source"
+        sed 's/^/  /' "$tmp/msgfmt.err"
+        status=1
+        continue
+    fi
+
+    # A catalogue with no (or a charset-less) header decodes to mojibake rather
+    # than failing, which would turn the diff below into thousands of lines of
+    # "invalid multibyte sequence". Reject it here with something readable.
+    if ! msgfmt --check-header -o /dev/null "$po" 2>"$tmp/hdr.err"; then
+        echo "::error file=$po::catalogue header is missing or malformed"
+        sed 's/^/  /' "$tmp/hdr.err"
+        status=1
+        continue
+    fi
+
+    if ! msgunfmt -o "$tmp/committed.po" "$mo" 2>"$tmp/unfmt.err" ||
+        ! msgunfmt -o "$tmp/generated.po" "$tmp/generated.mo" 2>>"$tmp/unfmt.err"; then
+        echo "::error file=$mo::cannot decode this compiled catalogue"
+        sed 's/^/  /' "$tmp/unfmt.err"
+        status=1
+        continue
+    fi
+
+    if diff -u --label "$mo (committed)" --label "$po (recompiled)" \
+        "$tmp/committed.po" "$tmp/generated.po" >"$tmp/diff.txt"; then
+        # Byte equality is not required, but its loss is the only warning that
+        # the runner's gettext has started encoding differently, so say so.
+        if cmp -s "$mo" "$tmp/generated.mo"; then
+            echo "  ok  $mo"
+        else
+            echo "  ok  $mo (content matches; bytes differ — gettext encoder drift)"
+        fi
+        continue
+    fi
+
+    echo "::error file=$mo::compiled catalogue disagrees with $po — it was not recompiled"
+    echo "  fix: msgfmt -o $mo $po"
+    echo "  '-' lines are in the committed .mo but NOT in the .po (a string the"
+    echo "      .po deleted, still live in the compiled catalogue)"
+    echo "  '+' lines are in the .po but NOT in the committed .mo (a string the"
+    echo "      .po added, missing from the compiled catalogue)"
+    sed 's/^/  /' "$tmp/diff.txt"
+    status=1
+done
+
+# A .mo with no .po cannot be regenerated or reviewed by anyone.
+for mo in "${mo_files[@]}"; do
+    po="${mo%.mo}.po"
+    if [ ! -f "$po" ]; then
+        echo "::error file=$mo::compiled catalogue has no .po source — delete it or add the source"
+        status=1
+    fi
+done
+
+if [ "$status" -ne 0 ]; then
+    echo
+    echo "::error::catalogue check failed — see the per-file errors above."
+    echo "Recompile every locale with: for po in languages/*.po; do msgfmt -o \"\${po%.po}.mo\" \"\$po\"; done"
+    exit 1
+fi
+
+echo "all catalogues agree with their sources"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -8,7 +8,9 @@ concurrency:
   group: static-analysis-${{ github.ref_name }}
   cancel-in-progress: true
 
-# phpcs (PSR-12, phpcs.xml) + phpstan (level 2, phpstan.neon) — TWO-25108.
+# phpcs (PSR-12, phpcs.xml) + phpstan (level 2, phpstan.neon) — TWO-25108 —
+# and the gettext catalogue agreement check (TWO-25292), whose job is at the
+# bottom of this file.
 # The repo has no Composer, so both tools are installed as standalone phars
 # via shivammathur/setup-php `tools:` (same action the unit-test matrix
 # already uses). Tool versions are pinned to the releases the committed
@@ -57,3 +59,22 @@ jobs:
 
       - name: Run phpstan
         run: phpstan analyse --no-progress --memory-limit=4G
+
+  catalogues:
+    name: Gettext catalogues
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      # gettext is not pinned, and does not need to be: the check decodes the
+      # committed .mo and a freshly compiled one with the same binary and
+      # compares the decoded catalogues, so a runner-image toolchain bump
+      # cannot make it fail on its own. See the script header (TWO-25292).
+      - name: Install gettext if the runner image lacks it
+        run: command -v msgfmt >/dev/null || (sudo apt-get update && sudo apt-get install -y gettext)
+
+      - name: Compiled .mo agrees with its .po
+        run: .github/scripts/check-catalogues.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,9 @@ WordPress and WooCommerce Best Practices
 - Check for WooCommerce activation and version compatibility.
 - Gracefully disable functionality if requirements aren't met.
 - Use WooCommerce's translation functions for text strings.
+- After editing any `languages/*.po`, recompile its `.mo` — WordPress reads only
+  the compiled catalogue: `for po in languages/*.po; do msgfmt -o "${po%.po}.mo" "$po"; done`.
+  CI fails when a `.mo` disagrees with its `.po` (`.github/scripts/check-catalogues.sh`).
 - Support RTL languages in your plugin's CSS.
 - Utilize WooCommerce's logging system for debugging.
 - Example: `wc_get_logger()->debug('Your debug message', array('source' => 'your-plugin'));`


### PR DESCRIPTION
## Why

`.po` / `.pot` are text and auto-merge on rebase. The compiled `.mo` is binary and **cannot** merge — and resolving that conflict by keeping either side is silently wrong in one direction or the other:

- keeping **ours** resurrects a msgid the other side deleted
- keeping **theirs** drops a msgid this side added

WordPress reads only the `.mo`, so either way a translated shop ships wrong copy — or silently reverts to English — and nothing in CI could see it. This happened twice in one day: `staging` had removed a msgid (TWO-25287) while a feature branch added two (TWO-25283), and the resurrection was caught only because someone noticed and recompiled all three catalogues by hand.

## What

`.github/scripts/check-catalogues.sh`, wired as a `Gettext catalogues` job on the existing **Static analysis** workflow (no new workflow file). For every `languages/*.po`:

- recompiles it with `msgfmt` and compares against the committed sibling `.mo`
- fails on a `.po` with no `.mo`, a `.mo` with no `.po`, a `.po` msgfmt cannot compile, and a missing/malformed header
- locales are globbed, never listed

Failure output names the file, prints the exact `msgfmt -o <mo> <po>` to run, and states which side each diff line came from (`-` = live in the compiled catalogue but deleted from the `.po`; `+` = added to the `.po` but missing from the `.mo`).

## Decoded catalogues, not bytes

Byte comparison is simpler and every committed `.mo` here *is* currently byte-reproducible (verified with gettext 0.21). It was still rejected: the `.mo` encoder may change between gettext releases, the runners are self-hosted images this repo does not pin, and a byte check would then fail on every unrelated PR — worse than no check.

Instead both sides are decoded with the **same `msgunfmt` binary in the same job**, so whatever gettext the runner carries applies identically to both and cannot on its own produce a mismatch. That makes version pinning unnecessary rather than merely skipped; `msgfmt --version` is printed so a real toolchain change stays visible, and loss of byte-equality is reported as a note rather than a failure. Same reason fuzzy and obsolete entries need no handling — msgfmt drops them from both sides. Comment/line-reference churn in a `.po` correctly does *not* fail the gate, since it is not part of the compiled catalogue.

## Verified by mutation, not inspection

| | result |
|---|---|
| unmodified `staging`, all 3 locales | **PASS** |
| add a msgid to a `.po`, don't recompile | **FAIL** — diff shows `+msgid "…"` missing from the `.mo` |
| remove a msgid from a `.po`, don't recompile (the resurrection case) | **FAIL** — diff shows `-msgid "%s API Key"` still live in the `.mo` |
| then recompile the `.mo` properly | **PASS** |
| delete a `.mo` | **FAIL** — "no compiled catalogue for this source" |
| add a `.mo` with no `.po` | **FAIL** — "compiled catalogue has no .po source" |

An empty `languages/*.po` glob is also a hard failure, so the guard cannot pass vacuously.

## Follow-up worth a decision (not in this PR)

Whether the `.mo` files should be committed at all, or compiled at release time — that removes this class of conflict rather than guarding it. Not acted on; noted on TWO-25292.

Ticket: TWO-25292
