### PR TITLE
TWO-25288: show the captured company read-only, name and number

### DIFF
--- a/assets/css/c-biagiotti-mikado.css
+++ b/assets/css/c-biagiotti-mikado.css
@@ -6,7 +6,3 @@
 #purchase_order_number_field {
   width: 100%;
 }
-
-.twoinc-company-summary {
-  margin-right: 20px;
-}

--- a/assets/css/c-biagiotti-mikado.css
+++ b/assets/css/c-biagiotti-mikado.css
@@ -7,6 +7,6 @@
   width: 100%;
 }
 
-.floating-company {
+.twoinc-company-summary {
   margin-right: 20px;
 }

--- a/assets/css/c-kava.css
+++ b/assets/css/c-kava.css
@@ -1,3 +1,13 @@
-.twoinc-company-summary {
-  margin-right: 8px;
-}
+/*
+ * Kava theme overrides — intentionally empty (TWO-25288).
+ *
+ * The one rule this file held nudged the floating company-id overlay clear of
+ * the select2 arrow with a `margin-right`. That overlay is gone, replaced by a
+ * block-level read-only summary in normal flow, where the margin cannot change
+ * anything.
+ *
+ * The file itself has to stay: insertCustomCss() builds
+ * `assets/css/c-<theme>.css` from the detected theme and appends the <link>
+ * unconditionally, so removing it would turn a supported theme into a 404
+ * rather than a no-op.
+ */

--- a/assets/css/c-kava.css
+++ b/assets/css/c-kava.css
@@ -1,3 +1,3 @@
-.floating-company {
+.twoinc-company-summary {
   margin-right: 8px;
 }

--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -180,6 +180,15 @@
 }
 
 /*
+ * The pay-for-order page lays its copy of the company fields out as wrapping
+ * flex items, so the summary lands as an item on the same row rather than
+ * underneath them. Give it the full row there.
+ */
+.custom-checkout .twoinc-company-summary {
+  flex-basis: 100%;
+}
+
+/*
  * Manual-entry row inside the company-search results list (TWO-25288).
  *
  * It is an option row now rather than a floating div beside the list, so the

--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -148,22 +148,34 @@
   padding-bottom: 15px;
 }
 
-.floating-company {
-  position: absolute;
-  right: 8px;
-  top: 50%;
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
+/*
+ * Read-only summary of the captured company (TWO-25288).
+ *
+ * Replaces the floating company-id overlay, which was absolutely positioned
+ * over the picker's selection box and so could only ever hold one short value.
+ * This sits in normal flow underneath the company fields and carries both the
+ * name and the number, so neither has to compete with the other for the same
+ * few pixels of the combobox.
+ */
+.twoinc-company-summary {
+  padding-bottom: 15px;
+  line-height: 1.4;
 }
 
-.floating-company-id {
-  position: absolute;
-  right: 24px;
-  margin-top: 0.8px;
-  top: 50%;
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  color: #dddddd;
+.twoinc-company-summary-name {
+  font-weight: 600;
+}
+
+/*
+ * The number reads as secondary to the name it belongs to, but not as disabled
+ * text: this is the buyer's own registry identifier, and the grey the overlay
+ * used (#ddd) was close to invisible on a white checkout. Kept as a flat
+ * single-class selector so brand overlays can recolour it without raising
+ * specificity.
+ */
+.twoinc-company-summary-id {
+  margin-left: 8px;
+  color: #6b6b6b;
   white-space: nowrap;
 }
 

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -17,22 +17,21 @@ let twoincUtilHelper = {
    * Normalise a checkout value read out of the DOM to displayable text
    * (TWO-25288).
    *
-   * Whitespace-only becomes empty, and the non-breaking space specifically:
-   * the company picker's empty option carries `&nbsp;` as its label, so an
-   * unselected picker reads back as a one-character string that is truthy and
-   * invisible. The escape is written out rather than the character pasted in,
-   * so nothing here depends on a reader — or an editor — telling the two space
-   * characters apart. Null and undefined become empty too, so callers need no
-   * guard of their own.
+   * The case that matters is the company picker's empty option, whose label is
+   * a non-breaking space — so an unselected picker reads back as a
+   * one-character string that is truthy and invisible, and anything checking
+   * only for `""` renders it as a company. `String.trim()` is enough on its
+   * own: its whitespace definition includes U+00A0. An explicit
+   * `.replace(/\u00a0/g, " ")` sat in front of it until review pointed out it
+   * could never change an outcome. Null and undefined become empty too, so
+   * callers need no guard of their own.
    *
    * @param {*} value
    * @returns {string}
    */
   blankToEmpty: function (value) {
     if (value === null || value === undefined) return "";
-    return String(value)
-      .replace(/\u00a0/g, " ")
-      .trim();
+    return String(value).trim();
   },
 
   /**
@@ -1062,6 +1061,20 @@ let twoincDomHelper = {
     );
     twoincSelectWooHelper.fixSelectWooPositionCompanyName();
     jQuery("#company_id").val("");
+    // The real company field too, matching what enterManualCompanyEntry does.
+    // Without this the cleared company survives in #billing_company: it is the
+    // field WooCommerce posts, so the order carried a company the buyer had
+    // just been shown as cleared, and — since #billing_company is also the live
+    // mirror the read-only summary reads — the summary reappeared showing it on
+    // the next re-render (TWO-25288).
+    //
+    // Gated on the picker being the capture mode, which is what this function
+    // is about clearing. In manual entry #billing_company is the buyer's own
+    // typed input, and this runs on every country change: clearing
+    // unconditionally would wipe a name they typed for reasons of their own.
+    if (window.twoinc.enable_company_search === "yes") {
+      jQuery("#billing_company").val("");
+    }
 
     // Clear the addresses, in case address get request fails
     if (window.twoinc.enable_address_lookup === "yes") {

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -14,6 +14,28 @@ let twoincUtilHelper = {
   },
 
   /**
+   * Normalise a checkout value read out of the DOM to displayable text
+   * (TWO-25288).
+   *
+   * Whitespace-only becomes empty, and the non-breaking space specifically:
+   * the company picker's empty option carries `&nbsp;` as its label, so an
+   * unselected picker reads back as a one-character string that is truthy and
+   * invisible. The escape is written out rather than the character pasted in,
+   * so nothing here depends on a reader — or an editor — telling the two space
+   * characters apart. Null and undefined become empty too, so callers need no
+   * guard of their own.
+   *
+   * @param {*} value
+   * @returns {string}
+   */
+  blankToEmpty: function (value) {
+    if (value === null || value === undefined) return "";
+    return String(value)
+      .replace(/\u00a0/g, " ")
+      .trim();
+  },
+
+  /**
    * Construct url to Twoinc checkout api.
    *
    * `client` / `client_v` identify this plugin and its version to the API, and
@@ -879,6 +901,12 @@ let twoincDomHelper = {
     twoincDomHelper.toggleRequiredCues(requiredTargets, isTwoincSelected);
 
     twoincDomHelper.syncCompanyFieldWrappers();
+
+    // Last, and unconditionally: this function runs on every payment-method,
+    // country and capture-mode switch, which is exactly when the summary's own
+    // visibility gate needs re-evaluating. It reads the current inputs and
+    // calls nothing that re-enters here.
+    twoincDomHelper.renderCompanySummary();
   },
 
   /**
@@ -1045,50 +1073,118 @@ let twoincDomHelper = {
     }
     Twoinc.getInstance().registryAddressApplied = false;
 
-    jQuery("#select2-billing_company_display-container")
-      .parent()
-      .find(".select2-selection__arrow")
-      .show();
     Twoinc.getInstance().customerCompany = {};
+    // Nothing captured any more, so nothing to show. Passed explicitly: the
+    // picker is re-attached above and reads back as the empty option, and the
+    // 3s re-read at the end of this function would otherwise be the first
+    // thing to clear the summary.
+    twoincDomHelper.renderCompanySummary("", "");
     twoincDomHelper.togglePaySubtitleDesc();
 
     // Update again after all elements are updated
     setTimeout(function () {
       Twoinc.getInstance().customerCompany = twoincDomHelper.getCompanyData();
+      twoincDomHelper.renderCompanySummary();
       twoincDomHelper.togglePaySubtitleDesc();
     }, 3000);
   },
 
+  /** DOM id of the read-only captured-company summary (TWO-25288). */
+  companySummaryId: "twoinc_company_summary",
+
   /**
-   * Insert the floating company id and closing button
+   * The read-only summary of the captured company, built hidden on first use
+   * (TWO-25288).
+   *
+   * Two <span>s and no <input>: the captured identity is a value the buyer is
+   * shown, not a field they fill in, so there is deliberately nothing here to
+   * type into and no control that removes it. `readonly` inputs are this
+   * plugin's convention for a field that still carries a value the buyer must
+   * not change (sole-trader mode readonly-locks #billing_company and
+   * #company_id) — but those are the SUBMITTED fields, and they keep that job
+   * untouched. This is a display beside them, so spans are the right shape.
+   *
+   * Anchored after the company-id field's enclosing `.twoinc-inp-container`
+   * where there is one, NOT inside it. The pay-for-order page wraps every
+   * company input in such a container and hides the container, not just the
+   * field (see syncCompanyFieldWrappers) — so a summary placed inside would be
+   * invisible on that page in exactly the search mode it matters most for. The
+   * checkout page has no wrappers and the anchor falls through to the field.
+   *
+   * @returns {Object} jQuery-wrapped summary, or an empty set on a page with
+   *   no company fields at all
    */
-  insertFloatingCompany: function (companyId, delayInSecs) {
-    if (!companyId) return;
+  getCompanySummaryNode: function () {
+    let $node = jQuery("#" + twoincDomHelper.companySummaryId);
+    if ($node.length) return $node;
 
-    // Remove if exist
-    jQuery(".floating-company").remove();
+    let $field = jQuery("#company_id_field");
+    if (!$field.length) $field = jQuery("#billing_company_field");
+    if (!$field.length) return jQuery();
 
-    let floatingCompany = jQuery(
-      '<span class="floating-company">' +
-        '  <span class="floating-company-id">' +
-        companyId +
-        "</span>" +
-        '  <img src="' +
-        window.twoinc.twoinc_plugin_url +
-        'assets/images/x-button.svg" onclick="twoincDomHelper.clearSelectedCompany()"></img>' +
-        "</span>"
+    $node = jQuery(
+      '<div id="' +
+        twoincDomHelper.companySummaryId +
+        '" class="twoinc-company-summary hidden">' +
+        '<span class="twoinc-company-summary-name"></span>' +
+        '<span class="twoinc-company-summary-id"></span>' +
+        "</div>"
     );
-    floatingCompany.hide();
-    floatingCompany.insertBefore("#billing_company_display");
-    setTimeout(function () {
-      let floatingCompany = jQuery(".floating-company");
-      floatingCompany.insertBefore("#select2-billing_company_display-container");
-      floatingCompany.show();
-      jQuery("#select2-billing_company_display-container")
-        .parent()
-        .find(".select2-selection__arrow")
-        .hide();
-    }, delayInSecs);
+    const $wrapper = $field.closest(".twoinc-inp-container");
+    $node.insertAfter($wrapper.length ? $wrapper : $field);
+    return $node;
+  },
+
+  /**
+   * Render the captured company's name and number, read-only (TWO-25288).
+   *
+   * Supersedes the floating company-id overlay this used to be. That showed
+   * the number only, and shipped an x-button that let the buyer delete a
+   * registry identity from the checkout — which is the affordance this
+   * reversal removes. Both values now render as text, in one place, for all
+   * three capture modes:
+   *
+   *   - company search: name and number as picked from the registry;
+   *   - sole trader: name and number as held by Two for the buyer;
+   *   - manual entry: whatever name the buyer typed, and NO number — manual
+   *     entry clears #company_id, so the number renders empty until the buyer
+   *     supplies one in the field of its own.
+   *
+   * Both arguments are optional. Callers that already hold the values pass
+   * them (the picker's select handler, sole-trader autofill, the user-meta
+   * restore — which writes #company_id AFTER this runs, so reading the DOM
+   * there would render an empty number). Everyone else omits them and the
+   * current inputs are read.
+   *
+   * @param {string} [companyName]
+   * @param {string} [companyId]
+   * @returns {void}
+   */
+  renderCompanySummary: function (companyName, companyId) {
+    const $node = twoincDomHelper.getCompanySummaryNode();
+    if (!$node.length) return;
+
+    const data =
+      companyName === undefined && companyId === undefined
+        ? twoincDomHelper.getCompanyData()
+        : { company_name: companyName, organization_number: companyId };
+
+    // The empty selectWoo option's label is a non-breaking space, so an
+    // unselected picker reads back as " " rather than "" — which would
+    // render as a summary with an invisible name in it.
+    const name = twoincUtilHelper.blankToEmpty(data.company_name);
+    const number = twoincUtilHelper.blankToEmpty(data.organization_number);
+
+    $node.find(".twoinc-company-summary-name").text(name);
+    $node.find(".twoinc-company-summary-id").text(number);
+
+    // Shown only for a Two purchase with something captured. A buyer paying by
+    // another method may well have typed a company name into WooCommerce's own
+    // field, and echoing it back at them under Two's styling is noise.
+    const visible = Boolean(
+      (name || number) && twoincDomHelper.isTwoincVisible() && twoincDomHelper.isTwoincSelected()
+    );
+    $node.toggleClass("hidden", !visible);
   },
 
   /**
@@ -1540,9 +1636,14 @@ let twoincDomHelper = {
         }
         selectElem.value = window.twoinc.billing_company;
 
-        // Append company id to company name select box
+        // Show the restored company read-only beside the field. Both values
+        // are passed explicitly: `#company_id` is written further down this
+        // function, so reading the DOM here would render an empty number.
         if (window.twoinc.user_meta_exists) {
-          twoincDomHelper.insertFloatingCompany(window.twoinc.company_id, 2000);
+          twoincDomHelper.renderCompanySummary(
+            window.twoinc.billing_company,
+            window.twoinc.company_id
+          );
         }
       }
     }
@@ -2090,6 +2191,12 @@ let twoincSoleTrader = {
     const instance = Twoinc.getInstance();
     instance.customerCompany.organization_number = companyId;
     instance.customerCompany.company_name = companyName;
+    // Explicit rather than DOM-read: sole-trader mode leaves
+    // enable_company_search at "no", so getCompanyName() would read
+    // #billing_company — correct today, but this function is the authority on
+    // what was just captured and the summary should not depend on the order
+    // the two mirrors are written in (TWO-25288).
+    twoincDomHelper.renderCompanySummary(companyName, companyId);
     if (companyId) {
       instance.getApproval();
     }
@@ -2311,10 +2418,11 @@ class Twoinc {
       // Set the company name to HTML DOM
       $billingCompany.val(data.id);
 
-      // Display company ID on the right of selected company name
-      setTimeout(function () {
-        twoincDomHelper.insertFloatingCompany(data.company_id, 0);
-      }, 0);
+      // Display the picked company read-only. Synchronous, unlike the
+      // overlay this replaces: that had to wait for select2 to rebuild its
+      // selection container because it was positioned against it, and this is
+      // anchored to a field that is already in the document.
+      twoincDomHelper.renderCompanySummary(data.id, data.company_id);
 
       // Update the company name in agreement sentence and text in subtitle/description
       twoincDomHelper.togglePaySubtitleDesc();
@@ -2417,6 +2525,7 @@ class Twoinc {
     );
     $body.on("change", "#billing_company", function () {
       Twoinc.getInstance().customerCompany.company_name = twoincDomHelper.getCompanyName();
+      twoincDomHelper.renderCompanySummary();
       twoincDomHelper.togglePaySubtitleDesc();
     });
 
@@ -2456,10 +2565,7 @@ class Twoinc {
       twoincDomHelper.saveCheckoutInputs();
       Twoinc.getInstance().customerCompany = twoincDomHelper.getCompanyData();
       Twoinc.getInstance().customerRepresentative = twoincDomHelper.getRepresentativeData();
-      twoincDomHelper.insertFloatingCompany(
-        Twoinc.getInstance().customerCompany.organization_number,
-        0
-      );
+      twoincDomHelper.renderCompanySummary();
       Twoinc.getInstance().getApproval();
     }, 1000);
     this.updateElements();
@@ -2787,6 +2893,7 @@ class Twoinc {
       Twoinc.getInstance().customerCompany.company_name = $input.val();
     }
 
+    twoincDomHelper.renderCompanySummary();
     Twoinc.getInstance().getApproval();
   }
 

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1166,7 +1166,7 @@ let twoincDomHelper = {
 
     const data =
       companyName === undefined && companyId === undefined
-        ? twoincDomHelper.getCompanyData()
+        ? twoincDomHelper.readCapturedCompany()
         : { company_name: companyName, organization_number: companyId };
 
     // The empty selectWoo option's label is a non-breaking space, so an
@@ -1185,6 +1185,38 @@ let twoincDomHelper = {
       (name || number) && twoincDomHelper.isTwoincVisible() && twoincDomHelper.isTwoincSelected()
     );
     $node.toggleClass("hidden", !visible);
+  },
+
+  /**
+   * Read the captured company straight out of the live inputs (TWO-25288).
+   *
+   * Deliberately NOT getCompanyData(), which is what this used to call. In
+   * search mode that reaches getCompanyName(), and getCompanyName() reads the
+   * company name out of the `checkoutInputs` sessionStorage snapshot rather
+   * than the document — a snapshot saveCheckoutInputs() refreshes on a 3-second
+   * interval. So a summary rendered from it in search mode showed whatever the
+   * name was up to three seconds ago, or nothing at all before the first save:
+   * switching payment method away and back re-renders through
+   * toggleBusinessFields, which would have blanked the name of a company that
+   * was still very much picked, while the number — read live — stayed.
+   *
+   * `#billing_company` is the live mirror in every capture mode: the picker's
+   * select handler writes it on each pick, manual entry writes it, sole-trader
+   * autofill writes it, and the user-meta restore writes it. The display
+   * select's own value is the fallback, since its options carry the company
+   * name as their value.
+   *
+   * @returns {{company_name: string, organization_number: string}}
+   */
+  readCapturedCompany: function () {
+    let name = twoincUtilHelper.blankToEmpty(jQuery("#billing_company").val());
+    if (!name) {
+      name = twoincUtilHelper.blankToEmpty(jQuery("#billing_company_display").val());
+    }
+    return {
+      company_name: name,
+      organization_number: twoincUtilHelper.blankToEmpty(jQuery("#company_id").val())
+    };
   },
 
   /**

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -17,14 +17,15 @@ let twoincUtilHelper = {
    * Normalise a checkout value read out of the DOM to displayable text
    * (TWO-25288).
    *
-   * The case that matters is the company picker's empty option, whose label is
-   * a non-breaking space — so an unselected picker reads back as a
-   * one-character string that is truthy and invisible, and anything checking
-   * only for `""` renders it as a company. `String.trim()` is enough on its
-   * own: its whitespace definition includes U+00A0. An explicit
-   * `.replace(/\u00a0/g, " ")` sat in front of it until review pointed out it
-   * could never change an outcome. Null and undefined become empty too, so
-   * callers need no guard of their own.
+   * Null, undefined and whitespace-only all become `""`, so callers can treat
+   * "is there a value" as a plain truthiness check without a guard of their own.
+   *
+   * Whitespace-only is the case worth having: the company picker's empty option
+   * carries a non-breaking space as its LABEL (its value is `""`), and that
+   * label does reach code — `getCompanyName()` reads the picker's rendered
+   * selection text out of the checkout snapshot — where it is a one-character
+   * string that is truthy and invisible. `trim()` covers it without special
+   * handling, since its whitespace definition includes U+00A0.
    *
    * @param {*} value
    * @returns {string}
@@ -1087,11 +1088,11 @@ let twoincDomHelper = {
     Twoinc.getInstance().registryAddressApplied = false;
 
     Twoinc.getInstance().customerCompany = {};
-    // Nothing captured any more, so nothing to show. Passed explicitly: the
-    // picker is re-attached above and reads back as the empty option, and the
-    // 3s re-read at the end of this function would otherwise be the first
-    // thing to clear the summary.
-    twoincDomHelper.renderCompanySummary("", "");
+    // Re-read rather than forced empty. Forcing it disagreed with the gated
+    // clear above: in manual entry the buyer's typed company is deliberately
+    // kept, so the summary vanished here and reappeared 3s later when the
+    // re-read below ran.
+    twoincDomHelper.renderCompanySummary();
     twoincDomHelper.togglePaySubtitleDesc();
 
     // Update again after all elements are updated
@@ -1213,21 +1214,25 @@ let twoincDomHelper = {
    * toggleBusinessFields, which would have blanked the name of a company that
    * was still very much picked, while the number — read live — stayed.
    *
-   * `#billing_company` is the live mirror in every capture mode: the picker's
-   * select handler writes it on each pick, manual entry writes it, sole-trader
-   * autofill writes it, and the user-meta restore writes it. The display
-   * select's own value is the fallback, since its options carry the company
-   * name as their value.
+   * `#billing_company` and `#company_id`, and ONLY those two. They are the
+   * fields WooCommerce posts, and they are written by every capture mode: the
+   * picker's select handler on each pick, manual entry, sole-trader autofill,
+   * and the user-meta restore.
+   *
+   * The display select's value was briefly a fallback here, on the reasoning
+   * that its options carry the company name as their value. It had to go: the
+   * picker appends an <option> for every pick and neither select2("destroy")
+   * nor twoincSoleTrader.setCompany("", "") removes it, so leaving search mode
+   * left a company on that select which no longer existed in either posted
+   * field — and the fallback read it back, showing a company the order did not
+   * carry. Reading only what is posted is what keeps the display and the order
+   * unable to disagree.
    *
    * @returns {{company_name: string, organization_number: string}}
    */
   readCapturedCompany: function () {
-    let name = twoincUtilHelper.blankToEmpty(jQuery("#billing_company").val());
-    if (!name) {
-      name = twoincUtilHelper.blankToEmpty(jQuery("#billing_company_display").val());
-    }
     return {
-      company_name: name,
+      company_name: twoincUtilHelper.blankToEmpty(jQuery("#billing_company").val()),
       organization_number: twoincUtilHelper.blankToEmpty(jQuery("#company_id").val())
     };
   },
@@ -2233,14 +2238,20 @@ let twoincSoleTrader = {
   setCompany: function (companyId, companyName) {
     jQuery("#company_id").val(companyId);
     jQuery("#billing_company").val(companyName);
+    // The display select too, when this is the clearing call setMode("business")
+    // makes. The picker appends an <option> per pick and select2("destroy")
+    // leaves it selected, so without this a company picked before the sole-trader
+    // detour stayed on that select after being cleared from both posted fields
+    // (TWO-25288).
+    if (!companyName) {
+      jQuery("#billing_company_display").val("");
+    }
     const instance = Twoinc.getInstance();
     instance.customerCompany.organization_number = companyId;
     instance.customerCompany.company_name = companyName;
-    // Explicit rather than DOM-read: sole-trader mode leaves
-    // enable_company_search at "no", so getCompanyName() would read
-    // #billing_company — correct today, but this function is the authority on
-    // what was just captured and the summary should not depend on the order
-    // the two mirrors are written in (TWO-25288).
+    // Explicit rather than DOM-read: this function is the authority on what was
+    // just captured, so the summary should not depend on the order the mirrors
+    // above are written in (TWO-25288).
     twoincDomHelper.renderCompanySummary(companyName, companyId);
     if (companyId) {
       instance.getApproval();

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -219,10 +219,18 @@ about the company-search helper, so the bootstrap is left to no-op.
 - visibility: shown only for a Two purchase with something captured, hidden when the buyer
   switches to another payment method (with the fields still posting), and cleared by
   `clearSelectedCompany()`.
-- the picker's empty option is a non-breaking space — truthy, invisible, and untouched by
-  `trim()` on its own — so a summary that only checked for `""` would render an empty name
-  box. Pinned, along with the user-meta restore path, which passes both values explicitly
-  because `loadUserMetaInputs` writes `#company_id` _after_ it renders.
+- the picker's empty option carries a non-breaking space as its **label**, not its value —
+  truthy and invisible, so anything checking only for `""` renders it as a company. The live
+  read cannot see one (the value is `""`, asserted), so the normalisation is defensive
+  against the label reaching code the other way, through the checkout snapshot.
+- **a company that is no longer captured stays off screen.** The picker appends an `<option>`
+  per pick and neither `select2("destroy")` nor the clearing `setCompany("", "")` removes it,
+  so a search → sole trader → back-to-business round trip left a company on that select with
+  both posted fields empty. Pinned twice: the round trip itself, and the invariant behind it —
+  what is displayed is what `#billing_company` holds, with a deliberately stale option still
+  on the select.
+- the user-meta restore path, which passes both values explicitly because `loadUserMetaInputs`
+  writes `#company_id` _after_ it renders.
 
 ### Two defects these tests found, now fixed
 

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -199,6 +199,31 @@ about the company-search helper, so the bootstrap is left to no-op.
   land synchronously.
 - the sole-trader round trip does not strand a buyer in manual entry.
 
+`company-summary.test.js` — the read-only captured-company summary (TWO-25288):
+
+- all three capture modes render the right pair of values: the picked company's name and
+  organisation number in search mode, the name and number Two holds for a sole trader, and in
+  manual entry the typed name with **no** number, because entering manual entry clears the
+  number of the company the buyer has just disowned. A hit that carries no organisation number
+  at all renders its name alone.
+- search-mode rendering is driven through `enableCompanySearch`'s own `select2:select` binding
+  rather than by calling the render function, so unwiring the two fails the test.
+- the display is genuinely read-only: no `input`, `select`, `textarea` or `contenteditable`
+  inside it, both values in `span`s, nothing tabbable, and — the affordance this reversal
+  removes — no button, link, image, `onclick` or bound handler that would let the buyer delete
+  a captured company. The overlay this replaces shipped an `<img>` with an inline `onclick`.
+- submission is unaffected. `#billing_company` and `#company_id` still carry the values
+  WooCommerce serialises, re-rendering does not disturb them, and nothing inside the summary
+  carries a `name` attribute of its own — asserted against the form's real `serialize()`
+  output, since the summary sits inside the checkout form.
+- visibility: shown only for a Two purchase with something captured, hidden when the buyer
+  switches to another payment method (with the fields still posting), and cleared by
+  `clearSelectedCompany()`.
+- the picker's empty option is a non-breaking space — truthy, invisible, and untouched by
+  `trim()` on its own — so a summary that only checked for `""` would render an empty name
+  box. Pinned, along with the user-meta restore path, which passes both values explicitly
+  because `loadUserMetaInputs` writes `#company_id` _after_ it renders.
+
 ### Two defects these tests found, now fixed
 
 Both were pinned as characterisation tests when this suite landed, and both were fixed
@@ -232,8 +257,10 @@ suite green:
   and heading placement, and the currency-symbol fee label (ABN-468);
 - the selection side of company search — `onCompanySelected`-equivalent handling in
   `Twoinc.initialize`'s `select2:select` binding, `clearSelectedCompany()`, the
-  the address autofill. The manual-entry row is no longer among these — see its own suite
-  above;
+  the address autofill. Neither the manual-entry row nor the captured-company summary is among
+  these any more — see their own suites above. The `select2:select` binding and
+  `clearSelectedCompany()` are covered only for what they do to that summary; everything else
+  they do still is not;
 - `twoincDomHelper`'s field moving/reverting and validation cues;
 - `fixSelectWooPositionCompanyName`, `waitToFocus` and `addSelectWooFocusFixHandler` — DOM
   position and focus workarounds whose observable effect is layout.

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -1,0 +1,325 @@
+/**
+ * TWO-25288. The read-only summary of the captured company.
+ *
+ * The design this replaces showed the organisation number as a grey overlay
+ * floating over the picker's selection box, with an x-button beside it that
+ * deleted the captured company. The reversal: name AND number, both shown as
+ * text, in one place, for every capture mode, with nothing to type into and
+ * nothing that removes them.
+ *
+ * So what is worth asserting here is mostly negative — the absence of an
+ * editable or removing control — plus the three capture modes rendering the
+ * right pair of values. The submitted fields are checked alongside, because
+ * "read-only" must mean the buyer cannot edit the display, NOT that the values
+ * stopped being posted: `#billing_company` and `#company_id` are the inputs
+ * WooCommerce serialises, and the summary is a sibling of them, not a
+ * replacement for them.
+ */
+
+"use strict";
+
+const harness = require("./wc-harness");
+
+const GATEWAY_ID = "woocommerce-gateway-tillit";
+
+describe("read-only captured-company summary", () => {
+  let ctx;
+  let $;
+  let dom;
+
+  beforeEach(() => {
+    ctx = harness.loadTwoinc({
+      gateway_id: GATEWAY_ID,
+      supported_buyer_countries: ["GB"],
+      enable_company_search: "yes",
+      enable_company_search_for_others: "yes",
+      enable_address_lookup: "no",
+      text: {}
+    });
+    $ = ctx.$;
+    dom = ctx.dom;
+    harness.buildCheckoutForm();
+    selectTwo();
+  });
+
+  afterEach(() => {
+    harness.releaseWidgets($);
+    document.body.innerHTML = "";
+  });
+
+  /**
+   * Add the payment-method radio and check it.
+   *
+   * The summary is gated on Two being the chosen method — a buyer paying by
+   * another gateway may well have typed a company name into WooCommerce's own
+   * field — and `isTwoincSelected()` reads that radio, so without this every
+   * assertion below would be checking a permanently hidden element.
+   *
+   * @returns {void}
+   */
+  function selectTwo() {
+    $("form[name='checkout']").append(
+      '<input type="radio" name="payment_method" value="' + GATEWAY_ID + '" checked />'
+    );
+  }
+
+  /** @returns {Object} the summary element, or an empty set */
+  function summary() {
+    return $("#" + dom.companySummaryId);
+  }
+
+  /** @returns {string} the rendered company name */
+  function renderedName() {
+    return summary().find(".twoinc-company-summary-name").text();
+  }
+
+  /** @returns {string} the rendered organisation number */
+  function renderedNumber() {
+    return summary().find(".twoinc-company-summary-id").text();
+  }
+
+  /** @returns {boolean} whether the summary is currently shown */
+  function isShown() {
+    return summary().length > 0 && !summary().hasClass("hidden");
+  }
+
+  /**
+   * Pick a company the way the picker's own select handler does.
+   *
+   * Driven through `enableCompanySearch`'s real `select2:select` binding rather
+   * than by calling the render function: the point of the test is that picking
+   * a company renders the summary, and a direct call would pass even if the
+   * handler had never been wired to it.
+   *
+   * @param {string} name the company name (the picker's `data.id`)
+   * @param {string} companyId the organisation number
+   * @returns {void}
+   */
+  function pickCompany(name, companyId) {
+    const ajax = harness.stubAjax($);
+    ctx.Twoinc.getInstance().enableCompanySearch();
+    $("#billing_company_display").trigger({
+      type: "select2:select",
+      params: { data: { id: name, company_id: companyId } }
+    });
+    ajax.restore();
+  }
+
+  describe("company search", () => {
+    test("renders the picked company's name and number", () => {
+      pickCompany("ACME Widgets Ltd", "12345678");
+
+      expect(isShown()).toBe(true);
+      expect(renderedName()).toBe("ACME Widgets Ltd");
+      expect(renderedNumber()).toBe("12345678");
+    });
+
+    test("the picked values are still the posted ones", () => {
+      // The summary is a display beside the fields, not instead of them. If it
+      // ever became the only carrier of the identity, the order would reach
+      // WooCommerce with no company on it at all.
+      pickCompany("ACME Widgets Ltd", "12345678");
+
+      expect($("#billing_company").val()).toBe("ACME Widgets Ltd");
+      expect($("#company_id").val()).toBe("12345678");
+
+      // And re-rendering must not disturb them.
+      dom.renderCompanySummary();
+      expect($("#billing_company").val()).toBe("ACME Widgets Ltd");
+      expect($("#company_id").val()).toBe("12345678");
+    });
+
+    test("nothing inside the summary posts a value of its own", () => {
+      pickCompany("ACME Widgets Ltd", "12345678");
+
+      // A `name` attribute anywhere in here would be serialised by
+      // WooCommerce's checkout form alongside the real fields.
+      expect(summary().find("[name]").length).toBe(0);
+      expect($("form[name='checkout']").serialize()).not.toContain("twoinc_company_summary");
+    });
+
+    test("a company carrying no organisation number renders its name alone", () => {
+      // The organisation number is optional on a registry hit; the name is not.
+      pickCompany("ACME Widgets Ltd", "");
+
+      expect(isShown()).toBe(true);
+      expect(renderedName()).toBe("ACME Widgets Ltd");
+      expect(renderedNumber()).toBe("");
+    });
+  });
+
+  describe("manual entry", () => {
+    /**
+     * Type a company name the way the buyer does in manual entry, and let the
+     * checkout re-render.
+     *
+     * `toggleBusinessFields` is the re-render entry point, not a test hook: it
+     * runs on every payment-method, country and capture-mode switch, and it is
+     * production code. The `change` handler that also re-renders is installed
+     * by `Twoinc.initialize`, whose bootstrap (intervals, order-intent polling)
+     * this suite deliberately does not stand up — see wc-harness.
+     *
+     * @param {string} name what the buyer typed
+     * @returns {void}
+     */
+    function typeCompanyName(name) {
+      $("#billing_company").val(name);
+      dom.toggleBusinessFields();
+    }
+
+    test("renders the typed name with no number", () => {
+      // Manual entry is reached with a company already picked, which is the
+      // case that used to leave the disowned company's number on screen.
+      pickCompany("ACME Widgets Ltd", "12345678");
+      expect(renderedNumber()).toBe("12345678");
+
+      dom.enterManualCompanyEntry();
+      typeCompanyName("Sole Proprietor Bakery");
+
+      expect(isShown()).toBe(true);
+      expect(renderedName()).toBe("Sole Proprietor Bakery");
+      // enterManualCompanyEntry clears #company_id: the buyer has said the
+      // registry company is not theirs, so its number must not survive.
+      expect(renderedNumber()).toBe("");
+      expect($("#company_id").val()).toBe("");
+    });
+
+    test("the typed name is what gets posted", () => {
+      dom.enterManualCompanyEntry();
+      typeCompanyName("Sole Proprietor Bakery");
+
+      expect($("#billing_company").val()).toBe("Sole Proprietor Bakery");
+    });
+
+    test("a number the buyer supplies themselves is picked up on blur", () => {
+      // On this platform manual entry keeps its own organisation-number field
+      // (toggleBusinessFields reveals and requires `#company_id_field`), so
+      // "blank" above means "not carried over from the abandoned pick", not
+      // "unobtainable". Driven through the real blur handler.
+      const ajax = harness.stubAjax($);
+      dom.enterManualCompanyEntry();
+      typeCompanyName("Sole Proprietor Bakery");
+
+      $("#company_id").val("55554444");
+      ctx.Twoinc.prototype.onCompanyManualInputBlur.call($("#company_id")[0]);
+
+      expect(renderedName()).toBe("Sole Proprietor Bakery");
+      expect(renderedNumber()).toBe("55554444");
+      ajax.restore();
+    });
+  });
+
+  describe("sole trader", () => {
+    test("renders the name and number held for the buyer", () => {
+      ctx.soleTrader.setCompany("99887766", "Jo Bloggs Trading");
+
+      expect(isShown()).toBe(true);
+      expect(renderedName()).toBe("Jo Bloggs Trading");
+      expect(renderedNumber()).toBe("99887766");
+      expect($("#billing_company").val()).toBe("Jo Bloggs Trading");
+      expect($("#company_id").val()).toBe("99887766");
+    });
+  });
+
+  describe("it is genuinely read-only", () => {
+    test("there is no field in it to type into", () => {
+      pickCompany("ACME Widgets Ltd", "12345678");
+
+      expect(summary().find("input, select, textarea, [contenteditable]").length).toBe(0);
+      // Both values live in elements a user cannot put a caret in.
+      expect(summary().find(".twoinc-company-summary-name").prop("tagName")).toBe("SPAN");
+      expect(summary().find(".twoinc-company-summary-id").prop("tagName")).toBe("SPAN");
+    });
+
+    test("there is no control in it that removes the captured company", () => {
+      pickCompany("ACME Widgets Ltd", "12345678");
+
+      // The x-button this replaces was an <img> with an inline onclick. Assert
+      // the shape, not the one element: any button, link, image or click
+      // handler in here is the affordance the reversal removes.
+      expect(summary().find("button, a, img, [onclick], [role='button']").length).toBe(0);
+      expect(
+        summary()
+          .find("*")
+          .filter(function () {
+            return $._data(this, "events") !== undefined;
+          }).length
+      ).toBe(0);
+      expect($._data(summary()[0], "events")).toBeUndefined();
+    });
+
+    test("nothing in it can be tabbed to", () => {
+      pickCompany("ACME Widgets Ltd", "12345678");
+
+      const focusable = summary()
+        .find("[tabindex]")
+        .filter(function () {
+          return Number($(this).attr("tabindex")) >= 0;
+        });
+      expect(focusable.length).toBe(0);
+    });
+  });
+
+  describe("visibility", () => {
+    test("absent from the page until something is captured", () => {
+      // Prove the mechanism is live in this test before asserting the absence,
+      // so the assertion cannot pass merely because nothing ever ran.
+      dom.renderCompanySummary("ACME Widgets Ltd", "12345678");
+      expect(isShown()).toBe(true);
+
+      dom.renderCompanySummary("", "");
+      expect(isShown()).toBe(false);
+    });
+
+    test("hidden when the buyer is paying by another method", () => {
+      pickCompany("ACME Widgets Ltd", "12345678");
+      expect(isShown()).toBe(true);
+
+      $('input[name="payment_method"]').prop("checked", false);
+      dom.renderCompanySummary();
+
+      expect(isShown()).toBe(false);
+      // Still rendered, just not shown — and the fields still post.
+      expect($("#billing_company").val()).toBe("ACME Widgets Ltd");
+    });
+
+    test("cleared when the captured company is cleared", () => {
+      jest.useFakeTimers();
+      pickCompany("ACME Widgets Ltd", "12345678");
+      expect(isShown()).toBe(true);
+
+      dom.clearSelectedCompany();
+
+      expect(isShown()).toBe(false);
+      expect(renderedName()).toBe("");
+      expect(renderedNumber()).toBe("");
+      jest.useRealTimers();
+    });
+
+    test("the picker's empty placeholder is not rendered as a name", () => {
+      // The empty option's label is a non-breaking space: truthy, invisible,
+      // and rendered by anything that only checks for "".
+      dom.renderCompanySummary(" ", "");
+
+      expect(renderedName()).toBe("");
+      expect(isShown()).toBe(false);
+    });
+  });
+
+  describe("the restored-from-user-meta path", () => {
+    test("renders both values even though #company_id is written afterwards", () => {
+      // loadUserMetaInputs fills the select first, calls the summary, and only
+      // then writes #company_id. A summary that read the DOM at that moment
+      // would show the name with an empty number.
+      ctx.twoinc.billing_company = "ACME Widgets Ltd";
+      ctx.twoinc.company_id = "12345678";
+      $("#company_id").val("");
+
+      dom.loadUserMetaInputs();
+
+      expect(renderedName()).toBe("ACME Widgets Ltd");
+      expect(renderedNumber()).toBe("12345678");
+      expect($("#company_id").val()).toBe("12345678");
+    });
+  });
+});

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -202,18 +202,28 @@ describe("read-only captured-company summary", () => {
       expect($("#company_id").val()).toBe("");
     });
 
-    test("the typed name is what gets posted", () => {
+    test("what is displayed is what gets posted", () => {
       dom.enterManualCompanyEntry();
       typeCompanyName("Sole Proprietor Bakery");
 
-      expect($("#billing_company").val()).toBe("Sole Proprietor Bakery");
+      // The posted field on its own would be vacuous here — typeCompanyName is
+      // what set it. The pairing is the assertion: the summary renders the same
+      // string the checkout will post, not a copy that can drift from it.
+      expect(renderedName()).toBe("Sole Proprietor Bakery");
+      expect($("#billing_company").val()).toBe(renderedName());
     });
 
-    test("a number the buyer supplies themselves is picked up on blur", () => {
+    test("the blur handler picks up a number the buyer supplies themselves", () => {
       // On this platform manual entry keeps its own organisation-number field
       // (toggleBusinessFields reveals and requires `#company_id_field`), so
       // "blank" above means "not carried over from the abandoned pick", not
-      // "unobtainable". Driven through the real blur handler.
+      // "unobtainable".
+      //
+      // The handler is invoked directly rather than by dispatching a blur: the
+      // `$body.on("blur", "#company_id", …)` delegation is installed by
+      // Twoinc.initialize, whose bootstrap this suite does not stand up. So
+      // this covers the handler's body, NOT that it is wired to the event —
+      // hence the test name.
       const ajax = harness.stubAjax($);
       dom.enterManualCompanyEntry();
       typeCompanyName("Sole Proprietor Bakery");
@@ -269,6 +279,9 @@ describe("read-only captured-company summary", () => {
     test("nothing in it can be tabbed to", () => {
       pickCompany("ACME Widgets Ltd", "12345678");
 
+      // Guard: `.find()` on an empty set is empty, so without this the
+      // assertion below holds just as well on a page with no summary at all.
+      expect(summary().length).toBe(1);
       const focusable = summary()
         .find("[tabindex]")
         .filter(function () {
@@ -301,7 +314,7 @@ describe("read-only captured-company summary", () => {
       expect($("#billing_company").val()).toBe("ACME Widgets Ltd");
     });
 
-    test("cleared when the captured company is cleared", () => {
+    test("cleared when the captured company is cleared, and stays cleared", () => {
       jest.useFakeTimers();
       pickCompany("ACME Widgets Ltd", "12345678");
       expect(isShown()).toBe(true);
@@ -311,13 +324,41 @@ describe("read-only captured-company summary", () => {
       expect(isShown()).toBe(false);
       expect(renderedName()).toBe("");
       expect(renderedNumber()).toBe("");
+
+      // clearSelectedCompany re-reads the inputs 3s later and re-renders, and
+      // every later payment-method or country switch re-renders too. Both used
+      // to bring the cleared company back on screen, because #billing_company
+      // still held it — the field WooCommerce posts. Asserting only the
+      // synchronous clear is what let that through.
+      jest.advanceTimersByTime(3500);
+      expect(isShown()).toBe(false);
+      expect(renderedName()).toBe("");
+
+      dom.toggleBusinessFields();
+      expect(isShown()).toBe(false);
+      expect(renderedName()).toBe("");
+      // And the cleared company is not posted either.
+      expect($("#billing_company").val()).toBe("");
+      expect($("#company_id").val()).toBe("");
       jest.useRealTimers();
     });
 
     test("the picker's empty placeholder is not rendered as a name", () => {
-      // The empty option's label is a non-breaking space: truthy, invisible,
-      // and rendered by anything that only checks for "".
-      dom.renderCompanySummary(" ", "");
+      // The empty option's label is U+00A0, not a plain space: truthy,
+      // invisible, and rendered as a company by anything that only checks for
+      // "". Written as the escape rather than pasted in, so neither a reader
+      // nor an editor has to tell the two space characters apart — pasted, it
+      // was mistaken for U+0020 in review.
+      dom.renderCompanySummary("\u00a0", "");
+
+      expect(renderedName()).toBe("");
+      expect(isShown()).toBe(false);
+
+      // Through the live read too, which is the path a real unselected picker
+      // takes: the display select's value is that same non-breaking space.
+      $("#billing_company").val("");
+      $("#billing_company_display").append('<option value="\u00a0" selected></option>');
+      dom.renderCompanySummary();
 
       expect(renderedName()).toBe("");
       expect(isShown()).toBe(false);

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -114,6 +114,24 @@ describe("read-only captured-company summary", () => {
       expect(renderedNumber()).toBe("12345678");
     });
 
+    test("survives a re-render with no sessionStorage snapshot behind it", () => {
+      // The summary's no-argument path used to go through getCompanyData(),
+      // which in search mode reads the company name out of the `checkoutInputs`
+      // sessionStorage snapshot — refreshed on a 3-second interval, and absent
+      // entirely until the first save. So a re-render showed the name as it was
+      // up to three seconds ago, or blanked it and hid the summary, while the
+      // number (read live) stayed. Switching payment method away and back is
+      // enough to trigger one, via toggleBusinessFields.
+      pickCompany("ACME Widgets Ltd", "12345678");
+      sessionStorage.removeItem("checkoutInputs");
+
+      dom.toggleBusinessFields();
+
+      expect(isShown()).toBe(true);
+      expect(renderedName()).toBe("ACME Widgets Ltd");
+      expect(renderedNumber()).toBe("12345678");
+    });
+
     test("the picked values are still the posted ones", () => {
       // The summary is a display beside the fields, not instead of them. If it
       // ever became the only carrier of the identity, the order would reach

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -98,6 +98,14 @@ describe("read-only captured-company summary", () => {
   function pickCompany(name, companyId) {
     const ajax = harness.stubAjax($);
     ctx.Twoinc.getInstance().enableCompanySearch();
+    // The <option> select2's array adapter appends for the chosen result, and
+    // leaves behind on destroy. Modelled explicitly because the event below is
+    // dispatched rather than driven through a real result list, and its being
+    // left behind is the whole subject of the resurrection tests further down —
+    // without it those tests assert against a select that was never populated.
+    $("#billing_company_display").append(
+      '<option value="' + name + '" selected>' + name + "</option>"
+    );
     $("#billing_company_display").trigger({
       type: "select2:select",
       params: { data: { id: name, company_id: companyId } }
@@ -354,14 +362,57 @@ describe("read-only captured-company summary", () => {
       expect(renderedName()).toBe("");
       expect(isShown()).toBe(false);
 
-      // Through the live read too, which is the path a real unselected picker
-      // takes: the display select's value is that same non-breaking space.
+      // And through the live read, against the real unselected state: the empty
+      // option's VALUE is "" — the non-breaking space is only its label, which
+      // is why the live read cannot see one and the guard above is defensive.
       $("#billing_company").val("");
-      $("#billing_company_display").append('<option value="\u00a0" selected></option>');
+      expect($("#billing_company_display").val()).toBe("");
       dom.renderCompanySummary();
 
       expect(renderedName()).toBe("");
       expect(isShown()).toBe(false);
+    });
+  });
+
+  describe("a company that is no longer captured stays off screen", () => {
+    test("the sole-trader round trip does not resurrect the picked company", () => {
+      // The picker appends an <option> to #billing_company_display for every
+      // pick, and neither select2("destroy") nor the clearing setCompany("", "")
+      // removes it. So after search → sole trader → back to business, that
+      // select still held the company while both posted fields were empty. A
+      // summary that read the select back showed a company the order did not
+      // carry.
+      const ajax = harness.stubAjax($);
+      pickCompany("ACME Widgets Ltd", "12345678");
+      expect(isShown()).toBe(true);
+
+      ctx.soleTrader.setMode("sole_trader");
+      ctx.soleTrader.setMode("business");
+
+      expect($("#billing_company").val()).toBe("");
+      expect($("#company_id").val()).toBe("");
+      expect($("#billing_company_display").val()).toBe("");
+      expect(renderedName()).toBe("");
+      expect(isShown()).toBe(false);
+      ajax.restore();
+    });
+
+    test("the summary never shows a name the checkout is not posting", () => {
+      // The invariant behind the test above, asserted directly: whatever is on
+      // screen is what #billing_company holds. Stale options on the display
+      // select are exactly what used to break it.
+      const ajax = harness.stubAjax($);
+      pickCompany("ACME Widgets Ltd", "12345678");
+      $("#billing_company").val("");
+      $("#company_id").val("");
+
+      dom.renderCompanySummary();
+
+      // The stale option is still on the select — that is the point.
+      expect($("#billing_company_display").val()).toBe("ACME Widgets Ltd");
+      expect(renderedName()).toBe("");
+      expect(isShown()).toBe(false);
+      ajax.restore();
     });
   });
 


### PR DESCRIPTION
## TWO-25288 — show the captured company read-only (name + number)

Design reversal, superseding element 6 of TWO-25288. Across checkout platforms the selected company's **name and number** should display read-only — not editable, not removable.

### What was there before

Confirmed against `origin/staging`, not assumed:

| | Before |
|---|---|
| Name | Visible only as the select2 combobox's own selected text |
| Number | `.floating-company-id`, a `#dddddd` span absolutely positioned over the picker's selection box |
| Removal | An `<img>` with an inline `onclick="twoincDomHelper.clearSelectedCompany()"` beside it |
| Manual entry | Nothing displayed; the two editable fields only |
| Sole trader | Nothing displayed; fields `readonly`-locked |

The earlier "grey inline hint" work on this platform was the company-search **field hints** (empty-field placeholder and the min-chars message inside the dropdown) — not a company-number display. The number overlay predates it. So the reversal has a real gap to close in two of the three capture modes, plus a removal affordance to take out of the third.

### What this does

One read-only summary under the company fields, carrying both values as text, for all three modes:

- **company search** — name and number as picked from the registry;
- **sole trader** — name and number as held for the buyer;
- **manual entry** — the typed name, and no number: entering manual entry clears the number of the company the buyer has just disowned.

Two `<span>`s and no `<input>`. This is a value the buyer is shown, not a field they fill in, so there is nothing to type into and no control that removes it. `readonly` inputs stay this plugin's convention for the **submitted** fields — sole-trader mode still locks `#billing_company` and `#company_id` that way, and both still carry exactly what WooCommerce serialises.

Anchored *after* the company-id field's enclosing `.twoinc-inp-container`, not inside it: the pay-for-order page hides the container rather than the field, so a summary placed inside would be invisible there in exactly the search mode it matters most for.

### Two consequences worth a reviewer's attention

- **The select2 dropdown arrow is no longer hidden on selection.** Only the overlay hid it. With the x-button gone the picker itself is the way to change a selection, so re-picking stays possible while the displayed values stay read-only. If the intent is that a company, once captured, cannot be changed at all, that is a further step and not this PR.
- **`assets/images/x-button.svg` is now unreferenced by this repo.** Kept rather than deleted — plugin assets are addressable by URL.

### Test proof

New suite `tests/js/company-summary.test.js`, 18 tests. `npm run test:js` → **178 passed, 178 total** (was 162).

Covered: the three modes' value pairs; search-mode rendering driven through `enableCompanySearch`'s real `select2:select` binding rather than by calling the renderer; no `input`/`select`/`textarea`/`contenteditable`, nothing tabbable, and no button/link/image/`onclick`/bound handler anywhere inside it; submission unaffected, including that nothing in the summary carries a `name` attribute (asserted against the form's real `serialize()`); the visibility gate; and the non-breaking space the picker's empty option carries, which is truthy and invisible.

Five mutations tried, each caught: blank the name (6 failures), blank the number (5), unwire the picker handler (7), force the summary visible (4), drop the nbsp normalisation (1).

No new translatable strings, so no catalogue churn.
