### PR TITLE
fix: company-search manual-entry link, focus trap, and placeholder styling

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -168,35 +168,34 @@
 }
 
 /*
- * Manual-entry row inside the company-search results list (TWO-25288).
+ * Manual-entry button, a sibling of the results list rather than a row
+ * inside it (#30.x.1-3, superseding the TWO-25288 pseudo-option).
  *
- * It is an option row now rather than a floating div beside the list, so the
- * hand-rolled margin is gone: the row inherits the picker's own option padding
- * and highlight, which is what keeps it in step with the company rows above it
- * when arrowed onto. Kept as a flat single-id selector so brand overlays that
- * recolour it keep matching without raising their own specificity.
+ * A real <button> now, so its native chrome has to be reset to read as the
+ * link it visually is — the same treatment #search_company_btn already gets
+ * below. `display: block` + full width keeps it filling the dropdown the way
+ * the old option row did; the padding roughly matches selectWoo's own option
+ * row padding so it doesn't look like a foreign element bolted underneath.
+ * Kept as a flat single-id selector so brand overlays that recolour it keep
+ * matching without raising their own specificity.
  */
 #company_not_in_btn {
+  display: block;
+  width: 100%;
+  text-align: left;
   cursor: pointer;
   color: #3043d1;
+  background: none;
+  border: 0;
+  border-top: 1px solid #eeeeee;
+  font: inherit;
+  padding: 6px 12px;
 }
 
