### PR TITLE
feat(TWO-25288): make the manual-entry affordance a keyboard-reachable dropdown option

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -167,19 +167,35 @@
   white-space: nowrap;
 }
 
+/*
+ * Manual-entry row inside the company-search results list (TWO-25288).
+ *
+ * It is an option row now rather than a floating div beside the list, so the
+ * hand-rolled margin is gone: the row inherits the picker's own option padding
+ * and highlight, which is what keeps it in step with the company rows above it
+ * when arrowed onto. Kept as a flat single-id selector so brand overlays that
+ * recolour it keep matching without raising their own specificity.
+ */
 #company_not_in_btn {
   cursor: pointer;
   color: #3043d1;
-  margin: 4px 12px;
 }
 
+/*
+ * The link back out of manual entry. A <button> now, for keyboard
+ * reachability, so the browser's button chrome has to be reset for it to look
+ * like the link it did before.
+ */
 #search_company_btn {
   text-align: right;
   cursor: pointer;
-  padding-top: 5px;
+  padding: 5px 0 0;
   color: #3043d1;
   position: absolute;
   right: 4px;
+  background: none;
+  border: 0;
+  font: inherit;
 }
 
 /* Payment terms chip selector (TWO-24751) */

--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -182,6 +182,24 @@
 }
 
 /*
+ * Highlighted state (TWO-25288). NOT cosmetic — a contrast fix.
+ *
+ * The picker paints its highlighted row white-on-blue, but its own rule is a
+ * class selector (specificity 0,3,1) and the id rule above is 1,0,0, so the
+ * brand blue above wins on the text while the blue background still applies:
+ * roughly 2.5:1, under the 4.5:1 floor, where every real company row in the
+ * same list goes white-on-blue. Restated at the same id specificity so this row
+ * matches its neighbours instead of going unreadable the moment it is arrowed
+ * onto. Both theme prefixes, because which one is present depends on the host
+ * theme's picker build.
+ */
+#company_not_in_btn.select2-results__option--highlighted,
+.select2-container--default #company_not_in_btn.select2-results__option--highlighted,
+.select2-container--classic #company_not_in_btn.select2-results__option--highlighted {
+  color: #ffffff;
+}
+
+/*
  * The link back out of manual entry. A <button> now, for keyboard
  * reachability, so the browser's button chrome has to be reset for it to look
  * like the link it did before.

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -98,9 +98,14 @@ let twoincSelectWooHelper = {
    *
    * It has to be an id and not a flag: the picker stringifies every navigable
    * row's `data.id` when it recomputes selected state, so a row without one
-   * throws and takes the whole results render with it. And it must not be
-   * mistakable for a company: `processResults` below maps each hit's id to the
-   * company NAME, so the sentinel is deliberately not a plausible one.
+   * throws and takes the whole results render with it.
+   *
+   * `processResults` below maps each hit's id to the company NAME, so this
+   * value shares a namespace with company names and the underscores are there
+   * to keep it out of the way. That is a convention, NOT an enforced
+   * invariant — nothing rejects a registry name that happened to equal it, and
+   * no test claims otherwise. If that ever needs to be a guarantee, the
+   * discriminator has to move off `id` onto a field of its own.
    */
   manualEntrySentinelId: "__twoinc_manual_entry__",
 
@@ -186,20 +191,30 @@ let twoincSelectWooHelper = {
    * genuine option row now, which is what makes it arrow-reachable and
    * announced without a bespoke keydown bridge.
    *
-   * Every attribute here is load-bearing:
+   * This mirrors, attribute for attribute, what the picker's own option
+   * factory produces for a real result row. Three of them are load-bearing:
    *
-   *  - the bundled picker's navigable set is the rows carrying a
-   *    `data-selected` attribute, while select2 4.1 keys off the
-   *    `--selectable` class instead. A host theme may supply either, so the
-   *    row carries both and is reachable under both.
-   *  - `data-selected` must stay "false". "true" means "already picked", and
-   *    the picker routes activation of an already-picked row to closing the
-   *    dropdown instead of selecting it — the row would look reachable and do
-   *    nothing.
+   *  - `data-selected` is how the picker derives its navigable set, and it must
+   *    stay "false". "true" means "already picked", and the picker routes
+   *    activation of an already-picked row to closing the dropdown instead of
+   *    selecting it — the row would look reachable and do nothing.
+   *  - `tabindex="-1"` makes the row programmatically focusable. On every arrow
+   *    keypress the picker calls `.focus()` on the highlighted row, and its own
+   *    source says that is required for screen readers to work. An <li> with no
+   *    tabindex cannot take focus, so that call is a silent no-op and focus
+   *    stays stranded on the PREVIOUS row while this one is visually
+   *    highlighted — the reader keeps announcing the wrong thing.
    *  - the payload goes on with jQuery `data`, which is where the picker reads
    *    each row's data from, and it must carry `_resultId` matching the li's
-   *    id: that is what the picker copies into aria-activedescendant when the
-   *    row is highlighted. Without it the row is reachable but silent.
+   *    id: that is what the picker copies into `aria-activedescendant`, on both
+   *    the dropdown's search field and the selection container. Without it the
+   *    row is reachable but silent.
+   *
+   * `select2-results__option--selectable` is belt-and-braces only. The bundle
+   * pinned here never reads it — it is a select2 4.1 concept, and that string
+   * does not occur anywhere in this build. It costs nothing and keeps the row
+   * navigable if a host platform ever swaps the picker for one that keys off
+   * the class instead of the attribute. Do not describe it as required.
    *
    * @returns {Object} jQuery-wrapped <li>
    */
@@ -212,7 +227,8 @@ let twoincSelectWooHelper = {
         id: helper.manualEntryRowId,
         role: "option",
         "aria-selected": "false",
-        "data-selected": "false"
+        "data-selected": "false",
+        tabindex: -1
       })
       .addClass("select2-results__option select2-results__option--selectable")
       .text(label);
