### PR TITLE
Cache-bust enqueued assets by file mtime

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -2406,8 +2406,8 @@ if (!class_exists('WC_Twoinc')) {
                 wp_enqueue_media();
             }
 
-            wp_enqueue_script('twoinc.admin', WC_TWOINC_PLUGIN_URL . '/assets/js/admin.js', ['jquery']);
-            wp_enqueue_style('twoinc.admin', WC_TWOINC_PLUGIN_URL . '/assets/css/admin.css');
+            wp_enqueue_script('twoinc.admin', WC_TWOINC_PLUGIN_URL . '/assets/js/admin.js', ['jquery'], twoinc_get_asset_version('assets/js/admin.js'));
+            wp_enqueue_style('twoinc.admin', WC_TWOINC_PLUGIN_URL . '/assets/css/admin.css', false, twoinc_get_asset_version('assets/css/admin.css'));
 
             // Localize script for AJAX
             wp_localize_script('twoinc.admin', 'twoinc_admin', [

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -1008,6 +1008,17 @@ function get_twoinc_plugin_version()
         : '2.23.9';
 }
 
+// The real one lives in tillit-payment-gateway.php (not loaded, see above);
+// this mirrors its filemtime-with-fallback logic exactly so the asset-cache
+// -busting tests exercise the real behaviour against the real files on disk.
+function twoinc_get_asset_version($relative_path)
+{
+    $path = WC_TWOINC_PLUGIN_PATH . ltrim($relative_path, '/');
+    $mtime = file_exists($path) ? @filemtime($path) : false;
+
+    return $mtime !== false ? (string) $mtime : get_twoinc_plugin_version();
+}
+
 // Read by admin_options() for the provenance footer. Only 'version' is asked
 // for; anything else returns '' rather than guessing at WordPress semantics.
 function get_bloginfo($show = '', $filter = 'raw')

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -187,6 +187,8 @@ final class BrandConfigSpec
             'testIntentApprovedNoticeInvalidSwitchReportsAndDefaultsOn',
             'testIntentLoaderRendersTheOneSharedDotPulse',
             'testIntentLoaderSuppressedWithTheNoticeButErrorBoxesSurvive',
+            'testAssetVersionTracksFileMtimeNotPluginVersion',
+            'testAssetVersionFallsBackToPluginVersionWhenFileMissing',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -5491,6 +5493,46 @@ final class BrandConfigSpec
             strpos($html, 'twoinc-pay-box twoinc-err-phone-number hidden') !== false,
             'the phone-number error box must survive the notice being off'
         );