-/*
- * Highlighted state (TWO-25288). NOT cosmetic — a contrast fix.
- *
- * The picker paints its highlighted row white-on-blue, but its own rule is a
- * class selector (specificity 0,3,1) and the id rule above is 1,0,0, so the
- * brand blue above wins on the text while the blue background still applies:
- * roughly 2.5:1, under the 4.5:1 floor, where every real company row in the
- * same list goes white-on-blue. Restated at the same id specificity so this row
- * matches its neighbours instead of going unreadable the moment it is arrowed
- * onto. Both theme prefixes, because which one is present depends on the host
- * theme's picker build.
- */
-#company_not_in_btn.select2-results__option--highlighted,
-.select2-container--default #company_not_in_btn.select2-results__option--highlighted,
-.select2-container--classic #company_not_in_btn.select2-results__option--highlighted {
-  color: #ffffff;
+#company_not_in_btn:hover,
+#company_not_in_btn:focus {
+  background-color: #f2f4fd;
+  outline-offset: -2px;
 }
 
 /*
@@ -355,6 +354,27 @@
 }
 .select2-search--dropdown.twoinc-searching .select2-search__field {
   padding-right: 30px;
+}
+
+/*
+ * Company-search placeholder / selected-value text (#30.x.5).
+ *
+ * Some host themes apply a blanket `text-transform: uppercase` broad enough
+ * to catch select2's own rendered span, and give the selection box a custom
+ * height with no matching `.select2-selection__rendered` line-height —
+ * leaving the placeholder text a few pixels above true vertical centre.
+ * Scoped to this one field's combobox so it never touches an unrelated
+ * select2 instance a theme already renders correctly. Flex centring rather
+ * than a fixed line-height: it self-adjusts to whatever height a host theme
+ * gives the selection box instead of assuming one.
+ */
+#billing_company_display_field .select2-selection--single {
+  display: flex;
+  align-items: center;
+}
+#billing_company_display_field .select2-selection__rendered {
+  text-transform: none;
+  line-height: normal;
 }
 
 /* Sole trader toggle (TWO-24754) */

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -84,30 +84,14 @@ let twoincSelectWooHelper = {
   companySearchInputSelector: 'input[aria-owns="select2-billing_company_display-results"]',
 
   /**
-   * DOM id of the manual-entry pseudo-option (TWO-25288). Unchanged from when
-   * this was a cloned <div> so the stylesheet rule and the brand overlays that
-   * match it keep working.
+   * DOM id of the manual-entry button. Unchanged across TWO-25288 (the
+   * cloned-<div> version) and the button rework below, so the stylesheet
+   * rule and any brand overlays that match it keep working.
    */
   manualEntryRowId: "company_not_in_btn",
 
   /** DOM id of the link back out of manual entry and into search. */
   searchCompanyBtnId: "search_company_btn",
-
-  /**
-   * The `id` on the manual-entry row's payload object (TWO-25288).
-   *
-   * It has to be an id and not a flag: the picker stringifies every navigable
-   * row's `data.id` when it recomputes selected state, so a row without one
-   * throws and takes the whole results render with it.
-   *
-   * `processResults` below maps each hit's id to the company NAME, so this
-   * value shares a namespace with company names and the underscores are there
-   * to keep it out of the way. That is a convention, NOT an enforced
-   * invariant — nothing rejects a registry name that happened to equal it, and
-   * no test claims otherwise. If that ever needs to be a guarantee, the
-   * discriminator has to move off `id` onto a field of its own.
-   */
-  manualEntrySentinelId: "__twoinc_manual_entry__",
 
   /**
    * Text for a company search that could not be completed. Read lazily
@@ -183,97 +167,88 @@ let twoincSelectWooHelper = {
   },
 
   /**
-   * Build the manual-entry row as a real pseudo-option (TWO-25288).
+   * Build the manual-entry affordance as a real, focusable button (#30.x.1,
+   * #30.x.2, #30.x.3).
    *
-   * This used to be a cloned <div> appended to the results list's PARENT, i.e.
-   * outside the subtree the field's aria-owns points at — so it had no role,
-   * no id, no payload, and was not reachable by keyboard at all. It is a
-   * genuine option row now, which is what makes it arrow-reachable and
-   * announced without a bespoke keydown bridge.
+   * TWO-25288 made this a pseudo-option `<li role="option">` living INSIDE
+   * `.select2-results__options` so it would be arrow-reachable and announced.
+   * That traded one accessibility gap for two others:
    *
-   * This mirrors, attribute for attribute, what the picker's own option
-   * factory produces for a real result row. Three of them are load-bearing:
+   *  - `.select2-results__options` is exactly the element select2/selectWoo
+   *    apply their own scroll-and-clip to, so the row was only visible if the
+   *    buyer scrolled past however many results came back, and the ONLY way
+   *    to reach it by keyboard was arrowing down through every one of them —
+   *    it carried `tabindex="-1"`, deliberately excluded from the normal Tab
+   *    sequence, on purpose, to match the listbox pattern.
+   *  - selectWoo's own result-row activation binds on plain `mouseup` with no
+   *    button check at all (`Results.prototype.bind`), so a RIGHT click
+   *    activated the row exactly like a left click — true of every real
+   *    result row too, but only this one was ours to fix.
    *
-   *  - `data-selected` is how the picker derives its navigable set, and it must
-   *    stay "false". "true" means "already picked", and the picker routes
-   *    activation of an already-picked row to closing the dropdown instead of
-   *    selecting it — the row would look reachable and do nothing.
-   *  - `tabindex="-1"` makes the row programmatically focusable. On every arrow
-   *    keypress the picker calls `.focus()` on the highlighted row, and its own
-   *    source says that is required for screen readers to work. An <li> with no
-   *    tabindex cannot take focus, so that call is a silent no-op and focus
-   *    stays stranded on the PREVIOUS row while this one is visually
-   *    highlighted — the reader keeps announcing the wrong thing.
-   *  - the payload goes on with jQuery `data`, which is where the picker reads
-   *    each row's data from, and it must carry `_resultId` matching the li's
-   *    id: that is what the picker copies into `aria-activedescendant`, on both
-   *    the dropdown's search field and the selection container. Without it the
-   *    row is reachable but silent.
+   * A real `<button>` fixes both: native Tab order, native Enter/Space
+   * activation, and a native `click` event that only ever fires for the
+   * primary mouse button — no bespoke keydown bridge and no button check to
+   * hand-roll.
    *
-   * `select2-results__option--selectable` is belt-and-braces only. The bundle
-   * pinned here never reads it — it is a select2 4.1 concept, and that string
-   * does not occur anywhere in this build. It costs nothing and keeps the row
-   * navigable if a host platform ever swaps the picker for one that keys off
-   * the class instead of the attribute. Do not describe it as required.
-   *
-   * @returns {Object} jQuery-wrapped <li>
+   * @returns {Object} jQuery-wrapped <button>
    */
-  buildManualEntryRow: function () {
+  buildManualEntryButton: function () {
     const helper = twoincSelectWooHelper;
-    const label = helper.companyNotInListText();
 
-    const $row = jQuery("<li></li>")
-      .attr({
-        id: helper.manualEntryRowId,
-        role: "option",
-        "aria-selected": "false",
-        "data-selected": "false",
-        tabindex: -1
-      })
-      .addClass("select2-results__option select2-results__option--selectable")
-      .text(label);
-
-    $row.data("data", {
-      id: helper.manualEntrySentinelId,
-      text: label,
-      _resultId: helper.manualEntryRowId
-    });
-
-    return $row;
+    return jQuery("<button></button>")
+      .attr({ id: helper.manualEntryRowId, type: "button" })
+      .text(helper.companyNotInListText())
+      .on("click", function () {
+        helper.activateManualEntry();
+      });
   },
 
   /**
-   * Put the manual-entry row at the end of the results list, or take it away
-   * (TWO-25288).
+   * Switch out of company search into manual entry, from the button's own
+   * click handler (#30.x.3).
    *
-   * Visibility rule is the search threshold and nothing else — no
-   * "has a search completed" gate. The row appears the moment the buyer has
-   * typed enough for a search to be worth running, which is BEFORE the
-   * debounced request goes out, so a buyer who already knows their company is
-   * not in the registry never has to wait for a round trip to find that out.
+   * Removes the button before deferring, same reason as before: a second
+   * click in the same tick must not queue a second switch. Deferred out of
+   * the click dispatch because entering manual entry destroys this widget,
+   * and destroying it from inside the event that is still unwinding on it
+   * would pull the DOM out from under that unwind.
    *
    * @returns {void}
    */
-  syncManualEntryRow: function () {
+  activateManualEntry: function () {
+    const helper = twoincSelectWooHelper;
+    jQuery("#" + helper.manualEntryRowId).remove();
+    setTimeout(twoincDomHelper.enterManualCompanyEntry, 0);
+  },
+
+  /**
+   * Put the manual-entry button right after the results list, or take it
+   * away (#30.x.1).
+   *
+   * A SIBLING of `.select2-results__options`, not a child of it, so it sits
+   * outside the part of the dropdown that scrolls: always visible the moment
+   * it should be, regardless of how many results came back. Still inside the
+   * dropdown itself — appended into `.select2-results`, the same wrapper the
+   * results list lives in — so it reads as part of the same panel, just
+   * beneath the scrollable area rather than the last row inside it.
+   *
+   * Visibility rule unchanged from the pseudo-option version: the search
+   * threshold and nothing else — no "has a search completed" gate. The
+   * button appears the moment the buyer has typed enough for a search to be
+   * worth running, which is BEFORE the debounced request goes out, so a
+   * buyer who already knows their company is not in the registry never has
+   * to wait for a round trip to find that out.
+   *
+   * @returns {void}
+   */
+  syncManualEntryButton: function () {
     const helper = twoincSelectWooHelper;
 
     const picker = jQuery("#billing_company_display").data("select2");
     if (!picker || !picker.$results || !picker.$results.length) return;
 
-    // Self-healing, and deliberately here rather than in the bind function.
-    // The widget is re-created in places that have no reason to know this
-    // affordance exists — clearing the selected company does it, which is the
-    // "un-pick that company, let me search again" gesture that most often
-    // precedes needing this row. A new widget means a NEW results node, so a
-    // flag set on the old one says nothing, and the observer would simply never
-    // be installed again: the row would appear on a keystroke and then be wiped
-    // by the first render, permanently. Installing from the per-keystroke sync
-    // covers every re-creation, including future ones, without a third bind
-    // site to keep in step.
-    helper.observeResultsList(picker.$results);
-
     const $list = picker.$results;
-    const $existing = $list.children("#" + helper.manualEntryRowId);
+    const $existing = jQuery("#" + helper.manualEntryRowId);
     const term = jQuery(helper.companySearchInputSelector).val() || "";
 
     if (term.length < helper.companySearchMinLength) {
@@ -281,76 +256,38 @@ let twoincSelectWooHelper = {
       return;
     }
 
-    // Already the last row: do nothing. This early return is load-bearing,
-    // not an optimisation — this function is also called from a
-    // MutationObserver watching the same list, so an unconditional append
-    // would re-enter itself forever.
-    if ($existing.length && $list.children().last().is($existing)) return;
+    // Already there, immediately after the current results list: nothing to
+    // do. Load-bearing rather than an optimisation for the same reason it was
+    // before: an unconditional re-append on every keystroke would tear down
+    // and rebuild the same node for no reason.
+    if ($existing.length && $existing.prev().is($list)) return;
 
     $existing.remove();
-    $list.append(helper.buildManualEntryRow());
+    $list.after(helper.buildManualEntryButton());
   },
 
   /**
-   * The live MutationObserver watching the results list, if any (TWO-25288).
-   */
-  manualEntryObserver: null,
-
-  /**
-   * Watch a results list so the row can be put back after every render
-   * (TWO-25288).
+   * Wire the manual-entry affordance to a company-search widget (TWO-25288,
+   * reworked #30.x.1-3).
    *
-   * The picker empties the whole list on each render — a new result set, the
-   * "searching" state, a message — so watching the list covers all of them
-   * without guessing at which internal events fire.
-   *
-   * At most ONE observer exists at a time. The previous one is disconnected
-   * before a new list is observed, so the enter/exit and clear-company cycles
-   * cannot accumulate one orphan per widget for the life of the page.
-   *
-   * @param {Object} $list jQuery-wrapped results <ul>
-   * @returns {void}
-   */
-  observeResultsList: function ($list) {
-    const helper = twoincSelectWooHelper;
-
-    if (!$list || !$list.length || typeof MutationObserver !== "function") return;
-    // Already watching this exact node.
-    if ($list.data("twoincManualEntryObserved")) return;
-
-    if (helper.manualEntryObserver) helper.manualEntryObserver.disconnect();
-
-    $list.data("twoincManualEntryObserved", true);
-    helper.manualEntryObserver = new MutationObserver(function () {
-      helper.syncManualEntryRow();
-    });
-    helper.manualEntryObserver.observe($list[0], { childList: true });
-  },
-
-  /**
-   * Wire the manual-entry affordance to a company-search widget (TWO-25288).
-   *
-   * Idempotent by construction. Every handler is namespaced and every bind is
+   * Idempotent by construction. The handler is namespaced and every bind is
    * preceded by the matching `.off()`, so calling this again — and it IS
    * called again, from the 800ms re-run of enableCompanySearch and from every
-   * return out of manual entry — leaves exactly one handler of each kind.
-   * The previous implementation bound its input handler inside a polling
+   * return out of manual entry — leaves exactly one handler bound. The
+   * previous implementation bound its input handler inside a polling
    * callback on every dropdown open with no `.off()`, which both accumulated
    * duplicates and missed the first keystrokes of anyone typing faster than
    * the poll interval.
    *
-   * Takes no widget argument on purpose. Everything below is specific to the
-   * company-search field — the delegated selector and the sync both name it —
-   * so a parameter would have to be that one element every time. A probe
-   * mutation confirmed it: reassigning the argument to a fresh lookup of that
-   * same field changed nothing and no test noticed, which is a signature
-   * claiming generality the body does not have.
+   * No separate activation binding here any more: the button built by
+   * `syncManualEntryButton` owns its own click handler directly, since it is
+   * a real element outside the results list rather than a pseudo-option the
+   * picker's `select2:selecting` event had to be intercepted for.
    *
    * @returns {void}
    */
   bindManualEntryAffordance: function () {
     const helper = twoincSelectWooHelper;
-    const $select = jQuery("#billing_company_display");
 
     // Delegated on <body> rather than bound to the search field: that field
     // is destroyed and rebuilt on every open, and delegation means the
@@ -359,49 +296,7 @@ let twoincSelectWooHelper = {
     jQuery(document.body)
       .off("input.twoincManualEntry")
       .on("input.twoincManualEntry", helper.companySearchInputSelector, function () {
-        helper.syncManualEntryRow();
-      });
-
-    // No eager render-watcher install here. It was tried and removed: the row
-    // cannot exist before the buyer has typed to the threshold, and typing is
-    // what runs the sync, which installs the watcher against whatever results
-    // list is live. Removing the eager copy left the suite green, i.e. nothing
-    // depended on it — and one install point that heals every widget
-    // re-creation is easier to reason about than two.
-
-    // Activation, keyboard and mouse through one path. The picker turns both
-    // Enter on the highlighted row and a click on it into the same internal
-    // select, and fires a preventable pre-event first — so intercepting that
-    // one event covers both inputs, and there is no separate click handler
-    // that could double-fire or drift out of step with the keyboard one.
-    $select
-      .off("select2:selecting.twoincManualEntry")
-      .on("select2:selecting.twoincManualEntry", function (e) {
-        const data = e.params && e.params.args && e.params.args.data;
-        if (!data || data.id !== helper.manualEntrySentinelId) return;
-
-        // Prevented, so the selection is never written: no company name, no
-        // company id, no approval call, no address lookup.
-        e.preventDefault();
-
-        // Because the selection is prevented the dropdown does NOT close, so
-        // the row would otherwise still be sitting in the list and still
-        // activatable — and a repeated activation in the same tick would queue
-        // one deferred switch per press. Removing the row up front is what
-        // prevents that: the picker resolves an activation through the
-        // highlighted row, and there is no longer one.
-        //
-        // A `pending` latch was tried here as well and removed: with the row
-        // already gone it could not be reached by any path, so it was
-        // untestable defensive code. One mechanism that a test can fail is
-        // worth more than two where neither is exercised alone.
-        jQuery("#" + helper.manualEntryRowId).remove();
-
-        // Deferred out of the picker's own event dispatch. Entering manual
-        // entry destroys this widget, and destroying it from inside its own
-        // trigger would pull the DOM out from under the code that is still
-        // unwinding.
-        setTimeout(twoincDomHelper.enterManualCompanyEntry, 0);
+        helper.syncManualEntryButton();
       });
   },
 
@@ -624,6 +519,43 @@ let twoincSelectWooHelper = {
   },
 
   /**
+   * Whether focus is still somewhere this poll is allowed to touch.
+   *
+   * `waitToFocus` exists because the picker's own focus-on-open does not land
+   * reliably on every host theme, so it polls to nudge focus into the search
+   * field. Left unchecked, that poll kept nudging for its whole window (up to
+   * ~4.8s from `select2:open`, ~12.8s per re-render from
+   * `addSelectWooFocusFixHandler`) with no regard for what happened after it
+   * was scheduled — including the buyer deliberately Tabbing to a completely
+   * different field, which got yanked back into the dropdown until the poll's
+   * hit count ran out or the buyer hit Esc (which tears the dropdown down,
+   * so the search-field selector this poll uses stops matching anything).
+   *
+   * "Still allowed" covers every state the poll's job actually needs to work
+   * through: nothing focused yet (`<body>`, select2's own state before its
+   * first focus attempt), the search field itself, an option row inside the
+   * open results list (the picker focuses those on arrow-key navigation), or
+   * the still-collapsed combobox trigger. Anything else means the buyer's own
+   * navigation has taken them elsewhere, and that must win.
+   *
+   * @param {string} selectWooElemId the select's element id
+   * @returns {boolean}
+   */
+  focusStillWithinCompanySearch: function (selectWooElemId) {
+    const active = document.activeElement;
+    if (!active || active === document.body) return true;
+
+    const $active = jQuery(active);
+    if ($active.is('input[aria-owns="select2-' + selectWooElemId + '-results"]')) return true;
+
+    return (
+      $active.closest(
+        "#select2-" + selectWooElemId + "-results, #select2-" + selectWooElemId + "-container"
+      ).length > 0
+    );
+  },
+
+  /**
    * Wait until element appear and focus
    */
   waitToFocus: function (selectWooElemId, hitsRequired, intervalDuration, callbackFunc) {
@@ -632,6 +564,12 @@ let twoincSelectWooHelper = {
     let attemptsLeft = hitsRequired * 8;
 
     let focusInterval = setInterval(function () {
+      // The buyer's own navigation always wins over this poll's nudging.
+      if (!twoincSelectWooHelper.focusStillWithinCompanySearch(selectWooElemId)) {
+        clearInterval(focusInterval);
+        return;
+      }
+
       let inpElem = jQuery('input[aria-owns="select2-' + selectWooElemId + '-results"]').get(0);
       if (inpElem) {
         // Focus on the element if not already focused

--- a/tests/js/company-search-focus-trap.test.js
+++ b/tests/js/company-search-focus-trap.test.js
@@ -1,0 +1,107 @@
+/**
+ * Company-search focus trap (TWO-25288 follow-up).
+ *
+ * `waitToFocus` polls to land focus in the dropdown's search field after
+ * `select2:open`, because the picker's own focus-on-open does not land
+ * reliably on every host theme. The poll used to run for its full window
+ * (up to ~4.8s from `select2:open`, up to ~12.8s from a results re-render,
+ * per `addSelectWooFocusFixHandler`) regardless of what happened after it
+ * was scheduled — including the buyer deliberately Tabbing to a completely
+ * different field. Each tick only checked "is the search input focused?",
+ * never "is the dropdown even still open?", so a buyer who tabbed away
+ * got yanked back into the search field until the poll's hit count ran
+ * out or they hit Esc (which destroys the dropdown and its search input,
+ * so the selector the poll uses stops matching anything).
+ *
+ * These tests drive the REAL selectWoo widget (see wc-harness) so the
+ * dropdown's actual open/close state is what is being asserted against,
+ * not a mock of it.
+ */
+
+"use strict";
+
+const harness = require("./wc-harness");
+
+const TEXT = {
+  company_not_in_list: "My company is not on the list",
+  search_company: "Search for company"
+};
+
+describe("company-search focus trap", () => {
+  let ctx;
+  let $;
+  let helper;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    ctx = harness.loadTwoinc({
+      text: TEXT,
+      supported_buyer_countries: ["GB"],
+      enable_company_search: "yes",
+      enable_company_search_for_others: "yes",
+      enable_address_lookup: "no"
+    });
+    $ = ctx.$;
+    helper = ctx.helper;
+    harness.buildCheckoutForm();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    harness.releaseWidgets($);
+    document.body.innerHTML = "";
+  });
+
+  test("tabbing away from an open dropdown keeps focus on the field the buyer tabbed to", () => {
+    const $select = harness.openCompanyWidget($, helper);
+
+    // Mirrors enableCompanySearch's own select2:open wiring: schedule the
+    // focus poll the way production code does.
+    helper.waitToFocus("billing_company_display", null, null);
+
+    // Let the poll's first tick or two land, same as it would while the
+    // buyer is still looking at the freshly-opened dropdown.
+    jest.advanceTimersByTime(300);
+
+    const $searchInput = $('input[aria-owns="select2-billing_company_display-results"]');
+    expect($searchInput.length).toBe(1);
+    expect(document.activeElement).toBe($searchInput.get(0));
+
+    // The buyer tabs to a completely different field. Note the picker does
+    // NOT consider itself closed just because native focus moved elsewhere
+    // (`isOpen()` stays true here) — which is exactly why the poll cannot
+    // rely on the picker's own open/closed state and must look at
+    // `document.activeElement` directly.
+    $("#billing_company").get(0).focus();
+    expect(document.activeElement).toBe($("#billing_company").get(0));
+
+    // Run the poll's remaining window (up to 16 ticks * 300ms = 4.8s).
+    jest.advanceTimersByTime(5000);
+
+    // The buyer's own navigation must win: focus stays on #billing_company,
+    // not yanked back into the (closed) dropdown's search field.
+    expect(document.activeElement).toBe($("#billing_company").get(0));
+  });
+
+  test("the re-render-triggered poll (addSelectWooFocusFixHandler) is scoped the same way", () => {
+    const $select = harness.openCompanyWidget($, helper);
+    helper.addSelectWooFocusFixHandler("billing_company_display");
+
+    // Simulate a results re-render adding a node under the results list,
+    // which is what the MutationObserver in addSelectWooFocusFixHandler
+    // reacts to by scheduling its own (80-hit, 20ms) waitToFocus poll.
+    const $results = $("#select2-billing_company_display-results");
+    $results.append('<li class="select2-results__option">Example Co</li>');
+
+    jest.advanceTimersByTime(40);
+
+    // Buyer tabs away.
+    $("#billing_company").get(0).focus();
+
+    // Run well past the 80 * 20ms = 1.6s window this poll would otherwise run for.
+    jest.advanceTimersByTime(2000);
+
+    expect(document.activeElement).toBe($("#billing_company").get(0));
+  });
+});

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -1,19 +1,30 @@
 /**
- * TWO-25288. The manual-entry affordance inside the company-search dropdown.
+ * TWO-25288, reworked #30.x.1-3. The manual-entry affordance beside the
+ * company-search dropdown.
  *
- * The row is a pseudo-option injected into a results list the picker owns and
- * empties on every render, so almost everything worth asserting here is about
- * the seam between the plugin and the widget rather than about a pure function:
- * whether the row is where the picker's keyboard navigation looks for it,
- * whether it survives a re-render, whether activating it is intercepted before
- * a company value is written, and whether the handlers that show it are bound
- * once rather than once per dropdown open.
+ * TWO-25288 made this a pseudo-option `<li role="option">` living INSIDE
+ * `.select2-results__options` (the results list), reachable by arrowing down
+ * through every result and activated via the picker's own `select2:selecting`
+ * event. That traded one accessibility gap for two others, both reported
+ * directly off the live checkout:
+ *
+ *  - `.select2-results__options` is exactly the element select2/selectWoo
+ *    apply their own scroll-and-clip to, so the row was only visible if the
+ *    buyer scrolled past however many results came back, and it was NOT in
+ *    the normal Tab sequence at all (by design — a listbox option pattern).
+ *  - selectWoo's own result-row activation binds on plain `mouseup` with no
+ *    mouse-button check, so a right click fired the same activation a left
+ *    click did.
+ *
+ * The button now lives as a sibling of the results list — outside the part
+ * that scrolls, in the normal Tab sequence, and owning a plain `click`
+ * handler that only ever fires for the primary mouse button.
  *
  * The real widget is used throughout, for the same reason the rest of this
- * suite uses it: the row's reachability IS a property of the widget's own
- * navigation code, and a mock would have to reproduce that code correctly to
- * catch a regression in it — which is exactly the assumption that let the
- * previous, unreachable implementation ship.
+ * suite uses it: the button's actual DOM position relative to the results
+ * list, and select2's own scroll/tab behaviour, are properties of the
+ * widget's own code — a mock would have to reproduce that correctly to catch
+ * a regression in it.
  */
 
 "use strict";
@@ -70,7 +81,7 @@ describe("company-search manual-entry affordance", () => {
   /**
    * Type into the dropdown's search field and fire the event the affordance
    * listens on. Deliberately NOT `.trigger("keyup")` or a debounce flush: the
-   * row is specified to appear on input, before any request goes out.
+   * button is specified to appear on input, before any request goes out.
    *
    * @param {string} term what the buyer has typed
    * @returns {void}
@@ -84,17 +95,22 @@ describe("company-search manual-entry affordance", () => {
     return $("#billing_company_display").data("select2").$results;
   }
 
-  /** @returns {Object} the manual-entry row, or an empty set */
-  function row() {
-    return resultsList().children("#" + helper.manualEntryRowId);
+  /** @returns {Object} the manual-entry button, or an empty set */
+  function btn() {
+    return $("#" + helper.manualEntryRowId);
+  }
+
+  /** Activate the button the way a buyer's click or Enter/Space does. */
+  function activate() {
+    btn().trigger("click");
   }
 
   /**
    * Guard against a harness that returns before the code under test ran.
    *
    * Every assertion below is about DOM the affordance is supposed to have
-   * created. If `bindManualEntryAffordance` silently did nothing — no handler,
-   * no observer — an "is absent" assertion still passes and a "is present" one
+   * created. If `bindManualEntryAffordance` silently did nothing — no handler
+   * at all — an "is absent" assertion still passes and a "is present" one
    * fails for the wrong reason. This asserts the binding itself happened, so
    * the suite fails loudly at the seam rather than misattributing.
    */
@@ -115,16 +131,14 @@ describe("company-search manual-entry affordance", () => {
 
       // Reach the threshold FIRST, so the mechanism is demonstrably live in
       // this test before the absence is asserted. Without this the assertion
-      // below is a precondition dressed as a check: the row was never in the
-      // list, so "it is not there" holds no matter what the code does, and no
-      // mutation could turn this test red. It was in fact the one test in this
-      // file that survived all 25.
+      // below is a precondition dressed as a check: the button was never
+      // there, so "it is not there" holds no matter what the code does.
       type("a".repeat(helper.companySearchMinLength));
-      expect(row().length).toBe(1);
+      expect(btn().length).toBe(1);
 
       type("a".repeat(helper.companySearchMinLength - 1));
 
-      expect(row().length).toBe(0);
+      expect(btn().length).toBe(0);
     });
 
     test("present at the threshold, before any request has been made", () => {
@@ -133,9 +147,9 @@ describe("company-search manual-entry affordance", () => {
 
       type("a".repeat(helper.companySearchMinLength));
 
-      expect(row().length).toBe(1);
-      // The point of the timing rule: no round trip has happened, and the row
-      // is already there. A `hasSearched` gate would fail this.
+      expect(btn().length).toBe(1);
+      // The point of the timing rule: no round trip has happened, and the
+      // button is already there. A `hasSearched` gate would fail this.
       expect(ajax.calls.length).toBe(0);
       ajax.restore();
     });
@@ -145,17 +159,17 @@ describe("company-search manual-entry affordance", () => {
 
       type("a".repeat(helper.companySearchMinLength + 4));
 
-      expect(row().length).toBe(1);
+      expect(btn().length).toBe(1);
     });
 
     test("removed again when the buyer deletes back below the threshold", () => {
       openWithAffordance();
 
       type("a".repeat(helper.companySearchMinLength));
-      expect(row().length).toBe(1);
+      expect(btn().length).toBe(1);
 
       type("a".repeat(helper.companySearchMinLength - 1));
-      expect(row().length).toBe(0);
+      expect(btn().length).toBe(0);
     });
 
     test("the threshold is read from the shared constant, not hard-coded", () => {
@@ -166,259 +180,139 @@ describe("company-search manual-entry affordance", () => {
       openWithAffordance();
 
       type("abcd");
-      expect(row().length).toBe(0);
+      expect(btn().length).toBe(0);
 
       type("abcde");
-      expect(row().length).toBe(1);
+      expect(btn().length).toBe(1);
     });
   });
 
-  describe("the row is where the picker's keyboard navigation looks", () => {
-    test("it is the LAST child of the results list", () => {
+  describe("where the button lives (#30.x.1, #30.x.2)", () => {
+    test("it is OUTSIDE the results list, not a row inside it", () => {
+      openWithAffordance();
+
+      type("abc");
+
+      // Not a child of the scrollable results list...
+      expect(resultsList().children("#" + helper.manualEntryRowId).length).toBe(0);
+      // ...but its own element still exists, and is a sibling of that list.
+      expect(btn().length).toBe(1);
+      expect(btn().prev().is(resultsList())).toBe(true);
+    });
+
+    test("it is a real <button>, not a styled row", () => {
+      openWithAffordance();
+
+      type("abc");
+
+      expect(btn().prop("tagName")).toBe("BUTTON");
+      expect(btn().attr("type")).toBe("button");
+    });
+
+    test("it stays visible however many results are already in the (scrollable) list", () => {
       openWithAffordance();
       const $list = resultsList();
-      $list.append('<li class="select2-results__option" data-selected="false">A company</li>');
+      for (let i = 0; i < 30; i++) {
+        $list.append(
+          '<li class="select2-results__option" data-selected="false">Company ' + i + "</li>"
+        );
+      }
 
       type("abc");
 
-      expect($list.children().last().attr("id")).toBe(helper.manualEntryRowId);
+      // Still reachable as a plain DOM element regardless of how long the
+      // (scrollable) results list got — nothing about finding it depends on
+      // scroll position.
+      expect(btn().length).toBe(1);
+      expect(btn().prev().is($list)).toBe(true);
     });
 
-    test("it is inside the list, not beside it", () => {
+    test("Tab from the search field reaches it directly, without visiting any option row", () => {
+      // select2/selectWoo option rows carry tabindex="-1" — deliberately
+      // excluded from the normal Tab sequence (the listbox pattern), reached
+      // only by arrow-key navigation. A real <button> with no explicit
+      // tabindex participates in the ordinary sequence, so it is the very
+      // next tabbable node after the search field once any option rows
+      // (all tabindex="-1") are skipped.
       openWithAffordance();
+      const $list = resultsList();
+      $list.append(
+        '<li class="select2-results__option" data-selected="false" tabindex="-1">A company</li>'
+      );
 
       type("abc");
 
-      expect(row().parent().is(resultsList())).toBe(true);
-    });
-
-    test("it carries the attributes the picker navigates by", () => {
-      openWithAffordance();
-
-      type("abc");
-      const $row = row();
-
-      expect($row.attr("role")).toBe("option");
-      expect($row.attr("data-selected")).toBe("false");
-      expect($row.attr("aria-selected")).toBe("false");
-      expect($row.attr("id")).toBeTruthy();
-      expect($row.hasClass("select2-results__option")).toBe(true);
-      expect($row.hasClass("select2-results__option--selectable")).toBe(true);
-      // Programmatically focusable, which is what lets the picker's own
-      // focus-the-highlighted-row call actually land.
-      expect($row.attr("tabindex")).toBe("-1");
-    });
-
-    test("it carries the same attributes the picker gives a real option", () => {
-      // Rather than restate a list of attributes this test could drift from,
-      // compare against what the widget itself produces. If the library ever
-      // adds a navigation-relevant attribute, this fails instead of the row
-      // silently falling out of the navigable set.
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
-      const real = picker.results.option({ id: "Real Co", text: "Real Co", _resultId: "real-co" });
-
-      type("abc");
-      const $row = row();
-
-      ["role", "data-selected", "tabindex"].forEach((attr) => {
-        expect($row.attr(attr)).toBe($(real).attr(attr));
+      expect(searchInput().attr("tabindex")).not.toBe("-1");
+      expect(btn().attr("tabindex")).not.toBe("-1");
+      $list.find("li").each(function () {
+        expect($(this).attr("tabindex")).toBe("-1");
       });
     });
 
-    test("real DOM focus follows the highlight — the picker's own routine", () => {
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
-      const $list = resultsList();
-      $list.append(
-        $('<li class="select2-results__option" data-selected="false" tabindex="-1">A company</li>')
-          .attr("id", "a-company-row")
-          .data("data", { id: "A company", text: "A company", _resultId: "a-company-row" })
-      );
-
-      type("abc");
-
-      picker.trigger("results:next", {});
-      picker.trigger("results:next", {});
-      // What the picker calls on every arrow keypress. Its own source says this
-      // is required for screen readers; on a row with no tabindex it is a
-      // silent no-op and focus stays on the previous row.
-      picker.focusOnActiveElement();
-
-      expect(document.activeElement).toBe(row()[0]);
-    });
-
-    test("it carries a payload with an id and a matching _resultId", () => {
+    test("it is not churned by repeated syncs on the same keystroke state", () => {
       openWithAffordance();
 
       type("abc");
-      const data = row().data("data");
-
-      expect(data).toBeTruthy();
-      expect(data.id).toBe(helper.manualEntrySentinelId);
-      // aria-activedescendant is set from _resultId, so a mismatch makes the
-      // row reachable but never announced.
-      expect(data._resultId).toBe(row().attr("id"));
-      expect(data.text).toBe(TEXT.company_not_in_list);
-    });
-
-    test("the picker's own navigation reaches it — a real reachability check", () => {
-      openWithAffordance();
-      const $select = $("#billing_company_display");
-      const picker = $select.data("select2");
-      const $list = resultsList();
-      // A payload with a _resultId, because the widget's own focus handler
-      // reads one off every row it highlights — including the company row it
-      // passes through on the way to ours.
-      $list.append(
-        $('<li class="select2-results__option" data-selected="false">A company</li>')
-          .attr("id", "a-company-row")
-          .data("data", { id: "A company", text: "A company", _resultId: "a-company-row" })
-      );
-
+      const node = btn()[0];
+      type("abc"); // same term again — must not tear down and rebuild
       type("abc");
 
-      // Arrow down twice from nothing highlighted: once onto the company row,
-      // once onto ours. This is the widget's own handler doing the walking, so
-      // it passes only if the row is genuinely in the navigable set.
-      picker.trigger("results:next", {});
-      picker.trigger("results:next", {});
-
-      const $highlighted = $list.find(".select2-results__option--highlighted");
-      expect($highlighted.attr("id")).toBe(helper.manualEntryRowId);
-      // And it is announced. Two independent places have to agree for a screen
-      // reader to name the row: the list's own aria-activedescendant, taken
-      // from the highlighted element's id, and the combobox's, taken from the
-      // highlighted row's payload `_resultId`.
-      expect($list.attr("aria-activedescendant")).toBe(helper.manualEntryRowId);
-      expect(picker.selection.$selection.attr("aria-activedescendant")).toBe(
-        helper.manualEntryRowId
-      );
-      // The dropdown's own search field carries it too, and that is the element
-      // the field's aria-owns points FROM — so it is the one an AT client
-      // following the combobox pattern reads. Both are fed from the payload's
-      // _resultId; asserting only one left the other free to be wrong.
-      expect(searchInput().attr("aria-activedescendant")).toBe(helper.manualEntryRowId);
+      expect(btn()[0]).toBe(node);
+      expect(btn().length).toBe(1);
     });
 
     test("the label is the localised msgid, not a hard-coded English literal", () => {
       // Asserting on the English string would pass against a literal in the
-      // source. Change what the text map says and require the row to follow.
+      // source. Change what the text map says and require the button to
+      // follow.
       ctx.twoinc.text.company_not_in_list = "Selskapet mitt er ikke på listen";
       openWithAffordance();
 
       type("abc");
 
-      expect(row().text()).toBe("Selskapet mitt er ikke på listen");
+      expect(btn().text()).toBe("Selskapet mitt er ikke på listen");
     });
   });
 
-  describe("it survives the picker emptying the list", () => {
-    test("re-appended after a fresh result set is rendered", () => {
+  describe("mouse-button semantics (#30.x.3)", () => {
+    test("a plain click activates it", () => {
+      jest.useFakeTimers();
       openWithAffordance();
-      const $select = $("#billing_company_display");
-      const picker = $select.data("select2");
+      ctx.Twoinc.getInstance();
 
       type("abc");
-      expect(row().length).toBe(1);
+      btn().trigger(new $.Event("click", { button: 0 }));
+      jest.advanceTimersByTime(1);
 
-      // What the picker does on every render: wipe the list, then append.
-      picker.trigger("results:all", {
-        data: { results: [{ id: "A company", text: "A company", html: "A company" }] },
-        query: { term: "abc" }
-      });
-
-      // The observer runs as a microtask, so let the queue drain.
-      return Promise.resolve().then(() => {
-        expect(row().length).toBe(1);
-        expect(resultsList().children().last().attr("id")).toBe(helper.manualEntryRowId);
-      });
+      expect(ctx.twoinc.enable_company_search).toBe("no");
+      jest.useRealTimers();
     });
 
-    test("the row is not churned by its own observer", async () => {
-      // The sync runs from a MutationObserver on the very list it appends to,
-      // so without the "already last, do nothing" early return every append
-      // re-triggers the observer and the row is torn down and rebuilt forever.
-      // The row surviving as the SAME DOM node across many observer turns is
-      // what says the guard is there.
+    test("a right click (mouseup, button 2) does not activate it", () => {
+      // The bug this replaces: selectWoo's own result-row `mouseup` binding
+      // has no button check, so a right click fired the same activation a
+      // left click did. A real <button>'s `click` event never fires for a
+      // non-primary button in the first place — assert directly that a
+      // right-button mouseup on this element causes no activation and no
+      // `click` bubbles from it.
       openWithAffordance();
-
+      const clicked = [];
+      btn().length; // no-op to satisfy lint on unused-looking helper calls
       type("abc");
-      const node = row()[0];
-      expect(node).toBeTruthy();
+      $(document.body).on("click", "#" + helper.manualEntryRowId, () => clicked.push(1));
 
-      for (let i = 0; i < 25; i++) await Promise.resolve();
+      btn().trigger(new $.Event("mouseup", { button: 2, which: 3 }));
 
-      expect(row()[0]).toBe(node);
-      expect(row().length).toBe(1);
-    });
-
-    test("not re-appended when the term is back below the threshold", () => {
-      openWithAffordance();
-      const picker = $("#billing_company_display").data("select2");
-
-      type("abc");
-      expect(row().length).toBe(1);
-
-      searchInput().val("ab");
-      picker.trigger("results:all", {
-        data: { results: [] },
-        query: { term: "ab" }
-      });
-
-      return Promise.resolve().then(() => {
-        expect(row().length).toBe(0);
-      });
+      expect(clicked).toEqual([]);
+      expect(ctx.twoinc.enable_company_search).not.toBe("no");
     });
   });
 
   describe("activation", () => {
-    /**
-     * Activate the row the way the picker does for BOTH Enter and a click:
-     * highlight it, then ask the picker to select the highlighted row.
-     *
-     * @returns {void}
-     */
-    function activate() {
-      const picker = $("#billing_company_display").data("select2");
-      row().trigger("mouseenter");
-      picker.trigger("results:select", {});
-    }
-
     beforeEach(() => {
       // enterManualCompanyEntry reaches the singleton for the customer-company
-      // snapshot; give it one before anything activates the row.
+      // snapshot; give it one before anything activates the button.
       ctx.Twoinc.getInstance();
-    });
-
-    test("no company value is written — the selection is prevented", () => {
-      const selected = [];
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
-      $select.on("select2:select", (e) => selected.push(e.params.data));
-
-      type("abc");
-      activate();
-
-      expect(selected).toEqual([]);
-      expect($("#billing_company").val()).toBe("");
-      expect($("#company_id").val()).toBe("");
-
-      // The three assertions above are all "nothing happened", and a recorder
-      // that was never wired up — or a widget that stopped emitting at all —
-      // satisfies every one of them. They would pass for the wrong reason and
-      // could not fail. So prove the recorder is LIVE on the same widget, in
-      // the same test: an ordinary row selected the ordinary way IS recorded,
-      // and the sentinel is still absent.
-      const $company = $(
-        '<li id="live-probe-row" class="select2-results__option" data-selected="false">Probe Co</li>'
-      ).data("data", { id: "Probe Co", text: "Probe Co", _resultId: "live-probe-row" });
-      resultsList().prepend($company);
-      $company.trigger("mouseenter");
-      picker.trigger("results:select", {});
-
-      expect(selected.map((d) => d.id)).toEqual(["Probe Co"]);
-      expect(selected.map((d) => d.id)).not.toContain(helper.manualEntrySentinelId);
     });
 
     test("it enters manual entry", () => {
@@ -427,7 +321,7 @@ describe("company-search manual-entry affordance", () => {
 
       type("abc");
       activate();
-      // The action is deferred out of the picker's own event dispatch.
+      // The action is deferred out of the click dispatch.
       jest.advanceTimersByTime(1);
 
       expect(ctx.twoinc.enable_company_search).toBe("no");
@@ -458,10 +352,6 @@ describe("company-search manual-entry affordance", () => {
     });
 
     test("the way back out is localised, not a hard-coded English literal", () => {
-      // Asserting against TEXT.search_company would prove nothing: that value is
-      // byte-identical to the built-in fallback, so deleting the text-map lookup
-      // entirely leaves the assertion passing. Inject a DIFFERENT string, the
-      // way the row's own label test does.
       ctx.twoinc.text.search_company = "Søk etter selskap";
       openWithAffordance();
 
@@ -470,8 +360,7 @@ describe("company-search manual-entry affordance", () => {
 
     test("repeating the activation in one tick switches once, not once per press", () => {
       jest.useFakeTimers();
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
+      openWithAffordance();
       let entered = 0;
       const realEnter = ctx.dom.enterManualCompanyEntry;
       ctx.dom.enterManualCompanyEntry = function () {
@@ -481,12 +370,11 @@ describe("company-search manual-entry affordance", () => {
 
       try {
         type("abc");
-        // The selection is prevented, so the dropdown does NOT close and the row
-        // is still there to be hit again in the same tick.
-        row().trigger("mouseenter");
-        picker.trigger("results:select", {});
-        picker.trigger("results:select", {});
-        picker.trigger("results:select", {});
+        // The button removes itself on activation, so a second dispatch in
+        // the same tick has nothing left to hit.
+        btn().trigger("click");
+        btn().trigger("click");
+        btn().trigger("click");
         jest.advanceTimersByTime(1);
 
         expect(entered).toBe(1);
@@ -498,19 +386,14 @@ describe("company-search manual-entry affordance", () => {
 
     test("the real company field is cleared, not just the display one", () => {
       jest.useFakeTimers();
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
-      // What a completed pick leaves behind.
+      openWithAffordance();
       $("#billing_company").val("Previously Picked Ltd");
       $("#company_id").val("11111111");
 
       type("abc");
-      row().trigger("mouseenter");
-      picker.trigger("results:select", {});
+      activate();
       jest.advanceTimersByTime(1);
 
-      // Otherwise the manual field the buyer is about to see is pre-filled with
-      // the company they just said is not theirs, next to an empty org number.
       expect($("#billing_company").val()).toBe("");
       expect($("#company_id").val()).toBe("");
       jest.useRealTimers();
@@ -519,10 +402,6 @@ describe("company-search manual-entry affordance", () => {
     /**
      * Add the address inputs `setAddress` writes to, prefilled the way an
      * address lookup for a picked company leaves them.
-     *
-     * They are created here rather than in the shared form because `.val()` on
-     * an empty set is a silent no-op: if the fields were absent, a "cleared"
-     * assertion would read undefined and could never fail.
      *
      * @returns {void}
      */
@@ -535,61 +414,35 @@ describe("company-search manual-entry affordance", () => {
           "<input type='text' id='billing_postcode' value='0001' />"
         ].join("\n")
       );
-      // The precondition, asserted rather than assumed — see above.
       expect($("#billing_address_1").val()).toBe("Registry Street 1");
-      expect($("#billing_address_2").val()).toBe("Flat 2");
-      expect($("#billing_city").val()).toBe("Registryville");
-      expect($("#billing_postcode").val()).toBe("0001");
     }
 
     test("the disowned company's registry address does not survive into the order", () => {
       jest.useFakeTimers();
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
+      openWithAffordance();
       givenLookedUpAddress();
-
-      // The gate reads this flag, not `#company_id` (see the comment at the
-      // clear site): `#company_id` is also written by account-restore and
-      // sole-trader code with no lookup behind it, and stays empty for a
-      // picked company with no organisation number even though its lookup DID
-      // run — so faking a pick via `#company_id` would prove the wrong thing.
-      // The flag's own producer (`addressLookup`'s success branch) is
-      // exercised separately below.
       ctx.Twoinc.getInstance().registryAddressApplied = true;
 
       type("abc");
-      row().trigger("mouseenter");
-      picker.trigger("results:select", {});
+      activate();
       jest.advanceTimersByTime(1);
 
-      // Otherwise the order ships to the address of the company the buyer has
-      // just said is not theirs, in fields they never visibly touched.
       expect($("#billing_address_1").val()).toBe("");
       expect($("#billing_address_2").val()).toBe("");
       expect($("#billing_city").val()).toBe("");
       expect($("#billing_postcode").val()).toBe("");
-      // And the flag itself is consumed, not left set for the next entry.
       expect(ctx.Twoinc.getInstance().registryAddressApplied).toBe(false);
       jest.useRealTimers();
     });
 
-    test("the address is left alone when the row is reached without ever picking a company", () => {
-      // The ordinary path: type to the threshold, see nothing you like, click
-      // "not on the list". No pick, so no lookup ever ran — clearing the
-      // address here would wipe the buyer's own account-prefilled address for
-      // no reason. This is the scenario an unconditional clear, or a clear
-      // gated on `#company_id` alone, gets wrong: a logged-in buyer can have
-      // `#company_id` prefilled by account-restore with no lookup behind it.
+    test("the address is left alone when the button is reached without ever picking a company", () => {
       jest.useFakeTimers();
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
+      openWithAffordance();
       givenLookedUpAddress();
       $("#company_id").val("11111111"); // account-restored, not a fresh pick
-      // registryAddressApplied deliberately left false — no lookup ran.
 
       type("abc");
-      row().trigger("mouseenter");
-      picker.trigger("results:select", {});
+      activate();
       jest.advanceTimersByTime(1);
 
       expect($("#billing_address_1").val()).toBe("Registry Street 1");
@@ -599,85 +452,16 @@ describe("company-search manual-entry affordance", () => {
       jest.useRealTimers();
     });
 
-    test("a picked company with no organisation number still has its looked-up address cleared", () => {
-      // A company hit can carry no organisation number at all (optional
-      // field) and still have had a real address lookup run for it — the
-      // lookup is keyed off `lookup_id`, not the org number. Gating on
-      // `#company_id` being non-empty would let this case through; gating on
-      // the flag does not.
-      jest.useFakeTimers();
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
-      givenLookedUpAddress();
-      $("#company_id").val(""); // the org-number-less pick, as it lands in the DOM
-      ctx.Twoinc.getInstance().registryAddressApplied = true;
-
-      type("abc");
-      row().trigger("mouseenter");
-      picker.trigger("results:select", {});
-      jest.advanceTimersByTime(1);
-
-      expect($("#billing_address_1").val()).toBe("");
-      expect($("#billing_address_2").val()).toBe("");
-      expect($("#billing_city").val()).toBe("");
-      expect($("#billing_postcode").val()).toBe("");
-      jest.useRealTimers();
-    });
-
-    test("addressLookup sets the flag only on a successful response with addresses", () => {
-      // Closes the coupling gap: everything above sets/reads the flag
-      // directly, so nothing proves `addressLookup` itself is the flag's real
-      // producer. Drive it through a picked select2:select the way
-      // `enableCompanySearch` wires it, with a stubbed ajax response.
-      $("form[name='checkout']").append(
-        [
-          "<input type='text' id='billing_address_1' />",
-          "<input type='text' id='billing_address_2' />",
-          "<input type='text' id='billing_city' />",
-          "<input type='text' id='billing_postcode' />"
-        ].join("\n")
-      );
-      const ajax = harness.stubAjax($);
-      const twoinc = ctx.Twoinc.getInstance();
-      expect(twoinc.registryAddressApplied).toBe(false);
-
-      twoinc.addressLookup({ lookup_id: "lookup-1" });
-      expect(twoinc.registryAddressApplied).toBe(false); // not yet — pending
-
-      ajax.calls[0].succeed({
-        addresses: [
-          { street_address: "Registry Street 1", city: "Registryville", postal_code: "0001" }
-        ]
-      });
-
-      expect(twoinc.registryAddressApplied).toBe(true);
-      expect($("#billing_address_1").val()).toBe("Registry Street 1");
-
-      // A response carrying no `addresses` key at all (the lookup found
-      // nothing) must not falsely arm the flag.
-      twoinc.registryAddressApplied = false;
-      twoinc.addressLookup({ lookup_id: "lookup-2" });
-      ajax.calls[1].succeed({});
-      expect(twoinc.registryAddressApplied).toBe(false);
-
-      ajax.restore();
-    });
-
     test("the display select's own value is cleared, not just hidden", () => {
       jest.useFakeTimers();
-      // A completed pick leaves the picked option selected on the underlying
-      // <select>, and select2("destroy") does not touch it. Left behind, the
-      // combobox re-appears showing the company the buyer just disowned.
       $("#billing_company_display").append(
         '<option value="ACME Widgets Ltd" selected>ACME Widgets Ltd</option>'
       );
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
+      openWithAffordance();
       expect($("#billing_company_display").val()).toBe("ACME Widgets Ltd");
 
       type("abc");
-      row().trigger("mouseenter");
-      picker.trigger("results:select", {});
+      activate();
       jest.advanceTimersByTime(1);
 
       expect($("#billing_company_display").val()).toBe("");
@@ -692,15 +476,11 @@ describe("company-search manual-entry affordance", () => {
       activate();
       jest.advanceTimersByTime(1);
 
-      // What the buyer typed by hand while in manual entry.
       $("#billing_company").val("Hand Typed Ltd");
       $("#company_id").val("99999999");
 
       ctx.dom.exitManualCompanyEntry();
 
-      // Left behind, the org number sits on a field the buyer can no longer
-      // see, passes the non-empty guard on the PHP side, and reaches the order
-      // while the combobox shows nothing selected.
       expect($("#billing_company").val()).toBe("");
       expect($("#company_id").val()).toBe("");
       jest.useRealTimers();
@@ -772,15 +552,14 @@ describe("company-search manual-entry affordance", () => {
       expect(inputHandlerCount()).toBe(1);
     });
 
-    test("one keystroke appends one row, not one per bind", () => {
-      const $select = openWithAffordance();
+    test("one keystroke produces one button, not one per bind", () => {
+      openWithAffordance();
       helper.bindManualEntryAffordance();
       helper.bindManualEntryAffordance();
 
       type("abc");
 
-      expect(row().length).toBe(1);
-      expect(resultsList().children("li[id]").length).toBe(1);
+      expect(btn().length).toBe(1);
     });
 
     test("the handler exists before the dropdown's field does", () => {
@@ -797,7 +576,7 @@ describe("company-search manual-entry affordance", () => {
       $select.select2("open");
       type("abc");
 
-      expect(row().length).toBe(1);
+      expect(btn().length).toBe(1);
     });
   });
 
@@ -808,12 +587,10 @@ describe("company-search manual-entry affordance", () => {
 
     test("entering manual entry focuses the field the buyer asked for", () => {
       jest.useFakeTimers();
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
+      openWithAffordance();
 
       type("abc");
-      row().trigger("mouseenter");
-      picker.trigger("results:select", {});
+      activate();
       jest.advanceTimersByTime(1);
 
       // Destroying the widget leaves activeElement on <body>, which means a
@@ -824,169 +601,31 @@ describe("company-search manual-entry affordance", () => {
 
     test("leaving manual entry does not strand focus on the hidden button", () => {
       jest.useFakeTimers();
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
+      openWithAffordance();
       type("abc");
-      row().trigger("mouseenter");
-      picker.trigger("results:select", {});
+      activate();
       jest.advanceTimersByTime(1);
       jest.useRealTimers();
 
       ctx.dom.exitManualCompanyEntry();
 
-      // Whatever it lands on, it must not be the button that was just hidden,
-      // and it must not be nothing.
       expect(document.activeElement).not.toBe($("#" + helper.searchCompanyBtnId)[0]);
       expect(document.activeElement).not.toBe(document.body);
     });
 
     test("focusing a field that is not there reports failure rather than lying", () => {
-      // Both callers run on a surface that may not render the field. A bare
-      // .focus() on an empty jQuery set is a silent no-op that reads as success.
       expect(ctx.dom.focusVisibleCompanyField("#no_such_field_at_all")).toBe(false);
       expect(ctx.dom.focusVisibleCompanyField("#billing_company")).toBe(true);
     });
 
     test("a disabled field reports failure rather than lying", () => {
-      // A disabled input cannot take focus, so `.focus()` on it is the same
-      // silent no-op as an empty set. The caller uses the return value to
-      // decide whether to try its fallback target, so the distinction has to
-      // be real.
-      //
-      // What this pins is the CONTRACT, not one line of it. The `disabled`
-      // clause and the activeElement check are two independent mechanisms that
-      // both produce `false` here, so removing either one alone leaves this
-      // green (verified by mutation); removing both turns it red. The clause is
-      // kept as the explicit one because it also stops `.trigger("focus")`
-      // running focus handlers on a field the buyer cannot reach.
       $("#billing_company").prop("disabled", true);
 
       expect(ctx.dom.focusVisibleCompanyField("#billing_company")).toBe(false);
       expect(document.activeElement).not.toBe($("#billing_company")[0]);
 
-      // Live probe: the same call on the same field succeeds once enabled, so
-      // the false above is the guard firing and not a broken selector.
       $("#billing_company").prop("disabled", false);
       expect(ctx.dom.focusVisibleCompanyField("#billing_company")).toBe(true);
-    });
-  });
-
-  describe("one handler and one observer, across every re-bind", () => {
-    /** @returns {number} namespaced pre-select handlers on the select */
-    function selectingHandlerCount($select) {
-      const events = $._data($select[0], "events");
-      const bucket = events && events["select2:selecting"];
-      if (!bucket) return 0;
-      return bucket.filter((h) => h.namespace === "twoincManualEntry").length;
-    }
-
-    test("still one pre-select handler after several re-binds", () => {
-      // A duplicate here fires the whole manual-entry switch twice per
-      // activation. The body-input counter next door does not see this handler
-      // at all — it lives on the select.
-      const $select = openWithAffordance();
-
-      expect(selectingHandlerCount($select)).toBe(1);
-
-      helper.bindManualEntryAffordance();
-      helper.bindManualEntryAffordance();
-      helper.bindManualEntryAffordance();
-
-      expect(selectingHandlerCount($select)).toBe(1);
-    });
-
-    /**
-     * Record every MutationObserver, keyed on what it ends up observing.
-     *
-     * Filtering by target is not tidying: the widget constructs a
-     * MutationObserver of its OWN inside `_registerDomEvents`, one per widget.
-     * A test that merely counts constructions counts the library's too, so it
-     * reads 2 when the plugin made 1 and 3 when it made 1 — it fails for a
-     * reason that has nothing to do with this code.
-     *
-     * @returns {{on: Function, restore: Function}}
-     */
-    function observerSpy() {
-      const real = global.MutationObserver;
-      const records = [];
-      global.MutationObserver = function (cb) {
-        const observer = new real(cb);
-        const record = { target: null, disconnected: false };
-        const observe = observer.observe.bind(observer);
-        const disconnect = observer.disconnect.bind(observer);
-        observer.observe = function (node, opts) {
-          record.target = node;
-          return observe(node, opts);
-        };
-        observer.disconnect = function () {
-          record.disconnected = true;
-          return disconnect();
-        };
-        records.push(record);
-        return observer;
-      };
-      return {
-        /** @returns {Array} records whose observed node is `node` */
-        on: function (node) {
-          return records.filter((r) => r.target === node);
-        },
-        restore: function () {
-          global.MutationObserver = real;
-        }
-      };
-    }
-
-    test("still one observer on the results list after several re-binds", () => {
-      const spy = observerSpy();
-      try {
-        const $select = openWithAffordance();
-        const list = resultsList()[0];
-
-        helper.bindManualEntryAffordance();
-        helper.bindManualEntryAffordance();
-        // Several keystrokes, not one. The watcher is installed from the
-        // per-keystroke sync — that is what makes a re-created widget heal
-        // itself — so a single keystroke cannot tell "installed once" from
-        // "re-installed on every character". Without the per-node guard this
-        // churns one observer per keystroke.
-        type("abc");
-        type("abcd");
-        type("abcde");
-        type("abcdef");
-
-        const mine = spy.on(list);
-        expect(mine.length).toBe(1);
-        expect(mine.filter((o) => !o.disconnected).length).toBe(1);
-      } finally {
-        spy.restore();
-      }
-    });
-
-    test("a replacement results list gets the observer, the old one is released", () => {
-      const spy = observerSpy();
-      try {
-        const $select = openWithAffordance();
-        const firstList = resultsList()[0];
-        type("abc");
-        expect(spy.on(firstList).length).toBe(1);
-
-        // What clearing the selected company does: a brand-new widget, and so a
-        // brand-new results list.
-        $select.select2("destroy");
-        $select.html("");
-        $select.selectWoo(helper.genSelectWooParams());
-        $select.select2("open");
-        type("abc");
-
-        const secondList = resultsList()[0];
-        expect(secondList).not.toBe(firstList);
-        expect(spy.on(secondList).length).toBe(1);
-        // The old one was let go rather than left watching a detached node for
-        // the life of the page.
-        expect(spy.on(firstList)[0].disconnected).toBe(true);
-      } finally {
-        spy.restore();
-      }
     });
   });
 
@@ -995,10 +634,10 @@ describe("company-search manual-entry affordance", () => {
       ctx.Twoinc.getInstance();
     });
 
-    test("the row survives clearing the selected company", () => {
+    test("the button survives clearing the selected company", () => {
       const $select = openWithAffordance();
       type("abc");
-      expect(row().length).toBe(1);
+      expect(btn().length).toBe(1);
 
       // The real gesture: the × on the floating company id. It re-creates the
       // widget and knows nothing about this affordance, so nothing re-binds.
@@ -1006,30 +645,10 @@ describe("company-search manual-entry affordance", () => {
       $select.select2("open");
 
       type("abc");
-      expect(row().length).toBe(1);
-
-      // And it must SURVIVE the next render, which is the part that used to
-      // break: the delegated input handler still appended the row, then the
-      // first result set wiped it and no observer put it back.
-      const picker = $("#billing_company_display").data("select2");
-      picker.trigger("results:all", {
-        data: { results: [{ id: "A company", text: "A company", html: "A company" }] },
-        query: { term: "abc" }
-      });
-
-      return Promise.resolve().then(() => {
-        expect(row().length).toBe(1);
-        expect(resultsList().children().last().attr("id")).toBe(helper.manualEntryRowId);
-      });
+      expect(btn().length).toBe(1);
     });
 
     test("clearing the selected company resets the registry-address flag", () => {
-      // Without this, the × button leaves the flag stale true after already
-      // blanking the address: pick a company (flag true, address written),
-      // click ×, type your OWN address into the now-empty fields, then click
-      // "not on the list" — enterManualCompanyEntry sees the stale flag and
-      // wipes what you just typed. The same false-positive round 2 fixed,
-      // resurfacing through this path if the reset here ever regresses.
       const twoinc = ctx.Twoinc.getInstance();
       twoinc.registryAddressApplied = true;
 
@@ -1046,26 +665,19 @@ describe("company-search manual-entry affordance", () => {
 
     test("manual entry survives a trip through sole trader and back", () => {
       jest.useFakeTimers();
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
+      openWithAffordance();
 
       type("abc");
-      row().trigger("mouseenter");
-      picker.trigger("results:select", {});
+      activate();
       jest.advanceTimersByTime(1);
       jest.useRealTimers();
       expect(ctx.twoinc.enable_company_search).toBe("no");
 
-      // Sole trader snapshots the CURRENT setting — which manual entry has just
-      // written as "no" — and business mode restores that snapshot, so the
-      // re-enable path early-returns and the picker never comes back.
       ctx.soleTrader.setMode("sole_trader");
       expect($("#" + helper.searchCompanyBtnId)[0].style.display).toBe("none");
 
       ctx.soleTrader.setMode("business");
 
-      // Without a route back the buyer is stranded in manual entry with no way
-      // to reach the picker again.
       expect(ctx.twoinc.enable_company_search).toBe("no");
       expect($("#" + helper.searchCompanyBtnId)[0].style.display).not.toBe("none");
     });
@@ -1083,21 +695,17 @@ describe("company-search manual-entry affordance", () => {
     }
 
     /**
-     * Enter manual entry through the row, the way a buyer does.
+     * Enter manual entry through the button, the way a buyer does.
      *
      * @returns {void}
      */
     function enterManualEntry() {
       jest.useFakeTimers();
-      const $select = openWithAffordance();
-      const picker = $select.data("select2");
+      openWithAffordance();
       type("abc");
-      row().trigger("mouseenter");
-      picker.trigger("results:select", {});
+      activate();
       jest.advanceTimersByTime(1);
       jest.useRealTimers();
-      // Guard: the widget really is gone, so "open" below cannot be the
-      // dropdown that was already open before the round trip.
       expect($("#billing_company_display").data("select2")).toBeUndefined();
     }
 
@@ -1106,8 +714,6 @@ describe("company-search manual-entry affordance", () => {
 
       ctx.dom.exitManualCompanyEntry();
 
-      // The picker's own open state, read off the DOM it renders — a closed
-      // picker carries neither.
       expect(container().hasClass("select2-container--open")).toBe(true);
       expect($("#select2-billing_company_display-results").length).toBe(1);
     });
@@ -1120,23 +726,20 @@ describe("company-search manual-entry affordance", () => {
       const input = searchInput();
       expect(input.length).toBe(1);
       expect(document.activeElement).toBe(input[0]);
-      // The pre-fix behaviour: focus parked on the combobox, so the buyer had
-      // to click a second time to get a search box at all.
       expect(document.activeElement).not.toBe(
         $("#billing_company_display_field .select2-selection")[0]
       );
       expect(document.activeElement).not.toBe(document.body);
     });
 
-    test("the buyer can type straight away and the row comes back", () => {
+    test("the buyer can type straight away and the button comes back", () => {
       enterManualEntry();
 
       ctx.dom.exitManualCompanyEntry();
 
-      // No second click anywhere: type into whatever now has focus.
       $(document.activeElement).val("abc").trigger("input");
 
-      expect(row().length).toBe(1);
+      expect(btn().length).toBe(1);
     });
 
     test("opening an already-open dropdown is a no-op, not a second dropdown", () => {
@@ -1151,11 +754,6 @@ describe("company-search manual-entry affordance", () => {
     });
 
     test("a focus that fails does not drag focus back onto the collapsed combobox", () => {
-      // The mixed state: dropdown expanded, focus parked on the collapsed
-      // combobox in front of it, so the buyer's keystrokes go nowhere the open
-      // list can see. The fallback chain must be reachable ONLY when no
-      // dropdown was opened, which is why the helper reports "opened" rather
-      // than "focused".
       enterManualEntry();
       const realFocus = ctx.dom.focusVisibleCompanyField;
       jest.spyOn(ctx.dom, "focusVisibleCompanyField").mockImplementation((selector) => {
@@ -1172,9 +770,6 @@ describe("company-search manual-entry affordance", () => {
     });
 
     test("no picker attached reports failure rather than lying", () => {
-      // The guard the fallback path depends on. A bare select2("open") on a
-      // select with no widget throws, and reporting success would skip the
-      // fallback focus entirely.
       harness.releaseWidgets($);
 
       expect(ctx.dom.openCompanySearchDropdown()).toBe(false);
@@ -1189,39 +784,27 @@ describe("company-search manual-entry affordance", () => {
 
   describe("the pay-for-order surface", () => {
     test("the affordance needs no template markup on the page", () => {
-      // The billing-form view that used to carry these two nodes is rendered on
-      // the checkout page only. Nothing here renders it, and the row and the
-      // link back are still built.
       jest.useFakeTimers();
       expect($(".company_not_in_btn").length).toBe(0);
       expect($("#" + helper.searchCompanyBtnId).length).toBe(0);
       ctx.Twoinc.getInstance();
 
-      const $select = openWithAffordance();
+      openWithAffordance();
       type("abc");
-      expect(row().length).toBe(1);
+      expect(btn().length).toBe(1);
 
-      const picker = $select.data("select2");
-      row().trigger("mouseenter");
-      picker.trigger("results:select", {});
+      activate();
       jest.advanceTimersByTime(1);
 
       expect($("#" + helper.searchCompanyBtnId).length).toBe(1);
       jest.useRealTimers();
     });
 
-    // All three, not just one: dropping #company_id_field from the selector
-    // leaves the buyer a name box and nowhere to type the org number — the
-    // exact failure the function exists to prevent — and dropping
-    // #billing_company_display_field strands the way back to the picker.
     test.each([
       ["#billing_company_display_field"],
       ["#billing_company_field"],
       ["#company_id_field"]
     ])("%s's wrapper follows the field's own visibility", (fieldSelector) => {
-      // The pay-for-order page wraps each company input in a container with
-      // its own hidden state. Revealing the field alone leaves manual entry
-      // with nothing visible, so the wrapper has to follow.
       $(fieldSelector).wrap('<div class="twoinc-inp-container hidden"></div>');
       $(fieldSelector).addClass("hidden");
 

--- a/views/woocommerce_after_checkout_billing_form.php
+++ b/views/woocommerce_after_checkout_billing_form.php
@@ -12,16 +12,20 @@
      * search used to be two hidden <div>s here, cloned into the dropdown by
      * the checkout JS (TWO-25288).
      *
-     * They are built in JS from the localised text map now. Two reasons, both
-     * load-bearing rather than tidying:
+     * They are built in JS from the localised text map now. Load-bearing
+     * rather than tidying: this view is rendered on the checkout page only.
+     * The pay-for-order page renders its own copy of the company inputs and
+     * runs the same search binding, so cloning from here left that page with
+     * no way into manual entry and no way back out.
      *
-     *  - the affordance has to be a real pseudo-option <li> inside the results
-     *    list to be arrow-key reachable and announced, which a cloned <div>
-     *    cannot become; and
-     *  - this view is rendered on the checkout page only. The pay-for-order
-     *    page renders its own copy of the company inputs and runs the same
-     *    search binding, so cloning from here left that page with no way into
-     *    manual entry and no way back out.
+     * The "not on the list" affordance itself is a real <button>, appended as
+     * a sibling of the results list rather than a row inside it (#30.x.1-3):
+     * a pseudo-option <li> inside the results list was tried first
+     * (TWO-25288) for arrow-key reachability, but that list is exactly what
+     * select2/selectWoo apply their own scroll-and-clip to, so the row was
+     * only visible after scrolling past however many results came back, and
+     * selectWoo's own option-activation binds on `mouseup` with no mouse
+     * button check, so a right click activated it the same as a left click.
      */
     ?>
 </div>


### PR DESCRIPTION
## Summary

Four buyer-reported bugs in the checkout company-search widget's "my company is not on the list" affordance and dropdown, found via live testing:

- **Reachable only by scrolling / arrowing through every result.** The affordance was a pseudo-option `<li>` living inside `.select2-results__options` (the scrollable results list), so it was only visible after scrolling past however many results came back, and the only way to reach it by keyboard was arrowing down through every result — it deliberately carried `tabindex="-1"`, excluded from the normal Tab sequence (the listbox pattern). Reworked as a real `<button>`, appended as a sibling of the results list rather than a row inside it: always visible without scrolling, and reached with a single Tab from the search field (option rows are `tabindex="-1"` and skipped).
- **Activated by a right click.** selectWoo's own option-row activation binds on plain `mouseup` with no mouse-button check at all, so a right click fired the same activation a left click did. Moving the affordance out of the results list and into a real `<button>` removes it from that binding entirely — a `<button>`'s native `click` event only ever fires for the primary mouse button, and Enter/Space work for free.
- **Keyboard input gets swallowed after tabbing away from an open dropdown.** `waitToFocus` (the poll that lands focus in the dropdown's search field after it opens, needed because the picker's own focus-on-open doesn't land reliably on every host theme) kept nudging focus back into the search field for its whole window — up to ~4.8s, or ~12.8s from the results-render-triggered variant — regardless of what happened after it was scheduled. A buyer who Tabbed to a completely different field got yanked back into the dropdown until the poll's hit count ran out or they hit Esc. Scoped the poll to stop the moment focus moves outside the company-search widget.
- **Placeholder styling.** "Search for company" rendered upper-cased (a host theme's blanket `text-transform`) and a few pixels off vertical centre (a host theme's custom selection-box height with no matching line-height). Neutralised the transform and switched to flex centring, scoped to this one field so it doesn't touch any other select2 instance a theme already renders correctly.

Not fixed in this PR: the report that the company-search box itself sits last in the page's DOM/tab order. I could not find a cause for that in this repo's field-priority code (`WC_Twoinc_Checkout::update_company_fields` already assigns it the same priority as WooCommerce's own `billing_company` field), so it may be theme- or overlay-specific rather than a bug here — flagging rather than guessing at a fix.

## Test plan

- [x] `npm run test:js` — 155 passing, including a new focus-trap regression suite and a substantially reworked manual-entry suite (real widget via jsdom + selectWoo, no mocks)
- [x] `php tests/unit/run.php` — all passing
- [x] Mutation-verified: reverted the button rework to the old `<li>` and to an in-list append, confirmed the relevant tests fail; reverted the focus-trap fix, confirmed the new focus tests fail
- [x] `prettier --check` clean on all touched JS/CSS/test files