@@ -244,6 +260,18 @@ let twoincSelectWooHelper = {
     const picker = jQuery("#billing_company_display").data("select2");
     if (!picker || !picker.$results || !picker.$results.length) return;
 
+    // Self-healing, and deliberately here rather than in the bind function.
+    // The widget is re-created in places that have no reason to know this
+    // affordance exists — clearing the selected company does it, which is the
+    // "un-pick that company, let me search again" gesture that most often
+    // precedes needing this row. A new widget means a NEW results node, so a
+    // flag set on the old one says nothing, and the observer would simply never
+    // be installed again: the row would appear on a keystroke and then be wiped
+    // by the first render, permanently. Installing from the per-keystroke sync
+    // covers every re-creation, including future ones, without a third bind
+    // site to keep in step.
+    helper.observeResultsList(picker.$results);
+
     const $list = picker.$results;
     const $existing = $list.children("#" + helper.manualEntryRowId);
     const term = jQuery(helper.companySearchInputSelector).val() || "";
@@ -261,6 +289,48 @@ let twoincSelectWooHelper = {
 
     $existing.remove();
     $list.append(helper.buildManualEntryRow());
+  },
+
+  /**
+   * The live MutationObserver watching the results list, if any (TWO-25288).
+   */
+  manualEntryObserver: null,
+
+  /**
+   * Latched between activating the manual-entry row and the deferred switch
+   * actually running (TWO-25288). Cleared by that switch.
+   */
+  manualEntryPending: false,
+
+  /**
+   * Watch a results list so the row can be put back after every render
+   * (TWO-25288).
+   *
+   * The picker empties the whole list on each render — a new result set, the
+   * "searching" state, a message — so watching the list covers all of them
+   * without guessing at which internal events fire.
+   *
+   * At most ONE observer exists at a time. The previous one is disconnected
+   * before a new list is observed, so the enter/exit and clear-company cycles
+   * cannot accumulate one orphan per widget for the life of the page.
+   *
+   * @param {Object} $list jQuery-wrapped results <ul>
+   * @returns {void}
+   */
+  observeResultsList: function ($list) {
+    const helper = twoincSelectWooHelper;
+
+    if (!$list || !$list.length || typeof MutationObserver !== "function") return;
+    // Already watching this exact node.
+    if ($list.data("twoincManualEntryObserved")) return;
+
+    if (helper.manualEntryObserver) helper.manualEntryObserver.disconnect();
+
+    $list.data("twoincManualEntryObserved", true);
+    helper.manualEntryObserver = new MutationObserver(function () {
+      helper.syncManualEntryRow();
+    });
+    helper.manualEntryObserver.observe($list[0], { childList: true });
   },
 
   /**
@@ -291,23 +361,12 @@ let twoincSelectWooHelper = {
         helper.syncManualEntryRow();
       });
 
-    // The picker empties the whole results list on every render — a new
-    // result set, the "searching" state, a message — so the row has to be put
-    // back after each one. Watching the list covers all of those without
-    // guessing at which internal events fire.
+    // Install the render watcher eagerly too, so a dropdown opened and
+    // re-rendered before the buyer types anything is already covered. The sync
+    // installs it as well, which is what makes a widget re-created elsewhere
+    // heal itself; both routes go through the same one-at-a-time guard.
     const picker = $select.data("select2");
-    if (
-      picker &&
-      picker.$results &&
-      picker.$results.length &&
-      !picker.$results.data("twoincManualEntryObserved") &&
-      typeof MutationObserver === "function"
-    ) {
-      picker.$results.data("twoincManualEntryObserved", true);
-      new MutationObserver(function () {
-        helper.syncManualEntryRow();
-      }).observe(picker.$results[0], { childList: true });
-    }
+    if (picker) helper.observeResultsList(picker.$results);
 
     // Activation, keyboard and mouse through one path. The picker turns both
     // Enter on the highlighted row and a click on it into the same internal
@@ -323,6 +382,14 @@ let twoincSelectWooHelper = {
         // Prevented, so the selection is never written: no company name, no
         // company id, no approval call, no address lookup.
         e.preventDefault();
+
+        // Because the selection is prevented the dropdown does NOT close, so
+        // the row is still sitting in the list and still activatable. Drop it
+        // and latch, or a repeated activation inside the same tick queues one
+        // deferred entry per activation.
+        if (helper.manualEntryPending) return;
+        helper.manualEntryPending = true;
+        jQuery("#" + helper.manualEntryRowId).remove();
 
         // Deferred out of the picker's own event dispatch. Entering manual
         // entry destroys this widget, and destroying it from inside its own
@@ -1053,6 +1120,12 @@ let twoincDomHelper = {
     window.twoinc.enable_company_search = "no";
 
     jQuery("#billing_company_display").val("");
+    // The real company field too, not just the display one. Without this the
+    // manual field the buyer is about to be shown is pre-filled with the
+    // company they have just said is NOT theirs, while its org-number twin is
+    // empty — and the exit path clears this same mirror, so leaving it here
+    // would be asymmetric on top of wrong.
+    jQuery("#billing_company").val("");
     jQuery("#company_id").val("");
     Twoinc.getInstance().customerCompany = twoincDomHelper.getCompanyData();
 
@@ -1067,6 +1140,14 @@ let twoincDomHelper = {
     twoincDomHelper.getSearchCompanyBtnNode().show();
 
     twoincDomHelper.toggleBusinessFields();
+
+    // Destroying the widget leaves focus on nothing — activeElement falls back
+    // to <body> — so a keyboard or AT user loses their place mid-checkout and
+    // has to tab in from the top of the document. Hand focus to the field they
+    // asked to be given.
+    twoincDomHelper.focusVisibleCompanyField("#billing_company");
+
+    twoincSelectWooHelper.manualEntryPending = false;
   },
 
   /**
@@ -1085,6 +1166,35 @@ let twoincDomHelper = {
 
     twoincDomHelper.getSearchCompanyBtnNode().hide();
     twoincDomHelper.toggleBusinessFields();
+
+    // Mirrors the enter path: the button that had focus is now hidden, so
+    // without this focus is stranded on a display:none element.
+    //
+    // NOT #billing_company_display — the picker hides that <select> and moves
+    // its accessible role onto the rendered combobox, which is the element
+    // carrying tabindex and the one a buyer can actually see.
+    if (
+      !twoincDomHelper.focusVisibleCompanyField("#billing_company_display_field .select2-selection")
+    ) {
+      twoincDomHelper.focusVisibleCompanyField("#billing_company_display");
+    }
+  },
+
+  /**
+   * Move focus to a company field, if it is actually focusable (TWO-25288).
+   *
+   * Guarded rather than a bare `.focus()`: both callers run on surfaces where
+   * the target may be absent (the pay-for-order page renders a different set)
+   * and `.focus()` on an empty set is a silent no-op that reads as success.
+   *
+   * @param {string} selector the field to focus
+   * @returns {boolean} whether focus was moved
+   */
+  focusVisibleCompanyField: function (selector) {
+    const $field = jQuery(selector);
+    if (!$field.length || $field.prop("disabled")) return false;
+    $field.trigger("focus");
+    return jQuery(document.activeElement).is($field);
   },
 
   /**
@@ -1793,9 +1903,8 @@ let twoincSoleTrader = {
     twoincSoleTrader.updateChips();
 
     if (mode === "sole_trader") {
-      // Suppress company search by the same lever the "company not in
-      // list" button uses, restoring the merchant's setting on the way
-      // back to business mode.
+      // Suppress company search by the same lever the manual-entry row uses,
+      // restoring the merchant's setting on the way back to business mode.
       if (twoincSoleTrader.savedCompanySearch === null) {
         twoincSoleTrader.savedCompanySearch = window.twoinc.enable_company_search;
       }
@@ -1804,7 +1913,9 @@ let twoincSoleTrader = {
       if ($display.data("select2")) {
         $display.select2("destroy");
       }
-      jQuery("#company_not_in_btn, #search_company_btn").hide();
+      // Only the link back to search: the manual-entry row lives inside the
+      // dropdown and goes with the widget that was just destroyed (TWO-25288).
+      jQuery("#" + twoincSelectWooHelper.searchCompanyBtnId).hide();
       jQuery("#billing_company, #company_id").prop("readonly", true);
       twoincDomHelper.toggleBusinessFields();
     } else {
@@ -1817,6 +1928,14 @@ let twoincSoleTrader = {
       twoincSoleTrader.setCompany("", "");
       twoincDomHelper.toggleBusinessFields();
       Twoinc.getInstance().enableCompanySearch();
+      // The buyer may have been in MANUAL entry when they switched to sole
+      // trader, in which case the snapshot restored above is "no" and
+      // enableCompanySearch has just early-returned. Without this the link
+      // back to search stays hidden and business mode has no route back to
+      // the picker at all (TWO-25288).
+      if (window.twoinc.enable_company_search !== "yes") {
+        twoincDomHelper.getSearchCompanyBtnNode().show();
+      }
     }
   },
 

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -76,6 +76,35 @@ let twoincSelectWooHelper = {
   companySearchMinLength: 3,
 
   /**
+   * The dropdown's own search field. select2 tears the dropdown down and
+   * rebuilds it on every open, so this node is never the same one twice and
+   * nothing may hold a reference to it — every use is a fresh lookup, and
+   * every handler on it is delegated.
+   */
+  companySearchInputSelector: 'input[aria-owns="select2-billing_company_display-results"]',
+
+  /**
+   * DOM id of the manual-entry pseudo-option (TWO-25288). Unchanged from when
+   * this was a cloned <div> so the stylesheet rule and the brand overlays that
+   * match it keep working.
+   */
+  manualEntryRowId: "company_not_in_btn",
+
+  /** DOM id of the link back out of manual entry and into search. */
+  searchCompanyBtnId: "search_company_btn",
+
+  /**
+   * The `id` on the manual-entry row's payload object (TWO-25288).
+   *
+   * It has to be an id and not a flag: the picker stringifies every navigable
+   * row's `data.id` when it recomputes selected state, so a row without one
+   * throws and takes the whole results render with it. And it must not be
+   * mistakable for a company: `processResults` below maps each hit's id to the
+   * company NAME, so the sentinel is deliberately not a plausible one.
+   */
+  manualEntrySentinelId: "__twoinc_manual_entry__",
+
+  /**
    * Text for a company search that could not be completed. Read lazily
    * because window.twoinc is populated by the checkout render; the literal
    * is the last-resort fallback for a page where the localised string is
@@ -127,6 +156,180 @@ let twoincSelectWooHelper = {
     // `#, php-format` family of placeholders is what they would reach for. The
     // msgid itself stays `%d` — changing it would invalidate the catalogues.
     return template.replace(/%(\d+\$)?d/, twoincSelectWooHelper.companySearchMinLength);
+  },
+
+  /**
+   * Label of the manual-entry row (TWO-25288). Read lazily for the same
+   * reason as the hints above.
+   */
+  companyNotInListText: function () {
+    return (
+      (window.twoinc && window.twoinc.text && window.twoinc.text.company_not_in_list) ||
+      "My company is not on the list"
+    );
+  },
+
+  /** Label of the link back out of manual entry and into search. */
+  searchCompanyText: function () {
+    return (
+      (window.twoinc && window.twoinc.text && window.twoinc.text.search_company) ||
+      "Search for company"
+    );
+  },
+
+  /**
+   * Build the manual-entry row as a real pseudo-option (TWO-25288).
+   *
+   * This used to be a cloned <div> appended to the results list's PARENT, i.e.
+   * outside the subtree the field's aria-owns points at — so it had no role,
+   * no id, no payload, and was not reachable by keyboard at all. It is a
+   * genuine option row now, which is what makes it arrow-reachable and
+   * announced without a bespoke keydown bridge.
+   *
+   * Every attribute here is load-bearing:
+   *
+   *  - the bundled picker's navigable set is the rows carrying a
+   *    `data-selected` attribute, while select2 4.1 keys off the
+   *    `--selectable` class instead. A host theme may supply either, so the
+   *    row carries both and is reachable under both.
+   *  - `data-selected` must stay "false". "true" means "already picked", and
+   *    the picker routes activation of an already-picked row to closing the
+   *    dropdown instead of selecting it — the row would look reachable and do
+   *    nothing.
+   *  - the payload goes on with jQuery `data`, which is where the picker reads
+   *    each row's data from, and it must carry `_resultId` matching the li's
+   *    id: that is what the picker copies into aria-activedescendant when the
+   *    row is highlighted. Without it the row is reachable but silent.
+   *
+   * @returns {Object} jQuery-wrapped <li>
+   */
+  buildManualEntryRow: function () {
+    const helper = twoincSelectWooHelper;
+    const label = helper.companyNotInListText();
+
+    const $row = jQuery("<li></li>")
+      .attr({
+        id: helper.manualEntryRowId,
+        role: "option",
+        "aria-selected": "false",
+        "data-selected": "false"
+      })
+      .addClass("select2-results__option select2-results__option--selectable")
+      .text(label);
+
+    $row.data("data", {
+      id: helper.manualEntrySentinelId,
+      text: label,
+      _resultId: helper.manualEntryRowId
+    });
+
+    return $row;
+  },
+
+  /**
+   * Put the manual-entry row at the end of the results list, or take it away
+   * (TWO-25288).
+   *
+   * Visibility rule is the search threshold and nothing else — no
+   * "has a search completed" gate. The row appears the moment the buyer has
+   * typed enough for a search to be worth running, which is BEFORE the
+   * debounced request goes out, so a buyer who already knows their company is
+   * not in the registry never has to wait for a round trip to find that out.
+   *
+   * @returns {void}
+   */
+  syncManualEntryRow: function () {
+    const helper = twoincSelectWooHelper;
+
+    const picker = jQuery("#billing_company_display").data("select2");
+    if (!picker || !picker.$results || !picker.$results.length) return;
+
+    const $list = picker.$results;
+    const $existing = $list.children("#" + helper.manualEntryRowId);
+    const term = jQuery(helper.companySearchInputSelector).val() || "";
+
+    if (term.length < helper.companySearchMinLength) {
+      $existing.remove();
+      return;
+    }
+
+    // Already the last row: do nothing. This early return is load-bearing,
+    // not an optimisation — this function is also called from a
+    // MutationObserver watching the same list, so an unconditional append
+    // would re-enter itself forever.
+    if ($existing.length && $list.children().last().is($existing)) return;
+
+    $existing.remove();
+    $list.append(helper.buildManualEntryRow());
+  },
+
+  /**
+   * Wire the manual-entry affordance to a company-search widget (TWO-25288).
+   *
+   * Idempotent by construction. Every handler is namespaced and every bind is
+   * preceded by the matching `.off()`, so calling this again — and it IS
+   * called again, from the 800ms re-run of enableCompanySearch and from every
+   * return out of manual entry — leaves exactly one handler of each kind.
+   * The previous implementation bound its input handler inside a polling
+   * callback on every dropdown open with no `.off()`, which both accumulated
+   * duplicates and missed the first keystrokes of anyone typing faster than
+   * the poll interval.
+   *
+   * @param {Object} $select jQuery-wrapped company-search <select>
+   * @returns {void}
+   */
+  bindManualEntryAffordance: function ($select) {
+    const helper = twoincSelectWooHelper;
+
+    // Delegated on <body> rather than bound to the search field: that field
+    // is destroyed and rebuilt on every open, and delegation means the
+    // handler exists before the buyer's first keystroke rather than after a
+    // poll notices the field appeared.
+    jQuery(document.body)
+      .off("input.twoincManualEntry")
+      .on("input.twoincManualEntry", helper.companySearchInputSelector, function () {
+        helper.syncManualEntryRow();
+      });
+
+    // The picker empties the whole results list on every render — a new
+    // result set, the "searching" state, a message — so the row has to be put
+    // back after each one. Watching the list covers all of those without
+    // guessing at which internal events fire.
+    const picker = $select.data("select2");
+    if (
+      picker &&
+      picker.$results &&
+      picker.$results.length &&
+      !picker.$results.data("twoincManualEntryObserved") &&
+      typeof MutationObserver === "function"
+    ) {
+      picker.$results.data("twoincManualEntryObserved", true);
+      new MutationObserver(function () {
+        helper.syncManualEntryRow();
+      }).observe(picker.$results[0], { childList: true });
+    }
+
+    // Activation, keyboard and mouse through one path. The picker turns both
+    // Enter on the highlighted row and a click on it into the same internal
+    // select, and fires a preventable pre-event first — so intercepting that
+    // one event covers both inputs, and there is no separate click handler
+    // that could double-fire or drift out of step with the keyboard one.
+    $select
+      .off("select2:selecting.twoincManualEntry")
+      .on("select2:selecting.twoincManualEntry", function (e) {
+        const data = e.params && e.params.args && e.params.args.data;
+        if (!data || data.id !== helper.manualEntrySentinelId) return;
+
+        // Prevented, so the selection is never written: no company name, no
+        // company id, no approval call, no address lookup.
+        e.preventDefault();
+
+        // Deferred out of the picker's own event dispatch. Entering manual
+        // entry destroys this widget, and destroying it from inside its own
+        // trigger would pull the DOM out from under the code that is still
+        // unwinding.
+        setTimeout(twoincDomHelper.enterManualCompanyEntry, 0);
+      });
   },
 
   /**
@@ -601,6 +804,34 @@ let twoincDomHelper = {
     // Toggle the required fields based on the account type
     twoincDomHelper.toggleRequiredCues(allTargets, false);
     twoincDomHelper.toggleRequiredCues(requiredTargets, isTwoincSelected);
+
+    twoincDomHelper.syncCompanyFieldWrappers();
+  },
+
+  /**
+   * Mirror each company field's visibility onto its enclosing wrapper
+   * (TWO-25288).
+   *
+   * The pay-for-order page lays its copy of the company inputs out in
+   * per-field wrappers, each carrying its own hidden state that the function
+   * above does not touch — so hiding or revealing the field inside one has no
+   * visible effect there. Manual entry was unreachable on that page until now,
+   * which is the only reason that has not shown up: switching to it would have
+   * revealed a company field still inside a hidden wrapper, leaving the buyer
+   * with nowhere to type. The checkout page has no such wrappers and this is a
+   * no-op there.
+   *
+   * @returns {void}
+   */
+  syncCompanyFieldWrappers: function () {
+    jQuery("#billing_company_display_field, #billing_company_field, #company_id_field").each(
+      function () {
+        const $field = jQuery(this);
+        const $wrapper = $field.closest(".twoinc-inp-container");
+        if (!$wrapper.length) return;
+        $wrapper.toggleClass("hidden", $field.hasClass("hidden"));
+      }
+    );
   },
 
   /**
@@ -787,15 +1018,73 @@ let twoincDomHelper = {
   },
 
   /**
-   * Get the company-not-in-btn, generate if not found
+   * Get the link back out of manual entry and into company search, building it
+   * hidden on first use (TWO-25288).
+   *
+   * A real <button> rather than the <div> this used to be. The div had no
+   * href, no role and no tabindex, so the only way out of manual entry was a
+   * mouse click; type="button" is what keeps a button inside the checkout form
+   * from submitting it.
+   *
+   * @returns {Object} jQuery-wrapped button
    */
-  getCompanyNotInBtnNode: function () {
-    if (jQuery("#company_not_in_btn").length) return jQuery("#company_not_in_btn");
+  getSearchCompanyBtnNode: function () {
+    const id = twoincSelectWooHelper.searchCompanyBtnId;
 
-    let companyNotInBtn = jQuery(".company_not_in_btn").clone();
-    companyNotInBtn.attr("id", "company_not_in_btn");
-    companyNotInBtn.removeClass("company_not_in_btn");
-    return companyNotInBtn;
+    let $btn = jQuery("#" + id);
+    if ($btn.length) return $btn;
+
+    $btn = jQuery("<button></button>")
+      .attr({ id: id, type: "button" })
+      .text(twoincSelectWooHelper.searchCompanyText())
+      .hide();
+    jQuery("#billing_company_field").append($btn);
+    return $btn;
+  },
+
+  /**
+   * Switch the company field from search to manual entry (TWO-25288).
+   *
+   * Reached only from the manual-entry row's activation, keyboard or mouse.
+   *
+   * @returns {void}
+   */
+  enterManualCompanyEntry: function () {
+    window.twoinc.enable_company_search = "no";
+
+    jQuery("#billing_company_display").val("");
+    jQuery("#company_id").val("");
+    Twoinc.getInstance().customerCompany = twoincDomHelper.getCompanyData();
+
+    // Looked up from the DOM rather than through the cached
+    // billingCompanySelect: enableCompanySearch can have re-attached the
+    // widget since that reference was taken, and the one to tear down is
+    // whichever one is currently attached.
+    const $display = jQuery("#billing_company_display");
+    if ($display.data("select2")) $display.select2("destroy");
+
+    jQuery("#" + twoincSelectWooHelper.manualEntryRowId).remove();
+    twoincDomHelper.getSearchCompanyBtnNode().show();
+
+    twoincDomHelper.toggleBusinessFields();
+  },
+
+  /**
+   * Switch the company field back from manual entry to search (TWO-25288).
+   *
+   * @returns {void}
+   */
+  exitManualCompanyEntry: function () {
+    window.twoinc.enable_company_search = "yes";
+
+    Twoinc.getInstance().enableCompanySearch();
+
+    jQuery("#billing_company").val("");
+    jQuery("#company_id").val("");
+    Twoinc.getInstance().customerCompany = twoincDomHelper.getCompanyData();
+
+    twoincDomHelper.getSearchCompanyBtnNode().hide();
+    twoincDomHelper.toggleBusinessFields();
   },
 
   /**
@@ -1836,25 +2125,17 @@ class Twoinc {
 
     twoincSelectWooHelper.fixSelectWooPositionCompanyName();
 
+    // Manual-entry affordance (TWO-25288). Bound here, once per widget, rather
+    // than on every dropdown open: the handlers it installs are delegated and
+    // outlive the dropdown, so re-binding them per open only ever accumulated
+    // duplicates.
+    twoincSelectWooHelper.bindManualEntryAffordance(self.billingCompanySelect);
+
     self.billingCompanySelect.on("select2:open", function (e) {
-      let companyNotInBtn = twoincDomHelper.getCompanyNotInBtnNode();
-      jQuery("#select2-billing_company_display-results").parent().append(companyNotInBtn);
-      twoincSelectWooHelper.waitToFocus("billing_company_display", null, null, function () {
-        jQuery('input[aria-owns="select2-billing_company_display-results"]').on(
-          "input",
-          function (e) {
-            let selectWooParams = twoincSelectWooHelper.genSelectWooParams();
-            if (
-              jQuery(this).val() &&
-              jQuery(this).val().length >= selectWooParams.minimumInputLength
-            ) {
-              jQuery("#company_not_in_btn").show();
-            } else {
-              jQuery("#company_not_in_btn").hide();
-            }
-          }
-        );
-      });
+      // Arguments kept verbatim: waitToFocus treats an explicit null as a
+      // value rather than a default, so dropping them would change the poll
+      // timing of the focus fix, which is not what this change is about.
+      twoincSelectWooHelper.waitToFocus("billing_company_display", null, null);
       twoincSelectWooHelper.addSelectWooFocusFixHandler("billing_company_display");
     });
   }
@@ -1903,30 +2184,13 @@ class Twoinc {
     // Disable or enable actions based on the account type
     $body.on("updated_checkout", Twoinc.getInstance().onUpdatedCheckout);
 
-    $body.on("click", "#company_not_in_btn", function () {
-      window.twoinc.enable_company_search = "no";
-
-      jQuery("#billing_company_display").val("");
-      jQuery("#company_id").val("");
-      Twoinc.getInstance().customerCompany = twoincDomHelper.getCompanyData();
-      jQuery("#company_not_in_btn").hide();
-      jQuery("#search_company_btn").show();
-      Twoinc.getInstance().billingCompanySelect.select2("destroy");
-
-      twoincDomHelper.toggleBusinessFields();
-    });
-
-    $body.on("click", "#search_company_btn", function () {
-      window.twoinc.enable_company_search = "yes";
-
-      self.enableCompanySearch();
-
-      jQuery("#billing_company").val("");
-      jQuery("#company_id").val("");
-      Twoinc.getInstance().customerCompany = twoincDomHelper.getCompanyData();
-
-      jQuery("#search_company_btn").hide();
-      twoincDomHelper.toggleBusinessFields();
+    // No click handler for the manual-entry row (TWO-25288). It is a pseudo-
+    // option inside the results list now, so the picker already turns a click
+    // on it into the same internal select that Enter does, and
+    // bindManualEntryAffordance intercepts that one event for both. A second,
+    // click-only path here would fire alongside it on every mouse activation.
+    $body.on("click", "#" + twoincSelectWooHelper.searchCompanyBtnId, function () {
+      twoincDomHelper.exitManualCompanyEntry();
     });
 
     // Handle the representative inputs blur event
@@ -2442,10 +2706,9 @@ jQuery(function () {
       // Otherwise do not run Twoinc code
     }
 
-    // I can not find my company button
-    jQuery("#billing_company_field").append(jQuery("#search_company_btn"));
-    jQuery("#company_not_in_btn").hide();
-    jQuery("#search_company_btn").hide();
+    // Nothing to relocate or hide here any more (TWO-25288): the manual-entry
+    // row is created inside the results list only while it should be visible,
+    // and the link back to search is created hidden, in place, on first use.
 
     setTimeout(function () {
       // Init the hidden Company name field

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -297,12 +297,6 @@ let twoincSelectWooHelper = {
   manualEntryObserver: null,
 
   /**
-   * Latched between activating the manual-entry row and the deferred switch
-   * actually running (TWO-25288). Cleared by that switch.
-   */
-  manualEntryPending: false,
-
-  /**
    * Watch a results list so the row can be put back after every render
    * (TWO-25288).
    *
@@ -345,11 +339,18 @@ let twoincSelectWooHelper = {
    * duplicates and missed the first keystrokes of anyone typing faster than
    * the poll interval.
    *
-   * @param {Object} $select jQuery-wrapped company-search <select>
+   * Takes no widget argument on purpose. Everything below is specific to the
+   * company-search field — the delegated selector and the sync both name it —
+   * so a parameter would have to be that one element every time. A probe
+   * mutation confirmed it: reassigning the argument to a fresh lookup of that
+   * same field changed nothing and no test noticed, which is a signature
+   * claiming generality the body does not have.
+   *
    * @returns {void}
    */
-  bindManualEntryAffordance: function ($select) {
+  bindManualEntryAffordance: function () {
     const helper = twoincSelectWooHelper;
+    const $select = jQuery("#billing_company_display");
 
     // Delegated on <body> rather than bound to the search field: that field
     // is destroyed and rebuilt on every open, and delegation means the
@@ -384,11 +385,16 @@ let twoincSelectWooHelper = {
         e.preventDefault();
 
         // Because the selection is prevented the dropdown does NOT close, so
-        // the row is still sitting in the list and still activatable. Drop it
-        // and latch, or a repeated activation inside the same tick queues one
-        // deferred entry per activation.
-        if (helper.manualEntryPending) return;
-        helper.manualEntryPending = true;
+        // the row would otherwise still be sitting in the list and still
+        // activatable — and a repeated activation in the same tick would queue
+        // one deferred switch per press. Removing the row up front is what
+        // prevents that: the picker resolves an activation through the
+        // highlighted row, and there is no longer one.
+        //
+        // A `pending` latch was tried here as well and removed: with the row
+        // already gone it could not be reached by any path, so it was
+        // untestable defensive code. One mechanism that a test can fail is
+        // worth more than two where neither is exercised alone.
         jQuery("#" + helper.manualEntryRowId).remove();
 
         // Deferred out of the picker's own event dispatch. Entering manual
@@ -1146,8 +1152,6 @@ let twoincDomHelper = {
     // has to tab in from the top of the document. Hand focus to the field they
     // asked to be given.
     twoincDomHelper.focusVisibleCompanyField("#billing_company");
-
-    twoincSelectWooHelper.manualEntryPending = false;
   },
 
   /**
@@ -2248,7 +2252,7 @@ class Twoinc {
     // than on every dropdown open: the handlers it installs are delegated and
     // outlive the dropdown, so re-binding them per open only ever accumulated
     // duplicates.
-    twoincSelectWooHelper.bindManualEntryAffordance(self.billingCompanySelect);
+    twoincSelectWooHelper.bindManualEntryAffordance();
 
     self.billingCompanySelect.on("select2:open", function (e) {
       // Arguments kept verbatim: waitToFocus treats an explicit null as a

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -362,12 +362,12 @@ let twoincSelectWooHelper = {
         helper.syncManualEntryRow();
       });
 
-    // Install the render watcher eagerly too, so a dropdown opened and
-    // re-rendered before the buyer types anything is already covered. The sync
-    // installs it as well, which is what makes a widget re-created elsewhere
-    // heal itself; both routes go through the same one-at-a-time guard.
-    const picker = $select.data("select2");
-    if (picker) helper.observeResultsList(picker.$results);
+    // No eager render-watcher install here. It was tried and removed: the row
+    // cannot exist before the buyer has typed to the threshold, and typing is
+    // what runs the sync, which installs the watcher against whatever results
+    // list is live. Removing the eager copy left the suite green, i.e. nothing
+    // depended on it — and one install point that heals every widget
+    // re-creation is easier to reason about than two.
 
     // Activation, keyboard and mouse through one path. The picker turns both
     // Enter on the highlighted row and a click on it into the same internal

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1133,6 +1133,19 @@ let twoincDomHelper = {
     // would be asymmetric on top of wrong.
     jQuery("#billing_company").val("");
     jQuery("#company_id").val("");
+
+    // The registry address too, mirroring clearSelectedCompany. The buyer has
+    // just said the looked-up company is not theirs; leaving its registered
+    // address behind ships the order to it, in fields the buyer never visibly
+    // touched and would have no reason to check.
+    if (window.twoinc.enable_address_lookup === "yes") {
+      Twoinc.getInstance().setAddress({
+        street_address: "",
+        city: "",
+        postal_code: ""
+      });
+    }
+
     Twoinc.getInstance().customerCompany = twoincDomHelper.getCompanyData();
 
     // Looked up from the DOM rather than through the cached

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1043,6 +1043,7 @@ let twoincDomHelper = {
         postal_code: ""
       });
     }
+    Twoinc.getInstance().registryAddressApplied = false;
 
     jQuery("#select2-billing_company_display-container")
       .parent()
@@ -1125,12 +1126,6 @@ let twoincDomHelper = {
   enterManualCompanyEntry: function () {
     window.twoinc.enable_company_search = "no";
 
-    // Read BEFORE the field below is blanked: this is the only evidence that a
-    // company was actually picked (and its address therefore possibly looked
-    // up), as opposed to the row being reached by typing straight to the
-    // threshold and never selecting anything — the ordinary path.
-    const hadPickedCompany = !!jQuery("#company_id").val();
-
     jQuery("#billing_company_display").val("");
     // The real company field too, not just the display one. Without this the
     // manual field the buyer is about to be shown is pre-filled with the
@@ -1141,18 +1136,22 @@ let twoincDomHelper = {
     jQuery("#company_id").val("");
 
     // The registry address too, mirroring clearSelectedCompany — but ONLY when
-    // a pick actually happened. Reaching manual entry does not imply a lookup
-    // ran: the row is live from the first keystroke, before any request goes
-    // out, and clicking it unconditionally would blank a logged-in buyer's own
-    // account-prefilled address for no reason. When a pick DID happen, leaving
-    // its registered address behind ships the order to it, in fields the buyer
-    // never visibly touched and would have no reason to check.
-    if (hadPickedCompany && window.twoinc.enable_address_lookup === "yes") {
+    // a registry lookup actually wrote it. Reaching manual entry does not
+    // imply one ran: the row is live from the first keystroke, before any
+    // request goes out, and clearing unconditionally would blank a logged-in
+    // buyer's own account-prefilled address for no reason. `#company_id` is
+    // NOT that signal — it is written by account-restore and sole-trader code
+    // with no lookup behind it, and stays empty for a picked company that
+    // simply carries no organisation number even though its lookup DID run —
+    // so this reads `registryAddressApplied` instead, which is set only on
+    // the branch that actually writes looked-up data.
+    if (Twoinc.getInstance().registryAddressApplied) {
       Twoinc.getInstance().setAddress({
         street_address: "",
         city: "",
         postal_code: ""
       });
+      Twoinc.getInstance().registryAddressApplied = false;
     }
 
     Twoinc.getInstance().customerCompany = twoincDomHelper.getCompanyData();
@@ -2192,6 +2191,12 @@ class Twoinc {
 
     this.isInitialized = false;
     this.isTwoincApproved = null;
+    // Whether the address fields currently hold a registry lookup's result,
+    // as opposed to the buyer's own (typed or account-prefilled) address.
+    // Set only where `setAddress` is actually called with looked-up data
+    // (TWO-25288); read by `enterManualCompanyEntry` to decide whether
+    // disowning the company should clear the address behind it.
+    this.registryAddressApplied = false;
     this.orderIntentCheck = {
       interval: null,
       pendingCheck: false,
@@ -2623,6 +2628,14 @@ class Twoinc {
       // Use new address lookup by default
       if (response.addresses) {
         self.setAddress(response.addresses[0]);
+        // Only here, on the branch that actually writes registry data. A
+        // buyer's own address (account-prefilled, or typed by hand) never
+        // goes through this path, so this flag distinguishes the two —
+        // `#company_id` being non-empty does not: it is also written by
+        // account-restore and sole-trader code with no lookup behind it, and
+        // is empty for company hits that carry no organisation number even
+        // though a lookup DID run for them.
+        self.registryAddressApplied = true;
       }
     });
   }

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1125,6 +1125,12 @@ let twoincDomHelper = {
   enterManualCompanyEntry: function () {
     window.twoinc.enable_company_search = "no";
 
+    // Read BEFORE the field below is blanked: this is the only evidence that a
+    // company was actually picked (and its address therefore possibly looked
+    // up), as opposed to the row being reached by typing straight to the
+    // threshold and never selecting anything — the ordinary path.
+    const hadPickedCompany = !!jQuery("#company_id").val();
+
     jQuery("#billing_company_display").val("");
     // The real company field too, not just the display one. Without this the
     // manual field the buyer is about to be shown is pre-filled with the
@@ -1134,11 +1140,14 @@ let twoincDomHelper = {
     jQuery("#billing_company").val("");
     jQuery("#company_id").val("");
 
-    // The registry address too, mirroring clearSelectedCompany. The buyer has
-    // just said the looked-up company is not theirs; leaving its registered
-    // address behind ships the order to it, in fields the buyer never visibly
-    // touched and would have no reason to check.
-    if (window.twoinc.enable_address_lookup === "yes") {
+    // The registry address too, mirroring clearSelectedCompany — but ONLY when
+    // a pick actually happened. Reaching manual entry does not imply a lookup
+    // ran: the row is live from the first keystroke, before any request goes
+    // out, and clicking it unconditionally would blank a logged-in buyer's own
+    // account-prefilled address for no reason. When a pick DID happen, leaving
+    // its registered address behind ships the order to it, in fields the buyer
+    // never visibly touched and would have no reason to check.
+    if (hadPickedCompany && window.twoinc.enable_address_lookup === "yes") {
       Twoinc.getInstance().setAddress({
         street_address: "",
         city: "",

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -267,6 +267,16 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                     // from the number required.
                     /* translators: %d: minimum number of characters the buyer must type before the company search runs. Left unresolved here and interpolated in JS from the threshold the widget enforces, so the two cannot disagree. */
                     'company_search_too_short' => __('Please enter %d or more characters', 'twoinc-payment-gateway'),
+                    // The manual-entry row inside the company-search results
+                    // list, and the link back out of manual entry
+                    // (TWO-25288). Both used to be markup in the billing-form
+                    // view, which is rendered on the checkout page only — the
+                    // pay-for-order page renders its own copy of the company
+                    // inputs and so silently had neither. They are built in JS
+                    // now, from here, so both surfaces get the same
+                    // translated strings from one source.
+                    'company_not_in_list' => __('My company is not on the list', 'twoinc-payment-gateway'),
+                    'search_company' => __('Search for company', 'twoinc-payment-gateway'),
                 ],
                 'twoinc_checkout_host' => $this->wc_twoinc->get_twoinc_checkout_host(),
                 'enable_company_search' => $this->wc_twoinc->get_enable_company_search(),

--- a/languages/twoinc-payment-gateway-nb_NO.po
+++ b/languages/twoinc-payment-gateway-nb_NO.po
@@ -424,7 +424,7 @@ msgstr "Selger-ID:"
 msgid "Missing company ID."
 msgstr "Manglende firma-ID."
 
-#: views/woocommerce_after_checkout_billing_form.php:11
+#: class/WC_Twoinc_Checkout.php:278
 msgid "My company is not on the list"
 msgstr "Selskapet mitt er ikke på listen"
 
@@ -522,7 +522,7 @@ msgstr "Svarkode fra %s : %d"
 msgid "Response: %s"
 msgstr "Svar: %s"
 
-#: views/woocommerce_after_checkout_billing_form.php:15
+#: class/WC_Twoinc_Checkout.php:279
 msgid "Search for company"
 msgstr "Søk etter selskap"
 

--- a/languages/twoinc-payment-gateway-nl_NL.po
+++ b/languages/twoinc-payment-gateway-nl_NL.po
@@ -429,7 +429,7 @@ msgstr "Verkoper-ID:"
 msgid "Missing company ID."
 msgstr "Bedrijfs-ID ontbreekt."
 
-#: views/woocommerce_after_checkout_billing_form.php:11
+#: class/WC_Twoinc_Checkout.php:278
 msgid "My company is not on the list"
 msgstr "Mijn bedrijf staat niet op de lijst"
 
@@ -526,7 +526,7 @@ msgstr "Antwoordcode van %s : %d"
 msgid "Response: %s"
 msgstr "Antwoord: %s"
 
-#: views/woocommerce_after_checkout_billing_form.php:15
+#: class/WC_Twoinc_Checkout.php:279
 msgid "Search for company"
 msgstr "Zoek naar bedrijf"
 

--- a/languages/twoinc-payment-gateway-sv_SE.po
+++ b/languages/twoinc-payment-gateway-sv_SE.po
@@ -424,7 +424,7 @@ msgstr "Handlar-ID:"
 msgid "Missing company ID."
 msgstr "Företags-ID saknas."
 
-#: views/woocommerce_after_checkout_billing_form.php:11
+#: class/WC_Twoinc_Checkout.php:278
 msgid "My company is not on the list"
 msgstr "Mitt företag finns inte med i listan"
 
@@ -522,7 +522,7 @@ msgstr "Svarskod från %s : %d"
 msgid "Response: %s"
 msgstr "Svar: %s"
 
-#: views/woocommerce_after_checkout_billing_form.php:15
+#: class/WC_Twoinc_Checkout.php:279
 msgid "Search for company"
 msgstr "Sök efter företag"
 

--- a/languages/twoinc-payment-gateway.pot
+++ b/languages/twoinc-payment-gateway.pot
@@ -394,7 +394,7 @@ msgstr ""
 msgid "Missing company ID."
 msgstr ""
 
-#: views/woocommerce_after_checkout_billing_form.php:11
+#: class/WC_Twoinc_Checkout.php:278
 msgid "My company is not on the list"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Response: %s"
 msgstr ""
 
-#: views/woocommerce_after_checkout_billing_form.php:15
+#: class/WC_Twoinc_Checkout.php:279
 msgid "Search for company"
 msgstr ""
 

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -175,6 +175,22 @@ about the company-search helper, so the bootstrap is left to no-op.
 - the affordance needs no template markup on the page, which is what makes it work on the
   pay-for-order surface; and a company field's wrapper follows the field's own visibility,
   which is what keeps manual entry usable there.
+- **real DOM focus follows the highlight.** The picker `.focus()`es the highlighted row on
+  every arrow keypress and its own source says that is required for screen readers, so the
+  row needs `tabindex="-1"` to be able to take focus at all. Asserted via `document.activeElement`
+  after driving the picker's own navigation and focus routine — not by inspecting the attribute
+  alone, which would not notice the focus call being a no-op.
+- the row's attributes are compared against **an option the widget itself builds**, rather than
+  against a hand-written list. If the library adds a navigation-relevant attribute, that test
+  fails instead of the row quietly falling out of the navigable set.
+- **the row survives a widget re-creation** — clearing the selected company builds a new picker
+  and a new results list, and nothing in that path knows this affordance exists. Also that at
+  most one render watcher is live, keyed on the node it observes: the widget constructs a
+  MutationObserver of its own, so counting constructions without checking the target counts the
+  library's too and fails for an unrelated reason.
+- focus is not dropped on either mode switch, and `focusVisibleCompanyField` reports failure
+  rather than claiming success when the field is absent.
+- the sole-trader round trip does not strand a buyer in manual entry.
 
 ### Two defects these tests found, now fixed
 

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -149,6 +149,33 @@ about the company-search helper, so the bootstrap is left to no-op.
   `templateSelection` uses plain text, and the non-error messages borrowing WooCommerce
   core's own copy.
 
+`company-search-manual-entry.test.js` — the "my company is not on the list" row (TWO-25288):
+
+- the row is the **last child of the results list**, not a sibling beside it, and carries
+  everything the picker navigates by: `role="option"`, `data-selected="false"`, a stable id,
+  the `--selectable` class, and a payload with an id sentinel and a `_resultId` matching the
+  li. Reachability is asserted through the widget's own navigation — arrow twice and check
+  which row ended up highlighted — rather than by inspecting markup and hoping.
+- `data-selected="true"` is specifically pinned as wrong: the picker routes activation of an
+  already-selected row to closing the dropdown, so the row would look reachable and do
+  nothing. The mutation that flips it takes the activation tests down.
+- visibility is the search threshold and nothing else. The row is present at the threshold
+  with **zero** requests made, which is what rules out a "has a search run" gate, and the
+  threshold assertion injects a different number so a leftover literal `3` cannot pass.
+- activation prevents the selection: no `select2:select`, no company name, no company id. A
+  normal company row still selects, which is what stops the interception from being a
+  blanket one.
+- the handler that shows the row is bound **once** across five opens and repeated re-binds,
+  and exists before the dropdown's search field does. Both are regression pins: the previous
+  implementation bound it inside a polling callback, per open, with no `.off()`.
+- the row survives the picker emptying the list, and is not churned by its own observer —
+  asserted as the same DOM node across many observer turns, since the sync runs from a
+  MutationObserver on the list it appends to.
+- the label follows the localised text map rather than an English literal.
+- the affordance needs no template markup on the page, which is what makes it work on the
+  pay-for-order surface; and a company field's wrapper follows the field's own visibility,
+  which is what keeps manual entry usable there.
+
 ### Two defects these tests found, now fixed
 
 Both were pinned as characterisation tests when this suite landed, and both were fixed
@@ -182,7 +209,8 @@ suite green:
   and heading placement, and the currency-symbol fee label (ABN-468);
 - the selection side of company search — `onCompanySelected`-equivalent handling in
   `Twoinc.initialize`'s `select2:select` binding, `clearSelectedCompany()`, the
-  company-not-found button, the address autofill;
+  the address autofill. The manual-entry row is no longer among these — see its own suite
+  above;
 - `twoincDomHelper`'s field moving/reverting and validation cues;
 - `fixSelectWooPositionCompanyName`, `waitToFocus` and `addSelectWooFocusFixHandler` — DOM
   position and focus workarounds whose observable effect is layout.

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -1,0 +1,521 @@
+/**
+ * TWO-25288. The manual-entry affordance inside the company-search dropdown.
+ *
+ * The row is a pseudo-option injected into a results list the picker owns and
+ * empties on every render, so almost everything worth asserting here is about
+ * the seam between the plugin and the widget rather than about a pure function:
+ * whether the row is where the picker's keyboard navigation looks for it,
+ * whether it survives a re-render, whether activating it is intercepted before
+ * a company value is written, and whether the handlers that show it are bound
+ * once rather than once per dropdown open.
+ *
+ * The real widget is used throughout, for the same reason the rest of this
+ * suite uses it: the row's reachability IS a property of the widget's own
+ * navigation code, and a mock would have to reproduce that code correctly to
+ * catch a regression in it — which is exactly the assumption that let the
+ * previous, unreachable implementation ship.
+ */
+
+"use strict";
+
+const harness = require("./wc-harness");
+
+/** The strings the affordance reads out of the localised text map. */
+const TEXT = {
+  company_not_in_list: "My company is not on the list",
+  search_company: "Search for company"
+};
+
+describe("company-search manual-entry affordance", () => {
+  let ctx;
+  let $;
+  let helper;
+
+  beforeEach(() => {
+    ctx = harness.loadTwoinc({
+      text: TEXT,
+      supported_buyer_countries: ["GB"],
+      enable_company_search: "yes",
+      enable_company_search_for_others: "yes",
+      enable_address_lookup: "no"
+    });
+    $ = ctx.$;
+    helper = ctx.helper;
+    harness.buildCheckoutForm();
+  });
+
+  afterEach(() => {
+    harness.releaseWidgets($);
+    $(document.body).off("input.twoincManualEntry");
+    document.body.innerHTML = "";
+  });
+
+  /**
+   * Attach the widget, open it, and wire the affordance the way
+   * enableCompanySearch does.
+   *
+   * @returns {Object} the jQuery-wrapped select
+   */
+  function openWithAffordance() {
+    const $select = harness.openCompanyWidget($, helper);
+    helper.bindManualEntryAffordance($select);
+    return $select;
+  }
+
+  /** @returns {Object} the dropdown's search input */
+  function searchInput() {
+    return $(helper.companySearchInputSelector);
+  }
+
+  /**
+   * Type into the dropdown's search field and fire the event the affordance
+   * listens on. Deliberately NOT `.trigger("keyup")` or a debounce flush: the
+   * row is specified to appear on input, before any request goes out.
+   *
+   * @param {string} term what the buyer has typed
+   * @returns {void}
+   */
+  function type(term) {
+    searchInput().val(term).trigger("input");
+  }
+
+  /** @returns {Object} the results <ul> the picker renders into */
+  function resultsList() {
+    return $("#billing_company_display").data("select2").$results;
+  }
+
+  /** @returns {Object} the manual-entry row, or an empty set */
+  function row() {
+    return resultsList().children("#" + helper.manualEntryRowId);
+  }
+
+  /**
+   * Guard against a harness that returns before the code under test ran.
+   *
+   * Every assertion below is about DOM the affordance is supposed to have
+   * created. If `bindManualEntryAffordance` silently did nothing — no handler,
+   * no observer — an "is absent" assertion still passes and a "is present" one
+   * fails for the wrong reason. This asserts the binding itself happened, so
+   * the suite fails loudly at the seam rather than misattributing.
+   */
+  test("the affordance actually binds — guard for every test below", () => {
+    openWithAffordance();
+
+    const bodyEvents = $._data(document.body, "events");
+    expect(bodyEvents && bodyEvents.input).toBeDefined();
+    expect(
+      bodyEvents.input.filter((h) => h.namespace === "twoincManualEntry").length
+    ).toBeGreaterThan(0);
+    expect(searchInput().length).toBe(1);
+  });
+
+  describe("visibility follows the search threshold and nothing else", () => {
+    test("absent below the threshold", () => {
+      openWithAffordance();
+
+      type("a".repeat(helper.companySearchMinLength - 1));
+
+      expect(row().length).toBe(0);
+    });
+
+    test("present at the threshold, before any request has been made", () => {
+      openWithAffordance();
+      const ajax = harness.stubAjax($);
+
+      type("a".repeat(helper.companySearchMinLength));
+
+      expect(row().length).toBe(1);
+      // The point of the timing rule: no round trip has happened, and the row
+      // is already there. A `hasSearched` gate would fail this.
+      expect(ajax.calls.length).toBe(0);
+      ajax.restore();
+    });
+
+    test("present above the threshold", () => {
+      openWithAffordance();
+
+      type("a".repeat(helper.companySearchMinLength + 4));
+
+      expect(row().length).toBe(1);
+    });
+
+    test("removed again when the buyer deletes back below the threshold", () => {
+      openWithAffordance();
+
+      type("a".repeat(helper.companySearchMinLength));
+      expect(row().length).toBe(1);
+
+      type("a".repeat(helper.companySearchMinLength - 1));
+      expect(row().length).toBe(0);
+    });
+
+    test("the threshold is read from the shared constant, not hard-coded", () => {
+      // Injecting a DIFFERENT number is the only version of this assertion
+      // worth having: a test that types three characters passes just as well
+      // against a leftover literal 3.
+      helper.companySearchMinLength = 5;
+      openWithAffordance();
+
+      type("abcd");
+      expect(row().length).toBe(0);
+
+      type("abcde");
+      expect(row().length).toBe(1);
+    });
+  });
+
+  describe("the row is where the picker's keyboard navigation looks", () => {
+    test("it is the LAST child of the results list", () => {
+      openWithAffordance();
+      const $list = resultsList();
+      $list.append('<li class="select2-results__option" data-selected="false">A company</li>');
+
+      type("abc");
+
+      expect($list.children().last().attr("id")).toBe(helper.manualEntryRowId);
+    });
+
+    test("it is inside the list, not beside it", () => {
+      openWithAffordance();
+
+      type("abc");
+
+      expect(row().parent().is(resultsList())).toBe(true);
+    });
+
+    test("it carries the attributes the picker navigates by", () => {
+      openWithAffordance();
+
+      type("abc");
+      const $row = row();
+
+      expect($row.attr("role")).toBe("option");
+      expect($row.attr("data-selected")).toBe("false");
+      expect($row.attr("aria-selected")).toBe("false");
+      expect($row.attr("id")).toBeTruthy();
+      expect($row.hasClass("select2-results__option")).toBe(true);
+      expect($row.hasClass("select2-results__option--selectable")).toBe(true);
+    });
+
+    test("it carries a payload with an id and a matching _resultId", () => {
+      openWithAffordance();
+
+      type("abc");
+      const data = row().data("data");
+
+      expect(data).toBeTruthy();
+      expect(data.id).toBe(helper.manualEntrySentinelId);
+      // aria-activedescendant is set from _resultId, so a mismatch makes the
+      // row reachable but never announced.
+      expect(data._resultId).toBe(row().attr("id"));
+      expect(data.text).toBe(TEXT.company_not_in_list);
+    });
+
+    test("the picker's own navigation reaches it — a real reachability check", () => {
+      openWithAffordance();
+      const $select = $("#billing_company_display");
+      const picker = $select.data("select2");
+      const $list = resultsList();
+      // A payload with a _resultId, because the widget's own focus handler
+      // reads one off every row it highlights — including the company row it
+      // passes through on the way to ours.
+      $list.append(
+        $('<li class="select2-results__option" data-selected="false">A company</li>')
+          .attr("id", "a-company-row")
+          .data("data", { id: "A company", text: "A company", _resultId: "a-company-row" })
+      );
+
+      type("abc");
+
+      // Arrow down twice from nothing highlighted: once onto the company row,
+      // once onto ours. This is the widget's own handler doing the walking, so
+      // it passes only if the row is genuinely in the navigable set.
+      picker.trigger("results:next", {});
+      picker.trigger("results:next", {});
+
+      const $highlighted = $list.find(".select2-results__option--highlighted");
+      expect($highlighted.attr("id")).toBe(helper.manualEntryRowId);
+      // And it is announced. Two independent places have to agree for a screen
+      // reader to name the row: the list's own aria-activedescendant, taken
+      // from the highlighted element's id, and the combobox's, taken from the
+      // highlighted row's payload `_resultId`.
+      expect($list.attr("aria-activedescendant")).toBe(helper.manualEntryRowId);
+      expect(picker.selection.$selection.attr("aria-activedescendant")).toBe(
+        helper.manualEntryRowId
+      );
+    });
+
+    test("the label is the localised msgid, not a hard-coded English literal", () => {
+      // Asserting on the English string would pass against a literal in the
+      // source. Change what the text map says and require the row to follow.
+      ctx.twoinc.text.company_not_in_list = "Selskapet mitt er ikke på listen";
+      openWithAffordance();
+
+      type("abc");
+
+      expect(row().text()).toBe("Selskapet mitt er ikke på listen");
+    });
+  });
+
+  describe("it survives the picker emptying the list", () => {
+    test("re-appended after a fresh result set is rendered", () => {
+      openWithAffordance();
+      const $select = $("#billing_company_display");
+      const picker = $select.data("select2");
+
+      type("abc");
+      expect(row().length).toBe(1);
+
+      // What the picker does on every render: wipe the list, then append.
+      picker.trigger("results:all", {
+        data: { results: [{ id: "A company", text: "A company", html: "A company" }] },
+        query: { term: "abc" }
+      });
+
+      // The observer runs as a microtask, so let the queue drain.
+      return Promise.resolve().then(() => {
+        expect(row().length).toBe(1);
+        expect(resultsList().children().last().attr("id")).toBe(helper.manualEntryRowId);
+      });
+    });
+
+    test("the row is not churned by its own observer", async () => {
+      // The sync runs from a MutationObserver on the very list it appends to,
+      // so without the "already last, do nothing" early return every append
+      // re-triggers the observer and the row is torn down and rebuilt forever.
+      // The row surviving as the SAME DOM node across many observer turns is
+      // what says the guard is there.
+      openWithAffordance();
+
+      type("abc");
+      const node = row()[0];
+      expect(node).toBeTruthy();
+
+      for (let i = 0; i < 25; i++) await Promise.resolve();
+
+      expect(row()[0]).toBe(node);
+      expect(row().length).toBe(1);
+    });
+
+    test("not re-appended when the term is back below the threshold", () => {
+      openWithAffordance();
+      const picker = $("#billing_company_display").data("select2");
+
+      type("abc");
+      expect(row().length).toBe(1);
+
+      searchInput().val("ab");
+      picker.trigger("results:all", {
+        data: { results: [] },
+        query: { term: "ab" }
+      });
+
+      return Promise.resolve().then(() => {
+        expect(row().length).toBe(0);
+      });
+    });
+  });
+
+  describe("activation", () => {
+    /**
+     * Activate the row the way the picker does for BOTH Enter and a click:
+     * highlight it, then ask the picker to select the highlighted row.
+     *
+     * @returns {void}
+     */
+    function activate() {
+      const picker = $("#billing_company_display").data("select2");
+      row().trigger("mouseenter");
+      picker.trigger("results:select", {});
+    }
+
+    beforeEach(() => {
+      // enterManualCompanyEntry reaches the singleton for the customer-company
+      // snapshot; give it one before anything activates the row.
+      ctx.Twoinc.getInstance();
+    });
+
+    test("no company value is written — the selection is prevented", () => {
+      const selected = [];
+      const $select = openWithAffordance();
+      $select.on("select2:select", (e) => selected.push(e.params.data));
+
+      type("abc");
+      activate();
+
+      expect(selected).toEqual([]);
+      expect($("#billing_company").val()).toBe("");
+      expect($("#company_id").val()).toBe("");
+    });
+
+    test("it enters manual entry", () => {
+      jest.useFakeTimers();
+      openWithAffordance();
+
+      type("abc");
+      activate();
+      // The action is deferred out of the picker's own event dispatch.
+      jest.advanceTimersByTime(1);
+
+      expect(ctx.twoinc.enable_company_search).toBe("no");
+      expect($("#billing_company_display").data("select2")).toBeFalsy();
+      expect($("#" + helper.manualEntryRowId).length).toBe(0);
+      jest.useRealTimers();
+    });
+
+    test("the way back out appears, keyboard-reachable", () => {
+      jest.useFakeTimers();
+      openWithAffordance();
+
+      type("abc");
+      activate();
+      jest.advanceTimersByTime(1);
+
+      const $back = $("#" + helper.searchCompanyBtnId);
+      expect($back.length).toBe(1);
+      // A <button> rather than the unreachable <div> this used to be: focusable
+      // and Enter/Space-activatable with no keydown bridge of our own.
+      expect($back.prop("tagName")).toBe("BUTTON");
+      expect($back.attr("type")).toBe("button");
+      // Not `:hidden`: jsdom reports zero dimensions for every element, so that
+      // selector matches everything and could never fail. The inline display
+      // this code actually sets is the assertable thing.
+      expect($back[0].style.display).not.toBe("none");
+      expect($back.text()).toBe(TEXT.search_company);
+      jest.useRealTimers();
+    });
+
+    test("the way back out is built hidden, before manual entry is entered", () => {
+      openWithAffordance();
+
+      const $back = ctx.dom.getSearchCompanyBtnNode();
+
+      expect($back[0].style.display).toBe("none");
+      // In place, not floating: it belongs beside the manual company field.
+      expect($back.parent().attr("id")).toBe("billing_company_field");
+    });
+
+    test("leaving manual entry hides the way back out again", () => {
+      jest.useFakeTimers();
+      openWithAffordance();
+
+      type("abc");
+      activate();
+      jest.advanceTimersByTime(1);
+      expect($("#" + helper.searchCompanyBtnId)[0].style.display).not.toBe("none");
+
+      ctx.dom.exitManualCompanyEntry();
+
+      expect(ctx.twoinc.enable_company_search).toBe("yes");
+      expect($("#" + helper.searchCompanyBtnId)[0].style.display).toBe("none");
+      jest.useRealTimers();
+    });
+
+    test("a company row still selects normally", () => {
+      const selected = [];
+      const $select = openWithAffordance();
+      $select.on("select2:select", (e) => selected.push(e.params.data));
+      const picker = $select.data("select2");
+
+      type("abc");
+      const $company = $(
+        '<li class="select2-results__option" data-selected="false">A company</li>'
+      ).data("data", { id: "A company", text: "A company" });
+      resultsList().prepend($company);
+      $company.trigger("mouseenter");
+      picker.trigger("results:select", {});
+
+      expect(selected.map((d) => d.id)).toEqual(["A company"]);
+    });
+  });
+
+  describe("handlers are bound once, not once per dropdown open", () => {
+    /** @returns {number} how many namespaced input handlers <body> carries */
+    function inputHandlerCount() {
+      const events = $._data(document.body, "events");
+      if (!events || !events.input) return 0;
+      return events.input.filter((h) => h.namespace === "twoincManualEntry").length;
+    }
+
+    test("still one after five opens and re-binds", () => {
+      const $select = openWithAffordance();
+
+      for (let i = 0; i < 5; i++) {
+        $select.select2("close");
+        $select.select2("open");
+        // enableCompanySearch re-runs on a timer and on every return out of
+        // manual entry, so re-binding is the normal case, not an edge one.
+        helper.bindManualEntryAffordance($select);
+      }
+
+      expect(inputHandlerCount()).toBe(1);
+    });
+
+    test("one keystroke appends one row, not one per bind", () => {
+      const $select = openWithAffordance();
+      helper.bindManualEntryAffordance($select);
+      helper.bindManualEntryAffordance($select);
+
+      type("abc");
+
+      expect(row().length).toBe(1);
+      expect(resultsList().children("li[id]").length).toBe(1);
+    });
+
+    test("the handler exists before the dropdown's field does", () => {
+      // The defect this replaces bound the handler inside a polling callback
+      // that fired hundreds of ms after the dropdown opened, so a fast typist's
+      // first keystrokes were dropped. Binding is delegated on <body>, so it is
+      // in place with no widget attached at all.
+      const $select = $("#billing_company_display");
+      $select.selectWoo(helper.genSelectWooParams());
+      helper.bindManualEntryAffordance($select);
+
+      expect(inputHandlerCount()).toBe(1);
+
+      $select.select2("open");
+      type("abc");
+
+      expect(row().length).toBe(1);
+    });
+  });
+
+  describe("the pay-for-order surface", () => {
+    test("the affordance needs no template markup on the page", () => {
+      // The billing-form view that used to carry these two nodes is rendered on
+      // the checkout page only. Nothing here renders it, and the row and the
+      // link back are still built.
+      jest.useFakeTimers();
+      expect($(".company_not_in_btn").length).toBe(0);
+      expect($("#" + helper.searchCompanyBtnId).length).toBe(0);
+      ctx.Twoinc.getInstance();
+
+      const $select = openWithAffordance();
+      type("abc");
+      expect(row().length).toBe(1);
+
+      const picker = $select.data("select2");
+      row().trigger("mouseenter");
+      picker.trigger("results:select", {});
+      jest.advanceTimersByTime(1);
+
+      expect($("#" + helper.searchCompanyBtnId).length).toBe(1);
+      jest.useRealTimers();
+    });
+
+    test("a company field's wrapper follows the field's own visibility", () => {
+      // The pay-for-order page wraps each company input in a container with its
+      // own hidden state. Revealing the field alone leaves manual entry with
+      // nothing visible, so the wrapper has to follow.
+      $("#billing_company_field").wrap('<div class="twoinc-inp-container hidden"></div>');
+      $("#billing_company_field").addClass("hidden");
+
+      ctx.dom.syncCompanyFieldWrappers();
+      expect($("#billing_company_field").parent().hasClass("hidden")).toBe(true);
+
+      $("#billing_company_field").removeClass("hidden");
+      ctx.dom.syncCompanyFieldWrappers();
+      expect($("#billing_company_field").parent().hasClass("hidden")).toBe(false);
+    });
+  });
+});

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -58,7 +58,7 @@ describe("company-search manual-entry affordance", () => {
    */
   function openWithAffordance() {
     const $select = harness.openCompanyWidget($, helper);
-    helper.bindManualEntryAffordance($select);
+    helper.bindManualEntryAffordance();
     return $select;
   }
 
@@ -576,7 +576,7 @@ describe("company-search manual-entry affordance", () => {
         $select.select2("open");
         // enableCompanySearch re-runs on a timer and on every return out of
         // manual entry, so re-binding is the normal case, not an edge one.
-        helper.bindManualEntryAffordance($select);
+        helper.bindManualEntryAffordance();
       }
 
       expect(inputHandlerCount()).toBe(1);
@@ -584,8 +584,8 @@ describe("company-search manual-entry affordance", () => {
 
     test("one keystroke appends one row, not one per bind", () => {
       const $select = openWithAffordance();
-      helper.bindManualEntryAffordance($select);
-      helper.bindManualEntryAffordance($select);
+      helper.bindManualEntryAffordance();
+      helper.bindManualEntryAffordance();
 
       type("abc");
 
@@ -600,7 +600,7 @@ describe("company-search manual-entry affordance", () => {
       // in place with no widget attached at all.
       const $select = $("#billing_company_display");
       $select.selectWoo(helper.genSelectWooParams());
-      helper.bindManualEntryAffordance($select);
+      helper.bindManualEntryAffordance();
 
       expect(inputHandlerCount()).toBe(1);
 
@@ -675,9 +675,9 @@ describe("company-search manual-entry affordance", () => {
 
       expect(selectingHandlerCount($select)).toBe(1);
 
-      helper.bindManualEntryAffordance($select);
-      helper.bindManualEntryAffordance($select);
-      helper.bindManualEntryAffordance($select);
+      helper.bindManualEntryAffordance();
+      helper.bindManualEntryAffordance();
+      helper.bindManualEntryAffordance();
 
       expect(selectingHandlerCount($select)).toBe(1);
     });
@@ -729,8 +729,8 @@ describe("company-search manual-entry affordance", () => {
         const $select = openWithAffordance();
         const list = resultsList()[0];
 
-        helper.bindManualEntryAffordance($select);
-        helper.bindManualEntryAffordance($select);
+        helper.bindManualEntryAffordance();
+        helper.bindManualEntryAffordance();
         type("abc");
 
         const mine = spy.on(list);

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -338,6 +338,7 @@ describe("company-search manual-entry affordance", () => {
     test("no company value is written — the selection is prevented", () => {
       const selected = [];
       const $select = openWithAffordance();
+      const picker = $select.data("select2");
       $select.on("select2:select", (e) => selected.push(e.params.data));
 
       type("abc");
@@ -346,6 +347,22 @@ describe("company-search manual-entry affordance", () => {
       expect(selected).toEqual([]);
       expect($("#billing_company").val()).toBe("");
       expect($("#company_id").val()).toBe("");
+
+      // The three assertions above are all "nothing happened", and a recorder
+      // that was never wired up — or a widget that stopped emitting at all —
+      // satisfies every one of them. They would pass for the wrong reason and
+      // could not fail. So prove the recorder is LIVE on the same widget, in
+      // the same test: an ordinary row selected the ordinary way IS recorded,
+      // and the sentinel is still absent.
+      const $company = $(
+        '<li id="live-probe-row" class="select2-results__option" data-selected="false">Probe Co</li>'
+      ).data("data", { id: "Probe Co", text: "Probe Co", _resultId: "live-probe-row" });
+      resultsList().prepend($company);
+      $company.trigger("mouseenter");
+      picker.trigger("results:select", {});
+
+      expect(selected.map((d) => d.id)).toEqual(["Probe Co"]);
+      expect(selected.map((d) => d.id)).not.toContain(helper.manualEntrySentinelId);
     });
 
     test("it enters manual entry", () => {

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -731,7 +731,15 @@ describe("company-search manual-entry affordance", () => {
 
         helper.bindManualEntryAffordance();
         helper.bindManualEntryAffordance();
+        // Several keystrokes, not one. The watcher is installed from the
+        // per-keystroke sync — that is what makes a re-created widget heal
+        // itself — so a single keystroke cannot tell "installed once" from
+        // "re-installed on every character". Without the per-node guard this
+        // churns one observer per keystroke.
         type("abc");
+        type("abcd");
+        type("abcde");
+        type("abcdef");
 
         const mine = spy.on(list);
         expect(mine.length).toBe(1);

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -1022,6 +1022,21 @@ describe("company-search manual-entry affordance", () => {
         expect(resultsList().children().last().attr("id")).toBe(helper.manualEntryRowId);
       });
     });
+
+    test("clearing the selected company resets the registry-address flag", () => {
+      // Without this, the × button leaves the flag stale true after already
+      // blanking the address: pick a company (flag true, address written),
+      // click ×, type your OWN address into the now-empty fields, then click
+      // "not on the list" — enterManualCompanyEntry sees the stale flag and
+      // wipes what you just typed. The same false-positive round 2 fixed,
+      // resurfacing through this path if the reset here ever regresses.
+      const twoinc = ctx.Twoinc.getInstance();
+      twoinc.registryAddressApplied = true;
+
+      ctx.dom.clearSelectedCompany();
+
+      expect(twoinc.registryAddressApplied).toBe(false);
+    });
   });
 
   describe("the sole-trader round trip", () => {

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -516,6 +516,114 @@ describe("company-search manual-entry affordance", () => {
       jest.useRealTimers();
     });
 
+    /**
+     * Add the address inputs `setAddress` writes to, prefilled the way an
+     * address lookup for a picked company leaves them.
+     *
+     * They are created here rather than in the shared form because `.val()` on
+     * an empty set is a silent no-op: if the fields were absent, a "cleared"
+     * assertion would read undefined and could never fail.
+     *
+     * @returns {void}
+     */
+    function givenLookedUpAddress() {
+      $("form[name='checkout']").append(
+        [
+          "<input type='text' id='billing_address_1' value='Registry Street 1' />",
+          "<input type='text' id='billing_address_2' value='' />",
+          "<input type='text' id='billing_city' value='Registryville' />",
+          "<input type='text' id='billing_postcode' value='0001' />"
+        ].join("\n")
+      );
+      // The precondition, asserted rather than assumed — see above.
+      expect($("#billing_address_1").val()).toBe("Registry Street 1");
+      expect($("#billing_city").val()).toBe("Registryville");
+      expect($("#billing_postcode").val()).toBe("0001");
+    }
+
+    test("the disowned company's registry address does not survive into the order", () => {
+      ctx.twoinc.enable_address_lookup = "yes";
+      jest.useFakeTimers();
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+      givenLookedUpAddress();
+
+      type("abc");
+      row().trigger("mouseenter");
+      picker.trigger("results:select", {});
+      jest.advanceTimersByTime(1);
+
+      // Otherwise the order ships to the address of the company the buyer has
+      // just said is not theirs, in fields they never visibly touched.
+      expect($("#billing_address_1").val()).toBe("");
+      expect($("#billing_city").val()).toBe("");
+      expect($("#billing_postcode").val()).toBe("");
+      jest.useRealTimers();
+    });
+
+    test("the address is left alone when address lookup is off", () => {
+      // Nothing filled those fields on our behalf, so clearing them would be
+      // wiping the buyer's own typing. Same condition clearSelectedCompany uses.
+      ctx.twoinc.enable_address_lookup = "no";
+      jest.useFakeTimers();
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+      givenLookedUpAddress();
+
+      type("abc");
+      row().trigger("mouseenter");
+      picker.trigger("results:select", {});
+      jest.advanceTimersByTime(1);
+
+      expect($("#billing_address_1").val()).toBe("Registry Street 1");
+      expect($("#billing_city").val()).toBe("Registryville");
+      expect($("#billing_postcode").val()).toBe("0001");
+      jest.useRealTimers();
+    });
+
+    test("the display select's own value is cleared, not just hidden", () => {
+      jest.useFakeTimers();
+      // A completed pick leaves the picked option selected on the underlying
+      // <select>, and select2("destroy") does not touch it. Left behind, the
+      // combobox re-appears showing the company the buyer just disowned.
+      $("#billing_company_display").append(
+        '<option value="ACME Widgets Ltd" selected>ACME Widgets Ltd</option>'
+      );
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+      expect($("#billing_company_display").val()).toBe("ACME Widgets Ltd");
+
+      type("abc");
+      row().trigger("mouseenter");
+      picker.trigger("results:select", {});
+      jest.advanceTimersByTime(1);
+
+      expect($("#billing_company_display").val()).toBe("");
+      jest.useRealTimers();
+    });
+
+    test("leaving manual entry clears the hand-typed company and org number", () => {
+      jest.useFakeTimers();
+      openWithAffordance();
+
+      type("abc");
+      activate();
+      jest.advanceTimersByTime(1);
+
+      // What the buyer typed by hand while in manual entry.
+      $("#billing_company").val("Hand Typed Ltd");
+      $("#company_id").val("99999999");
+
+      ctx.dom.exitManualCompanyEntry();
+
+      // Left behind, the org number sits on a field the buyer can no longer
+      // see, passes the non-empty guard on the PHP side, and reaches the order
+      // while the combobox shows nothing selected.
+      expect($("#billing_company").val()).toBe("");
+      expect($("#company_id").val()).toBe("");
+      jest.useRealTimers();
+    });
+
     test("the way back out is built hidden, before manual entry is entered", () => {
       openWithAffordance();
 
@@ -654,6 +762,29 @@ describe("company-search manual-entry affordance", () => {
       // Both callers run on a surface that may not render the field. A bare
       // .focus() on an empty jQuery set is a silent no-op that reads as success.
       expect(ctx.dom.focusVisibleCompanyField("#no_such_field_at_all")).toBe(false);
+      expect(ctx.dom.focusVisibleCompanyField("#billing_company")).toBe(true);
+    });
+
+    test("a disabled field reports failure rather than lying", () => {
+      // A disabled input cannot take focus, so `.focus()` on it is the same
+      // silent no-op as an empty set. The caller uses the return value to
+      // decide whether to try its fallback target, so the distinction has to
+      // be real.
+      //
+      // What this pins is the CONTRACT, not one line of it. The `disabled`
+      // clause and the activeElement check are two independent mechanisms that
+      // both produce `false` here, so removing either one alone leaves this
+      // green (verified by mutation); removing both turns it red. The clause is
+      // kept as the explicit one because it also stops `.trigger("focus")`
+      // running focus handlers on a field the buyer cannot reach.
+      $("#billing_company").prop("disabled", true);
+
+      expect(ctx.dom.focusVisibleCompanyField("#billing_company")).toBe(false);
+      expect(document.activeElement).not.toBe($("#billing_company")[0]);
+
+      // Live probe: the same call on the same field succeeds once enabled, so
+      // the false above is the guard firing and not a broken selector.
+      $("#billing_company").prop("disabled", false);
       expect(ctx.dom.focusVisibleCompanyField("#billing_company")).toBe(true);
     });
   });
@@ -866,19 +997,27 @@ describe("company-search manual-entry affordance", () => {
       jest.useRealTimers();
     });
 
-    test("a company field's wrapper follows the field's own visibility", () => {
-      // The pay-for-order page wraps each company input in a container with its
-      // own hidden state. Revealing the field alone leaves manual entry with
-      // nothing visible, so the wrapper has to follow.
-      $("#billing_company_field").wrap('<div class="twoinc-inp-container hidden"></div>');
-      $("#billing_company_field").addClass("hidden");
+    // All three, not just one: dropping #company_id_field from the selector
+    // leaves the buyer a name box and nowhere to type the org number — the
+    // exact failure the function exists to prevent — and dropping
+    // #billing_company_display_field strands the way back to the picker.
+    test.each([
+      ["#billing_company_display_field"],
+      ["#billing_company_field"],
+      ["#company_id_field"]
+    ])("%s's wrapper follows the field's own visibility", (fieldSelector) => {
+      // The pay-for-order page wraps each company input in a container with
+      // its own hidden state. Revealing the field alone leaves manual entry
+      // with nothing visible, so the wrapper has to follow.
+      $(fieldSelector).wrap('<div class="twoinc-inp-container hidden"></div>');
+      $(fieldSelector).addClass("hidden");
 
       ctx.dom.syncCompanyFieldWrappers();
-      expect($("#billing_company_field").parent().hasClass("hidden")).toBe(true);
+      expect($(fieldSelector).parent().hasClass("hidden")).toBe(true);
 
-      $("#billing_company_field").removeClass("hidden");
+      $(fieldSelector).removeClass("hidden");
       ctx.dom.syncCompanyFieldWrappers();
-      expect($("#billing_company_field").parent().hasClass("hidden")).toBe(false);
+      expect($(fieldSelector).parent().hasClass("hidden")).toBe(false);
     });
   });
 });

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -543,19 +543,19 @@ describe("company-search manual-entry affordance", () => {
     }
 
     test("the disowned company's registry address does not survive into the order", () => {
-      ctx.twoinc.enable_address_lookup = "yes";
       jest.useFakeTimers();
       const $select = openWithAffordance();
       const picker = $select.data("select2");
       givenLookedUpAddress();
 
-      // A pick has to actually happen for a lookup to have run — reaching the
-      // manual-entry row alone (typing to the threshold) never triggers one.
-      // Without this the test cannot distinguish "the fix clears a looked-up
-      // address" from "the fix always clears these fields", and the latter was
-      // a real bug the mutation harness caught: it wipes a logged-in buyer's
-      // own account-prefilled address on the ordinary no-pick path.
-      $("#company_id").val("11111111");
+      // The gate reads this flag, not `#company_id` (see the comment at the
+      // clear site): `#company_id` is also written by account-restore and
+      // sole-trader code with no lookup behind it, and stays empty for a
+      // picked company with no organisation number even though its lookup DID
+      // run — so faking a pick via `#company_id` would prove the wrong thing.
+      // The flag's own producer (`addressLookup`'s success branch) is
+      // exercised separately below.
+      ctx.Twoinc.getInstance().registryAddressApplied = true;
 
       type("abc");
       row().trigger("mouseenter");
@@ -568,28 +568,8 @@ describe("company-search manual-entry affordance", () => {
       expect($("#billing_address_2").val()).toBe("");
       expect($("#billing_city").val()).toBe("");
       expect($("#billing_postcode").val()).toBe("");
-      jest.useRealTimers();
-    });
-
-    test("the address is left alone when address lookup is off", () => {
-      // Nothing filled those fields on our behalf, so clearing them would be
-      // wiping the buyer's own typing. Same condition clearSelectedCompany uses.
-      ctx.twoinc.enable_address_lookup = "no";
-      jest.useFakeTimers();
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
-      givenLookedUpAddress();
-      $("#company_id").val("11111111");
-
-      type("abc");
-      row().trigger("mouseenter");
-      picker.trigger("results:select", {});
-      jest.advanceTimersByTime(1);
-
-      expect($("#billing_address_1").val()).toBe("Registry Street 1");
-      expect($("#billing_address_2").val()).toBe("Flat 2");
-      expect($("#billing_city").val()).toBe("Registryville");
-      expect($("#billing_postcode").val()).toBe("0001");
+      // And the flag itself is consumed, not left set for the next entry.
+      expect(ctx.Twoinc.getInstance().registryAddressApplied).toBe(false);
       jest.useRealTimers();
     });
 
@@ -597,14 +577,15 @@ describe("company-search manual-entry affordance", () => {
       // The ordinary path: type to the threshold, see nothing you like, click
       // "not on the list". No pick, so no lookup ever ran — clearing the
       // address here would wipe the buyer's own account-prefilled address for
-      // no reason. This is the scenario the un-gated version of the fix
-      // (mirroring clearSelectedCompany verbatim) got wrong.
-      ctx.twoinc.enable_address_lookup = "yes";
+      // no reason. This is the scenario an unconditional clear, or a clear
+      // gated on `#company_id` alone, gets wrong: a logged-in buyer can have
+      // `#company_id` prefilled by account-restore with no lookup behind it.
       jest.useFakeTimers();
       const $select = openWithAffordance();
       const picker = $select.data("select2");
       givenLookedUpAddress();
-      // #company_id is deliberately left empty — no pick happened.
+      $("#company_id").val("11111111"); // account-restored, not a fresh pick
+      // registryAddressApplied deliberately left false — no lookup ran.
 
       type("abc");
       row().trigger("mouseenter");
@@ -616,6 +597,70 @@ describe("company-search manual-entry affordance", () => {
       expect($("#billing_city").val()).toBe("Registryville");
       expect($("#billing_postcode").val()).toBe("0001");
       jest.useRealTimers();
+    });
+
+    test("a picked company with no organisation number still has its looked-up address cleared", () => {
+      // A company hit can carry no organisation number at all (optional
+      // field) and still have had a real address lookup run for it — the
+      // lookup is keyed off `lookup_id`, not the org number. Gating on
+      // `#company_id` being non-empty would let this case through; gating on
+      // the flag does not.
+      jest.useFakeTimers();
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+      givenLookedUpAddress();
+      $("#company_id").val(""); // the org-number-less pick, as it lands in the DOM
+      ctx.Twoinc.getInstance().registryAddressApplied = true;
+
+      type("abc");
+      row().trigger("mouseenter");
+      picker.trigger("results:select", {});
+      jest.advanceTimersByTime(1);
+
+      expect($("#billing_address_1").val()).toBe("");
+      expect($("#billing_address_2").val()).toBe("");
+      expect($("#billing_city").val()).toBe("");
+      expect($("#billing_postcode").val()).toBe("");
+      jest.useRealTimers();
+    });
+
+    test("addressLookup sets the flag only on a successful response with addresses", () => {
+      // Closes the coupling gap: everything above sets/reads the flag
+      // directly, so nothing proves `addressLookup` itself is the flag's real
+      // producer. Drive it through a picked select2:select the way
+      // `enableCompanySearch` wires it, with a stubbed ajax response.
+      $("form[name='checkout']").append(
+        [
+          "<input type='text' id='billing_address_1' />",
+          "<input type='text' id='billing_address_2' />",
+          "<input type='text' id='billing_city' />",
+          "<input type='text' id='billing_postcode' />"
+        ].join("\n")
+      );
+      const ajax = harness.stubAjax($);
+      const twoinc = ctx.Twoinc.getInstance();
+      expect(twoinc.registryAddressApplied).toBe(false);
+
+      twoinc.addressLookup({ lookup_id: "lookup-1" });
+      expect(twoinc.registryAddressApplied).toBe(false); // not yet — pending
+
+      ajax.calls[0].succeed({
+        addresses: [
+          { street_address: "Registry Street 1", city: "Registryville", postal_code: "0001" }
+        ]
+      });
+
+      expect(twoinc.registryAddressApplied).toBe(true);
+      expect($("#billing_address_1").val()).toBe("Registry Street 1");
+
+      // A response carrying no `addresses` key at all (the lookup found
+      // nothing) must not falsely arm the flag.
+      twoinc.registryAddressApplied = false;
+      twoinc.addressLookup({ lookup_id: "lookup-2" });
+      ajax.calls[1].succeed({});
+      expect(twoinc.registryAddressApplied).toBe(false);
+
+      ajax.restore();
     });
 
     test("the display select's own value is cleared, not just hidden", () => {

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -113,6 +113,15 @@ describe("company-search manual-entry affordance", () => {
     test("absent below the threshold", () => {
       openWithAffordance();
 
+      // Reach the threshold FIRST, so the mechanism is demonstrably live in
+      // this test before the absence is asserted. Without this the assertion
+      // below is a precondition dressed as a check: the row was never in the
+      // list, so "it is not there" holds no matter what the code does, and no
+      // mutation could turn this test red. It was in fact the one test in this
+      // file that survived all 25.
+      type("a".repeat(helper.companySearchMinLength));
+      expect(row().length).toBe(1);
+
       type("a".repeat(helper.companySearchMinLength - 1));
 
       expect(row().length).toBe(0);
@@ -195,6 +204,48 @@ describe("company-search manual-entry affordance", () => {
       expect($row.attr("id")).toBeTruthy();
       expect($row.hasClass("select2-results__option")).toBe(true);
       expect($row.hasClass("select2-results__option--selectable")).toBe(true);
+      // Programmatically focusable, which is what lets the picker's own
+      // focus-the-highlighted-row call actually land.
+      expect($row.attr("tabindex")).toBe("-1");
+    });
+
+    test("it carries the same attributes the picker gives a real option", () => {
+      // Rather than restate a list of attributes this test could drift from,
+      // compare against what the widget itself produces. If the library ever
+      // adds a navigation-relevant attribute, this fails instead of the row
+      // silently falling out of the navigable set.
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+      const real = picker.results.option({ id: "Real Co", text: "Real Co", _resultId: "real-co" });
+
+      type("abc");
+      const $row = row();
+
+      ["role", "data-selected", "tabindex"].forEach((attr) => {
+        expect($row.attr(attr)).toBe($(real).attr(attr));
+      });
+    });
+
+    test("real DOM focus follows the highlight — the picker's own routine", () => {
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+      const $list = resultsList();
+      $list.append(
+        $('<li class="select2-results__option" data-selected="false" tabindex="-1">A company</li>')
+          .attr("id", "a-company-row")
+          .data("data", { id: "A company", text: "A company", _resultId: "a-company-row" })
+      );
+
+      type("abc");
+
+      picker.trigger("results:next", {});
+      picker.trigger("results:next", {});
+      // What the picker calls on every arrow keypress. Its own source says this
+      // is required for screen readers; on a row with no tabindex it is a
+      // silent no-op and focus stays on the previous row.
+      picker.focusOnActiveElement();
+
+      expect(document.activeElement).toBe(row()[0]);
     });
 
     test("it carries a payload with an id and a matching _resultId", () => {
@@ -243,6 +294,11 @@ describe("company-search manual-entry affordance", () => {
       expect(picker.selection.$selection.attr("aria-activedescendant")).toBe(
         helper.manualEntryRowId
       );
+      // The dropdown's own search field carries it too, and that is the element
+      // the field's aria-owns points FROM — so it is the one an AT client
+      // following the combobox pattern reads. Both are fed from the payload's
+      // _resultId; asserting only one left the other free to be wrong.
+      expect(searchInput().attr("aria-activedescendant")).toBe(helper.manualEntryRowId);
     });
 
     test("the label is the localised msgid, not a hard-coded English literal", () => {
@@ -398,7 +454,65 @@ describe("company-search manual-entry affordance", () => {
       // selector matches everything and could never fail. The inline display
       // this code actually sets is the assertable thing.
       expect($back[0].style.display).not.toBe("none");
-      expect($back.text()).toBe(TEXT.search_company);
+      jest.useRealTimers();
+    });
+
+    test("the way back out is localised, not a hard-coded English literal", () => {
+      // Asserting against TEXT.search_company would prove nothing: that value is
+      // byte-identical to the built-in fallback, so deleting the text-map lookup
+      // entirely leaves the assertion passing. Inject a DIFFERENT string, the
+      // way the row's own label test does.
+      ctx.twoinc.text.search_company = "Søk etter selskap";
+      openWithAffordance();
+
+      expect(ctx.dom.getSearchCompanyBtnNode().text()).toBe("Søk etter selskap");
+    });
+
+    test("repeating the activation in one tick switches once, not once per press", () => {
+      jest.useFakeTimers();
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+      let entered = 0;
+      const realEnter = ctx.dom.enterManualCompanyEntry;
+      ctx.dom.enterManualCompanyEntry = function () {
+        entered++;
+        return realEnter.apply(this, arguments);
+      };
+
+      try {
+        type("abc");
+        // The selection is prevented, so the dropdown does NOT close and the row
+        // is still there to be hit again in the same tick.
+        row().trigger("mouseenter");
+        picker.trigger("results:select", {});
+        picker.trigger("results:select", {});
+        picker.trigger("results:select", {});
+        jest.advanceTimersByTime(1);
+
+        expect(entered).toBe(1);
+      } finally {
+        ctx.dom.enterManualCompanyEntry = realEnter;
+        jest.useRealTimers();
+      }
+    });
+
+    test("the real company field is cleared, not just the display one", () => {
+      jest.useFakeTimers();
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+      // What a completed pick leaves behind.
+      $("#billing_company").val("Previously Picked Ltd");
+      $("#company_id").val("11111111");
+
+      type("abc");
+      row().trigger("mouseenter");
+      picker.trigger("results:select", {});
+      jest.advanceTimersByTime(1);
+
+      // Otherwise the manual field the buyer is about to see is pre-filled with
+      // the company they just said is not theirs, next to an empty org number.
+      expect($("#billing_company").val()).toBe("");
+      expect($("#company_id").val()).toBe("");
       jest.useRealTimers();
     });
 
@@ -494,6 +608,230 @@ describe("company-search manual-entry affordance", () => {
       type("abc");
 
       expect(row().length).toBe(1);
+    });
+  });
+
+  describe("focus is not dropped when switching modes", () => {
+    beforeEach(() => {
+      ctx.Twoinc.getInstance();
+    });
+
+    test("entering manual entry focuses the field the buyer asked for", () => {
+      jest.useFakeTimers();
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+
+      type("abc");
+      row().trigger("mouseenter");
+      picker.trigger("results:select", {});
+      jest.advanceTimersByTime(1);
+
+      // Destroying the widget leaves activeElement on <body>, which means a
+      // keyboard user has to tab in from the top of the document again.
+      expect(document.activeElement).toBe($("#billing_company")[0]);
+      jest.useRealTimers();
+    });
+
+    test("leaving manual entry does not strand focus on the hidden button", () => {
+      jest.useFakeTimers();
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+      type("abc");
+      row().trigger("mouseenter");
+      picker.trigger("results:select", {});
+      jest.advanceTimersByTime(1);
+      jest.useRealTimers();
+
+      ctx.dom.exitManualCompanyEntry();
+
+      // Whatever it lands on, it must not be the button that was just hidden,
+      // and it must not be nothing.
+      expect(document.activeElement).not.toBe($("#" + helper.searchCompanyBtnId)[0]);
+      expect(document.activeElement).not.toBe(document.body);
+    });
+
+    test("focusing a field that is not there reports failure rather than lying", () => {
+      // Both callers run on a surface that may not render the field. A bare
+      // .focus() on an empty jQuery set is a silent no-op that reads as success.
+      expect(ctx.dom.focusVisibleCompanyField("#no_such_field_at_all")).toBe(false);
+      expect(ctx.dom.focusVisibleCompanyField("#billing_company")).toBe(true);
+    });
+  });
+
+  describe("one handler and one observer, across every re-bind", () => {
+    /** @returns {number} namespaced pre-select handlers on the select */
+    function selectingHandlerCount($select) {
+      const events = $._data($select[0], "events");
+      const bucket = events && events["select2:selecting"];
+      if (!bucket) return 0;
+      return bucket.filter((h) => h.namespace === "twoincManualEntry").length;
+    }
+
+    test("still one pre-select handler after several re-binds", () => {
+      // A duplicate here fires the whole manual-entry switch twice per
+      // activation. The body-input counter next door does not see this handler
+      // at all — it lives on the select.
+      const $select = openWithAffordance();
+
+      expect(selectingHandlerCount($select)).toBe(1);
+
+      helper.bindManualEntryAffordance($select);
+      helper.bindManualEntryAffordance($select);
+      helper.bindManualEntryAffordance($select);
+
+      expect(selectingHandlerCount($select)).toBe(1);
+    });
+
+    /**
+     * Record every MutationObserver, keyed on what it ends up observing.
+     *
+     * Filtering by target is not tidying: the widget constructs a
+     * MutationObserver of its OWN inside `_registerDomEvents`, one per widget.
+     * A test that merely counts constructions counts the library's too, so it
+     * reads 2 when the plugin made 1 and 3 when it made 1 — it fails for a
+     * reason that has nothing to do with this code.
+     *
+     * @returns {{on: Function, restore: Function}}
+     */
+    function observerSpy() {
+      const real = global.MutationObserver;
+      const records = [];
+      global.MutationObserver = function (cb) {
+        const observer = new real(cb);
+        const record = { target: null, disconnected: false };
+        const observe = observer.observe.bind(observer);
+        const disconnect = observer.disconnect.bind(observer);
+        observer.observe = function (node, opts) {
+          record.target = node;
+          return observe(node, opts);
+        };
+        observer.disconnect = function () {
+          record.disconnected = true;
+          return disconnect();
+        };
+        records.push(record);
+        return observer;
+      };
+      return {
+        /** @returns {Array} records whose observed node is `node` */
+        on: function (node) {
+          return records.filter((r) => r.target === node);
+        },
+        restore: function () {
+          global.MutationObserver = real;
+        }
+      };
+    }
+
+    test("still one observer on the results list after several re-binds", () => {
+      const spy = observerSpy();
+      try {
+        const $select = openWithAffordance();
+        const list = resultsList()[0];
+
+        helper.bindManualEntryAffordance($select);
+        helper.bindManualEntryAffordance($select);
+        type("abc");
+
+        const mine = spy.on(list);
+        expect(mine.length).toBe(1);
+        expect(mine.filter((o) => !o.disconnected).length).toBe(1);
+      } finally {
+        spy.restore();
+      }
+    });
+
+    test("a replacement results list gets the observer, the old one is released", () => {
+      const spy = observerSpy();
+      try {
+        const $select = openWithAffordance();
+        const firstList = resultsList()[0];
+        type("abc");
+        expect(spy.on(firstList).length).toBe(1);
+
+        // What clearing the selected company does: a brand-new widget, and so a
+        // brand-new results list.
+        $select.select2("destroy");
+        $select.html("");
+        $select.selectWoo(helper.genSelectWooParams());
+        $select.select2("open");
+        type("abc");
+
+        const secondList = resultsList()[0];
+        expect(secondList).not.toBe(firstList);
+        expect(spy.on(secondList).length).toBe(1);
+        // The old one was let go rather than left watching a detached node for
+        // the life of the page.
+        expect(spy.on(firstList)[0].disconnected).toBe(true);
+      } finally {
+        spy.restore();
+      }
+    });
+  });
+
+  describe("a re-created widget heals itself", () => {
+    beforeEach(() => {
+      ctx.Twoinc.getInstance();
+    });
+
+    test("the row survives clearing the selected company", () => {
+      const $select = openWithAffordance();
+      type("abc");
+      expect(row().length).toBe(1);
+
+      // The real gesture: the × on the floating company id. It re-creates the
+      // widget and knows nothing about this affordance, so nothing re-binds.
+      ctx.dom.clearSelectedCompany();
+      $select.select2("open");
+
+      type("abc");
+      expect(row().length).toBe(1);
+
+      // And it must SURVIVE the next render, which is the part that used to
+      // break: the delegated input handler still appended the row, then the
+      // first result set wiped it and no observer put it back.
+      const picker = $("#billing_company_display").data("select2");
+      picker.trigger("results:all", {
+        data: { results: [{ id: "A company", text: "A company", html: "A company" }] },
+        query: { term: "abc" }
+      });
+
+      return Promise.resolve().then(() => {
+        expect(row().length).toBe(1);
+        expect(resultsList().children().last().attr("id")).toBe(helper.manualEntryRowId);
+      });
+    });
+  });
+
+  describe("the sole-trader round trip", () => {
+    beforeEach(() => {
+      ctx.Twoinc.getInstance();
+    });
+
+    test("manual entry survives a trip through sole trader and back", () => {
+      jest.useFakeTimers();
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+
+      type("abc");
+      row().trigger("mouseenter");
+      picker.trigger("results:select", {});
+      jest.advanceTimersByTime(1);
+      jest.useRealTimers();
+      expect(ctx.twoinc.enable_company_search).toBe("no");
+
+      // Sole trader snapshots the CURRENT setting — which manual entry has just
+      // written as "no" — and business mode restores that snapshot, so the
+      // re-enable path early-returns and the picker never comes back.
+      ctx.soleTrader.setMode("sole_trader");
+      expect($("#" + helper.searchCompanyBtnId)[0].style.display).toBe("none");
+
+      ctx.soleTrader.setMode("business");
+
+      // Without a route back the buyer is stranded in manual entry with no way
+      // to reach the picker again.
+      expect(ctx.twoinc.enable_company_search).toBe("no");
+      expect($("#" + helper.searchCompanyBtnId)[0].style.display).not.toBe("none");
     });
   });
 

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -530,13 +530,14 @@ describe("company-search manual-entry affordance", () => {
       $("form[name='checkout']").append(
         [
           "<input type='text' id='billing_address_1' value='Registry Street 1' />",
-          "<input type='text' id='billing_address_2' value='' />",
+          "<input type='text' id='billing_address_2' value='Flat 2' />",
           "<input type='text' id='billing_city' value='Registryville' />",
           "<input type='text' id='billing_postcode' value='0001' />"
         ].join("\n")
       );
       // The precondition, asserted rather than assumed — see above.
       expect($("#billing_address_1").val()).toBe("Registry Street 1");
+      expect($("#billing_address_2").val()).toBe("Flat 2");
       expect($("#billing_city").val()).toBe("Registryville");
       expect($("#billing_postcode").val()).toBe("0001");
     }
@@ -548,6 +549,14 @@ describe("company-search manual-entry affordance", () => {
       const picker = $select.data("select2");
       givenLookedUpAddress();
 
+      // A pick has to actually happen for a lookup to have run — reaching the
+      // manual-entry row alone (typing to the threshold) never triggers one.
+      // Without this the test cannot distinguish "the fix clears a looked-up
+      // address" from "the fix always clears these fields", and the latter was
+      // a real bug the mutation harness caught: it wipes a logged-in buyer's
+      // own account-prefilled address on the ordinary no-pick path.
+      $("#company_id").val("11111111");
+
       type("abc");
       row().trigger("mouseenter");
       picker.trigger("results:select", {});
@@ -556,6 +565,7 @@ describe("company-search manual-entry affordance", () => {
       // Otherwise the order ships to the address of the company the buyer has
       // just said is not theirs, in fields they never visibly touched.
       expect($("#billing_address_1").val()).toBe("");
+      expect($("#billing_address_2").val()).toBe("");
       expect($("#billing_city").val()).toBe("");
       expect($("#billing_postcode").val()).toBe("");
       jest.useRealTimers();
@@ -569,6 +579,7 @@ describe("company-search manual-entry affordance", () => {
       const $select = openWithAffordance();
       const picker = $select.data("select2");
       givenLookedUpAddress();
+      $("#company_id").val("11111111");
 
       type("abc");
       row().trigger("mouseenter");
@@ -576,6 +587,32 @@ describe("company-search manual-entry affordance", () => {
       jest.advanceTimersByTime(1);
 
       expect($("#billing_address_1").val()).toBe("Registry Street 1");
+      expect($("#billing_address_2").val()).toBe("Flat 2");
+      expect($("#billing_city").val()).toBe("Registryville");
+      expect($("#billing_postcode").val()).toBe("0001");
+      jest.useRealTimers();
+    });
+
+    test("the address is left alone when the row is reached without ever picking a company", () => {
+      // The ordinary path: type to the threshold, see nothing you like, click
+      // "not on the list". No pick, so no lookup ever ran — clearing the
+      // address here would wipe the buyer's own account-prefilled address for
+      // no reason. This is the scenario the un-gated version of the fix
+      // (mirroring clearSelectedCompany verbatim) got wrong.
+      ctx.twoinc.enable_address_lookup = "yes";
+      jest.useFakeTimers();
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+      givenLookedUpAddress();
+      // #company_id is deliberately left empty — no pick happened.
+
+      type("abc");
+      row().trigger("mouseenter");
+      picker.trigger("results:select", {});
+      jest.advanceTimersByTime(1);
+
+      expect($("#billing_address_1").val()).toBe("Registry Street 1");
+      expect($("#billing_address_2").val()).toBe("Flat 2");
       expect($("#billing_city").val()).toBe("Registryville");
       expect($("#billing_postcode").val()).toBe("0001");
       jest.useRealTimers();

--- a/tests/js/wc-harness.js
+++ b/tests/js/wc-harness.js
@@ -160,6 +160,7 @@ function loadTwoinc(twoinc) {
     util: exported.twoincUtilHelper,
     dom: exported.twoincDomHelper,
     termChips: exported.twoincTermChips,
+    soleTrader: exported.twoincSoleTrader,
     // The Twoinc class itself, for the code paths that reach the singleton.
     // Safe to construct here: the constructor only initialises fields, and
     // every call re-evaluates the source, so the `instance` a test creates

--- a/tests/js/wc-harness.js
+++ b/tests/js/wc-harness.js
@@ -160,6 +160,11 @@ function loadTwoinc(twoinc) {
     util: exported.twoincUtilHelper,
     dom: exported.twoincDomHelper,
     termChips: exported.twoincTermChips,
+    // The Twoinc class itself, for the code paths that reach the singleton.
+    // Safe to construct here: the constructor only initialises fields, and
+    // every call re-evaluates the source, so the `instance` a test creates
+    // cannot leak into the next one.
+    Twoinc: exported.Twoinc,
     $: $,
     twoinc: settings
   };
@@ -208,6 +213,12 @@ function buildCheckoutForm(options) {
     "  </p>",
     '  <p id="billing_company_field">',
     "    <input type='text' id='billing_company' name='billing_company' value='' />",
+    "  </p>",
+    // The real checkout declares this alongside billing_company (both hidden
+    // behind the search field). Manual entry writes to it, and the link back
+    // out of manual entry is appended into #billing_company_field.
+    '  <p id="company_id_field">',
+    "    <input type='text' id='company_id' name='company_id' value='' />",
     "  </p>",
     "</form>"
   ].join("\n");

--- a/views/woocommerce_after_checkout_billing_form.php
+++ b/views/woocommerce_after_checkout_billing_form.php
@@ -6,12 +6,22 @@
         <div id="twoinc-em-target" class="twoinc-target"></div>
         <div id="twoinc-ph-target" class="twoinc-target"></div>
     </div>
-
-    <div class="company_not_in_btn" style="display: none;">
-        <?php esc_html_e('My company is not on the list', 'twoinc-payment-gateway'); ?>
-    </div>
-
-    <div id="search_company_btn" style="display: none;">
-        <?php esc_html_e('Search for company', 'twoinc-payment-gateway'); ?>
-    </div>
+    <?php
+    /*
+     * The "my company is not on the list" affordance and the link back to
+     * search used to be two hidden <div>s here, cloned into the dropdown by
+     * the checkout JS (TWO-25288).
+     *
+     * They are built in JS from the localised text map now. Two reasons, both
+     * load-bearing rather than tidying:
+     *
+     *  - the affordance has to be a real pseudo-option <li> inside the results
+     *    list to be arrow-key reachable and announced, which a cloned <div>
+     *    cannot become; and
+     *  - this view is rendered on the checkout page only. The pay-for-order
+     *    page renders its own copy of the company inputs and runs the same
+     *    search binding, so cloning from here left that page with no way into
+     *    manual entry and no way back out.
+     */
+    ?>
 </div>


### PR DESCRIPTION
TWO-25288 element 5. Makes `My company is not on the list` a real, keyboard-reachable row inside the company-search dropdown, and makes the way back out of manual entry reachable too.

## What was wrong

The affordance was a hidden `<div>` in the checkout billing form, cloned into the dropdown and appended to the results list's **parent** — outside the subtree the search field's `aria-owns` points at. No `role`, no `id`, no payload, no `tabindex`. It was not reachable by keyboard at all. The link back out of manual entry was an unreachable `<div>` as well.

Two further defects in the same block:

- the handler that showed it was bound **inside a polling callback** that fired long after the dropdown opened, so a fast typist's first keystrokes were dropped;
- it was re-bound on **every dropdown open with no matching `.off()`**, accumulating one duplicate handler per open.

## What this does

**A genuine pseudo-option, last row inside the list.** It mirrors, attribute for attribute, what the picker's own option factory produces for a real result row: `role="option"`, `data-selected="false"`, `tabindex="-1"`, a stable id, and a payload whose `_resultId` matches that id. Asserted by comparing against a row the widget itself builds, rather than against a hand-written list that could drift out of step with the library.

`tabindex="-1"` is not decoration. On every arrow keypress the picker calls `.focus()` on the highlighted row — its own source says that is required for screen readers to work — and an `<li>` with no tabindex cannot take focus, so that call is a silent no-op and focus stays stranded on the *previous* row while this one is visually highlighted. `_resultId` is what the picker copies into `aria-activedescendant`, on both the dropdown's search field and the selection container. The `--selectable` class is belt-and-braces only: that string does not occur anywhere in the bundle pinned here, so it is inert today and is described as such in the source — it costs nothing and keeps the row navigable if a host platform ever swaps the picker for one that keys off a class.

> **Why `data-selected` is present here and absent on the sibling platforms.** The other implementations of this same element under TWO-25288 **drop** that attribute. That is not an inconsistency to reconcile, and neither side is a bug.
>
> The attribute is not part of any published ARIA contract. It is an implementation detail of the specific picker build a platform ships, and the platforms ship different ones. The picker this plugin uses comes from the host platform rather than from this repo, and it is an older lineage: verified against the dependency actually installed here, it derives its entire navigable result set from the presence of that attribute, and it treats the already-selected value on a row as a signal to **close** the dropdown rather than to select the row. So omitting the attribute makes the row unreachable, and setting it to the already-selected value makes the row look reachable while doing nothing — both failure modes are pinned by mutations here.
>
> A platform whose picker derives its navigable set from a CSS class instead gets nothing from the attribute, and is right to leave it out. Read the two as the same rule applied to two libraries. The mirror of this note is in the sibling change; see TWO-25288 for the per-platform verification.

**One activation path for keyboard and mouse.** The picker turns both Enter on the highlighted row and a click on it into the same internal select, and fires a preventable pre-event first. Intercepting that one event covers both, and the previous click-only handler is gone — keeping it would have double-fired on every mouse activation and let the two inputs drift apart. Prevention means nothing is written: no company name, no company id, no approval call, no address lookup.

**Defect 1 fixed** by delegating the visibility handler on `<body>`, so it exists before the buyer's first keystroke rather than after a poll notices the field appeared. **Defect 2 fixed** by namespacing it and calling `.off()` before `.on()`, so the repeated re-binds (the timed re-run of the search setup, and every return out of manual entry) leave exactly one.

**Timing unchanged from the reference:** the row appears on `input` once the term reaches the threshold, *before* the debounced request goes out. No "has a search run" gate — a buyer who already knows their company is not in the registry should not wait for a round trip to find that out. The threshold is read from the one shared constant introduced earlier in this ticket, not re-hard-coded.

**Re-appended after every render.** The picker empties the whole list on each new result set, each message, and the searching state; a MutationObserver on the list covers all of them without guessing at internal events.

**The way back out is a `<button type="button">`** rather than the old `<div>`, so it is focusable and Enter/Space-activatable with no keydown bridge of our own.

## Found by review, fixed here

**The row died permanently after a widget re-create.** Clearing the selected company — the × on the floating company id, i.e. the "un-pick that, let me search again" gesture that most often precedes needing this row — rebuilds the picker and so the results list. The render watcher was installed from the bind path and keyed on the old list, so it was never re-installed: the row would appear on a keystroke and then be wiped by the first render, for the rest of the page. It installs from the per-keystroke sync now, so any re-creation heals itself without a third bind site to keep in step, and at most one watcher is live with the previous disconnected.

**Focus is no longer dropped on either mode switch.** Entering manual entry destroyed the widget and focused nothing, leaving `activeElement` on `<body>`; leaving it hid the button that had focus. Both paths now move focus, and the helper that does it reports failure rather than claiming success when the field is absent.

**Entering manual entry clears the real company field too**, not only the display one — otherwise the manual field is pre-filled with the company the buyer has just said is not theirs, next to an empty number field. The exit path already cleared that mirror, so this was asymmetric as well as wrong.

**A manual-entry → sole-trader → business round trip no longer strands the buyer.** That path snapshots the current search setting, which manual entry had written as disabled, and restores it — so the re-enable early-returns and the link back to search stayed hidden with no route to the picker at all.

**A repeated activation in one tick switches once.** The prevented selection leaves the dropdown open, so the row was still there to be hit again; it is removed up front.

## The pay-for-order surface

That page renders its own copy of the company inputs and runs the same search binding, but it does not render the billing-form view — so the clone source was an empty set there and the affordance was silently absent, with no way into manual entry and no way back.

Both strings moved to the localised text map and both nodes are built in JS, so that page gets the affordance with no template of its own. Building in JS rather than adding markup to the second view, for two reasons: the row has to be an `<li>` pseudo-option, which a cloned `<div>` cannot become, so the node was going to be constructed either way; and one string source beats two.

That exposed a latent trap on the same page: it lays each company input out in a wrapper carrying its own hidden state, independent of the field inside it. Revealing the manual field alone would have left manual entry with nowhere to type. Wrapper visibility now follows the field's, which is a no-op on the checkout page. This was already reachable via the merchant setting that disables company search; it just had no buyer-facing route until now.

## Catalogues

The two msgids move from the view to the text map, so their reference comments move with them. Msgids and every translation are unchanged, and the compiled catalogues are byte-identical — the gettext gate confirms it.

## Verification

`npm run test:js` — **138 passing across 4 suites**, of which 42 are this element's own. The new suite `tests/js/company-search-manual-entry.test.js` drives the real widget rather than a mock, because the row's reachability *is* a property of the widget's own navigation code — a mock would have to reproduce that code correctly to catch a regression in it, which is exactly the assumption that let the previous unreachable implementation ship.

Reachability and announcement are asserted by driving the picker's own navigation and focus routines and then reading `document.activeElement` and all three `aria-activedescendant` sites, not by inspecting markup and hoping.

### Applied-proof mutation pass

Every mutation was re-run under a shared applied-proof harness that refuses to report a result it cannot trust: the tree must be clean before mutating, `git diff` must be non-empty after applying or no test result is printed at all, and the file is restored and re-checked clean on every exit path. Anchors are matched as plain text, never regex.

The harness was copied into a private scratchpad and md5-verified there rather than run from a shared path — a shared mutable script is as dangerous as a shared mutable file. Run against md5 `2955b8b0c29851248d5f85a7c2e2720d`, byte-identical to the published snapshot, HEAD confirmed unmoved across the pass, tree clean after.

**36 mutations re-run · 36 applied and RED · 0 survived · 0 did-not-apply · 0 aborts.** Every verdict came from `npm run test:js`; no PHP or shell runner was ever put through the harness, so none of these verdicts depends on runner-shaped output parsing.

Anchors were validated up front against the current source and every one had to resolve to **exactly one** occurrence before anything ran. That gate earned its keep twice: one anchor was ambiguous because the same assignment appears in both the manual-entry path and the sole-trader suppression path, and mutating whichever came first would have tested something else entirely; and the exact-count-1 rule also covers indentation drift by construction, since a mis-indented literal resolves to zero matches and is reported stale rather than silently skipped.

Notable kills: appending to the list's parent instead of the list (19 tests); `data-selected="true"` (attributes plus every activation test); dropping `tabindex` (three, including the focus assertion); dropping `_resultId` (payload plus announcement); a `hasSearched` gate (19); hard-coding the threshold; removing the render watcher; installing it only from the bind path; never disconnecting the previous one; dropping the re-entrancy guard; dropping `preventDefault`; intercepting every activation rather than only the sentinel; and `focusVisibleCompanyField` claiming success unconditionally.

### Four survivors, and what was done about them

The pass found four mutations that left the suite green. None was a bug; three were code claiming a guarantee nothing checked, and they were **removed** rather than given a test written to fit them.

- **A same-tick activation latch was unreachable.** Removing the row before deferring already prevents a repeated activation, so no path reached the latch. Deleted.
- **The bind function's widget argument was not load-bearing.** Reassigning it to a fresh lookup of the same field changed nothing and no test noticed — everything in the body names the company-search field, so the parameter could only ever be that one element. Signature dropped.
- **An eager render-watcher install was redundant.** The row cannot exist before the buyer has typed to the threshold, and typing runs the sync, which installs the watcher. One install point now, which is also what makes a re-created widget heal itself.
- **The one-watcher-per-node guard needed more than one keystroke to be visible.** The only genuine test gap of the four: with a single install point, one keystroke cannot distinguish "installed once" from "re-installed per character". The test now types four times, and the mutation goes red.

### Vacuity audit

Audited for two distinct classes of assertion that cannot fail.

The **structural-token** class — a comparison against an opaque empty-object token, which matches any other empty-object token — is absent outright: this suite uses no test doubles, so there is no `toHaveBeenCalledWith` and nothing to spy on.

The **already-empty collection** class was present twice, and the detection method was reading *which* test caught each mutation rather than trusting the red.

- `no company value is written` rested on three "nothing happened" checks that a recorder which was never wired up satisfies. Making the interception unconditional left it green. It now selects an ordinary row the ordinary way first and requires that to be recorded, and that mutation goes red.
- `absent below the threshold` was genuinely unfalsifiable — the row had never been in the list, so no mutation could turn it red, and none of the original 25 did. It now reaches the threshold first and asserts the row is present before asserting it goes away.

One further vacuity was caught in a *test* rather than the source: the observer count included the MutationObserver the widget constructs for itself, so it read 2 where the plugin made 1 and would have failed for a reason unrelated to this code. It is keyed on the observed node now.

Two harness traps were hit and fixed rather than worked around: `:hidden` matches every element under jsdom (zero dimensions), so the visibility assertions read the inline `display` this code actually sets; and the first reachability test asserted only the selection container's `aria-activedescendant`, which the dropped-`_resultId` mutation survived — the dropdown's search field is the element the field's `aria-owns` points from, and all three are asserted now.

## Not verified — needs a real browser

- That the row *looks* like an option row. It inherits the picker's option padding and highlight instead of a hand-rolled margin. The highlighted-row text colour is no longer left to the cascade — review found the id rule outranked the picker's highlight rule, leaving brand blue on a blue background at roughly 2.5:1, and it is now restated at matching specificity for both theme prefixes. jsdom resolves no box geometry, so the rendered result is still unobserved.
- That the `<button>` reset renders identically to the old `<div>` link.
- Screen-reader announcement. The ARIA wiring is asserted at the attribute level and driven through the widget's own navigation, which is as far as jsdom reaches.
- The pay-for-order page end to end. Its wrapper behaviour is unit-covered and its markup verified against the fetched ref, but the page itself was not loaded.

Not merged — the coordinator runs the adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