+    }
+
+    /**
+     * Enqueued asset versions must key off the asset file's own mtime, not
+     * the static plugin version — a CDN/browser cache-busting fix. Two real
+     * files with different mtimes must resolve to different versions, and
+     * touching one file must not change the other's version.
+     */
+    private static function testAssetVersionTracksFileMtimeNotPluginVersion(): void
+    {
+        $js = WC_TWOINC_PLUGIN_PATH . 'assets/js/twoinc.js';
+        $css = WC_TWOINC_PLUGIN_PATH . 'assets/css/twoinc.css';
+
+        TinyAssert::same((string) filemtime($js), twoinc_get_asset_version('assets/js/twoinc.js'));
+        TinyAssert::same((string) filemtime($css), twoinc_get_asset_version('assets/css/twoinc.css'));
+
+        // Bumping one file's mtime changes only that file's resolved version.
+        $original_js_mtime = filemtime($js);
+        $css_version_before = twoinc_get_asset_version('assets/css/twoinc.css');
+        try {
+            touch($js, $original_js_mtime + 3600);
+            TinyAssert::same((string) ($original_js_mtime + 3600), twoinc_get_asset_version('assets/js/twoinc.js'));
+            TinyAssert::same($css_version_before, twoinc_get_asset_version('assets/css/twoinc.css'));
+        } finally {
+            touch($js, $original_js_mtime);
+        }
+    }
+
+    /**
+     * A missing/renamed asset must fall back to the plugin version string,
+     * not emit a PHP warning or an empty `?ver=` argument.
+     */
+    private static function testAssetVersionFallsBackToPluginVersionWhenFileMissing(): void
+    {
+        $GLOBALS['__twoinc_test_plugin_version'] = '9.9.9-test';
+        try {
+            TinyAssert::same('9.9.9-test', twoinc_get_asset_version('assets/js/does-not-exist.js'));
+        } finally {
+            unset($GLOBALS['__twoinc_test_plugin_version']);
+        }
     }
 }
 

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -183,7 +183,7 @@ function wc_twoinc_add_to_gateways($gateways)
  */
 function wc_twoinc_enqueue_styles()
 {
-    wp_enqueue_style('twoinc-payment-gateway-css', WC_TWOINC_PLUGIN_URL . '/assets/css/twoinc.css', false, get_twoinc_plugin_version());
+    wp_enqueue_style('twoinc-payment-gateway-css', WC_TWOINC_PLUGIN_URL . '/assets/css/twoinc.css', false, twoinc_get_asset_version('assets/css/twoinc.css'));
 }
 
 /**
@@ -191,7 +191,7 @@ function wc_twoinc_enqueue_styles()
  */
 function wc_twoinc_enqueue_scripts()
 {
-    wp_enqueue_script('twoinc-payment-gateway-js', WC_TWOINC_PLUGIN_URL . '/assets/js/twoinc.js', ['jquery'], get_twoinc_plugin_version());
+    wp_enqueue_script('twoinc-payment-gateway-js', WC_TWOINC_PLUGIN_URL . '/assets/js/twoinc.js', ['jquery'], twoinc_get_asset_version('assets/js/twoinc.js'));
 }
 
 /**
@@ -275,6 +275,29 @@ function get_twoinc_plugin_version()
 
     $plugin_data = get_plugin_data(__FILE__);
     return $plugin_data['Version'];
+}
+
+/**
+ * Cache-busting version for a single enqueued asset.
+ *
+ * The plugin version string only changes on a deliberate version bump, so an
+ * asset deployed between bumps keeps the same `?ver=` query arg — CDNs and
+ * browsers then keep serving the stale cached file after a deploy. Keying
+ * the version to the asset's own last-modified time changes the URL on every
+ * deploy that touches that file, busting both layers of cache automatically.
+ *
+ * Falls back to the plugin version if the file can't be stat'd (moved/
+ * missing asset, restrictive filesystem) so enqueuing never emits a PHP
+ * warning or an empty version argument.
+ *
+ * @param string $relative_path Asset path relative to the plugin root, e.g. 'assets/js/twoinc.js'.
+ */
+function twoinc_get_asset_version($relative_path)
+{
+    $path = WC_TWOINC_PLUGIN_PATH . ltrim($relative_path, '/');
+    $mtime = file_exists($path) ? @filemtime($path) : false;
+
+    return $mtime !== false ? (string) $mtime : get_twoinc_plugin_version();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Static asset URLs (`assets/js/twoinc.js`, `assets/css/twoinc.css`, `assets/js/admin.js`, `assets/css/admin.css`) were versioned with the plugin's static version string, which only changes on a deliberate version bump. Between bumps, a deploy that changes an asset's contents did not change its `?ver=` query arg, so CDN/browser caches kept serving the stale file after deploy.
- Adds `twoinc_get_asset_version()`, which derives each asset's version from its own `filemtime()`, falling back to the plugin version string if the file can't be stat'd. Every `wp_enqueue_script()`/`wp_enqueue_style()` call in the plugin now uses it.

## Test plan
- [x] `php tests/unit/run.php` — added `testAssetVersionTracksFileMtimeNotPluginVersion` (two real asset files resolve independent, mtime-derived versions) and `testAssetVersionFallsBackToPluginVersionWhenFileMissing` (missing file falls back cleanly, no warning). Full suite passes.
- [x] `php -l` on all four changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)