### PR TITLE
fix(company-search): uppercase/alignment round 2 + Tab-to-button shortcut

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -178,6 +178,15 @@
  * row padding so it doesn't look like a foreign element bolted underneath.
  * Kept as a flat single-id selector so brand overlays that recolour it keep
  * matching without raising their own specificity.
+ *
+ * `text-transform: none` is new (round 2, #30.x.5). It was never needed while
+ * this was an `<li>` — this <button> tag is what makes it a target for a host
+ * theme's generic `button { text-transform: uppercase; }` styling, which
+ * plenty of themes apply for CTA-style buttons. An `<li role="option">` never
+ * matched that selector; a real `<button>` always will. `!important` because
+ * that kind of theme rule is routinely `!important` itself (buttons are a
+ * common place themes fight plugins for the last word), and this element has
+ * no reason to ever want the theme's button casing.
  */
 #company_not_in_btn {
   display: block;
@@ -187,6 +196,7 @@
   color: #3043d1;
   background: none;
   border: 0;
+  text-transform: none !important;
   border-top: 1px solid #eeeeee;
   font: inherit;
   padding: 6px 12px;
@@ -357,24 +367,42 @@
 }
 
 /*
- * Company-search placeholder / selected-value text (#30.x.5).
+ * Company-search placeholder / selected-value text (#30.x.5, round 2).
  *
  * Some host themes apply a blanket `text-transform: uppercase` broad enough
  * to catch select2's own rendered span, and give the selection box a custom
  * height with no matching `.select2-selection__rendered` line-height —
  * leaving the placeholder text a few pixels above true vertical centre.
  * Scoped to this one field's combobox so it never touches an unrelated
- * select2 instance a theme already renders correctly. Flex centring rather
- * than a fixed line-height: it self-adjusts to whatever height a host theme
- * gives the selection box instead of assuming one.
+ * select2 instance a theme already renders correctly.
+ *
+ * Round 1 (first #30.x.5) set `text-transform: none` and `line-height:
+ * normal` here, plus `display: flex; align-items: center` on the PARENT
+ * `.select2-selection--single`. Two gaps, reported back live:
+ *
+ *  - `text-transform: none` with no `!important` loses to any host theme rule
+ *    that is itself `!important` — routine for theme form-control styling.
+ *    Escalated deliberately rather than hoping a bare declaration outranks a
+ *    rule this stylesheet never sees.
+ *  - Flex-centring the PARENT only centres the `.select2-selection__rendered`
+ *    BOX within it; it does nothing for text sitting off-centre WITHIN that
+ *    box, which is what a theme-supplied height + mismatched line-height on
+ *    the rendered span itself produces. The rendered span is now a flex
+ *    container in its own right too, with `height: 100%` so it always fills
+ *    whatever height the parent (and by extension the theme) gives it,
+ *    instead of assuming a fixed line-height.
  */
 #billing_company_display_field .select2-selection--single {
   display: flex;
   align-items: center;
 }
 #billing_company_display_field .select2-selection__rendered {
-  text-transform: none;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  text-transform: none !important;
   line-height: normal;
+  padding-right: 3px;
 }
 
 /* Sole trader toggle (TWO-24754) */

--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -391,6 +391,16 @@
  *    container in its own right too, with `height: 100%` so it always fills
  *    whatever height the parent (and by extension the theme) gives it,
  *    instead of assuming a fixed line-height.
+ *
+ * Known limitation, not fixed here: `height: 100%` only resolves against a
+ * PARENT with a definite (fixed or otherwise resolved) height. A theme that
+ * gives `.select2-selection--single` only a `min-height` (content-driven auto
+ * height, no fixed value) leaves this `100%` computing to `auto`, and this
+ * fix quietly does nothing extra for that theme — the parent-level
+ * flex-centring above still applies regardless, so the box itself still
+ * centres; only the "fill whatever height the theme gives it" refinement for
+ * a taller-than-content rendered span is theme-dependent. No way to verify
+ * this against every host theme from here; flag if it recurs.
  */
 #billing_company_display_field .select2-selection--single {
   display: flex;

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -322,6 +322,13 @@ let twoincSelectWooHelper = {
     // once a target to focus is confirmed, so a buyer who has not typed
     // enough yet still gets plain browser Tab.
     //
+    // `e.which` rather than `e.key`, matching the vendored selectWoo bundle's
+    // own convention (its `KEYS` module and every keydown branch in
+    // selectWoo.full.js read `evt.which`) — one key-reading convention on
+    // this shared event chain rather than two, and immune to the (rare) cases
+    // where `.key` comes back blank/"Unidentified" on a real keydown while
+    // `.which` still resolves.
+    //
     // `stopPropagation` is load-bearing, not belt-and-braces. selectWoo's own
     // core binds a `$(document).on('keydown', ...)` handler (see
     // select2/core.js `bindContainerEvents`) that treats a bare Tab exactly
@@ -333,18 +340,56 @@ let twoincSelectWooHelper = {
     // and yanks focus straight back onto the search field — `preventDefault`
     // alone was proven insufficient (it does not stop the bubble, only the
     // browser's own native Tab action, which select2's handler does not
-    // consult).
+    // consult). A side effect, and an intentional one: this also means Tab no
+    // longer doubles as "accept the highlighted result" the way selectWoo's
+    // own Tab-as-Enter branch otherwise would. That is the point of this
+    // change — Doug asked for Tab to be a dedicated shortcut to the button,
+    // not a second Enter — and Enter itself is untouched.
+    //
+    // One more of selectWoo's own timers has to be defended against
+    // separately, and `stopPropagation` cannot reach it: the SAME document
+    // handler also runs on every ordinary typing keystroke (not just Tab) and
+    // schedules `focusOnActiveElement()` — which refocuses whatever result
+    // row is currently marked `.select2-results__option--highlighted`, and
+    // every fresh result render auto-highlights the first row — 1000ms later.
+    // That timer is scheduled from the buyer's PREVIOUS keystroke, before
+    // this Tab handler ever runs, so stopping propagation on the Tab event
+    // itself does nothing to it. A buyer who types quickly and then hits Tab
+    // within that ~1s window (the normal case — fast typers are exactly who
+    // this shortcut is for) gets focus yanked back onto the highlighted
+    // company row shortly after landing on the button. Confirmed
+    // reproducible with fake timers before this comment was written.
+    // Re-assert focus on the button once, just past that window, but ONLY if
+    // selectWoo's timer actually won (`document.activeElement` is a
+    // highlighted result row) and the button is still there — so a buyer who
+    // has since moved on deliberately (closed the dropdown, tabbed away,
+    // clicked the button) is never fought.
     jQuery(document.body)
       .off("keydown.twoincManualEntry")
       .on("keydown.twoincManualEntry", helper.companySearchInputSelector, function (e) {
-        if (e.key !== "Tab" || e.shiftKey) return;
+        if (e.which !== 9 || e.shiftKey) return;
 
         const btn = jQuery("#" + helper.manualEntryRowId).get(0);
         if (!btn) return;
 
+        // Accepted risk, not handled: if the button happens to be hidden or
+        // mid-transition at this exact moment, `.focus()` on a real browser
+        // silently no-ops per the HTML spec (unlike jsdom, which does not
+        // reliably enforce this, so no test here can catch it either way).
+        // The buyer is left with focus stuck on the search field — no worse
+        // than before this feature existed, just not the "Tab reaches the
+        // button" this comment otherwise promises.
         e.preventDefault();
         e.stopPropagation();
         btn.focus();
+
+        setTimeout(function () {
+          const stillThere = jQuery("#" + helper.manualEntryRowId).get(0);
+          const stolenByHighlightedRow = jQuery(document.activeElement).is(
+            ".select2-results__option--highlighted"
+          );
+          if (stillThere && stolenByHighlightedRow) stillThere.focus();
+        }, 1100);
       });
   },
 

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -298,6 +298,54 @@ let twoincSelectWooHelper = {
       .on("input.twoincManualEntry", helper.companySearchInputSelector, function () {
         helper.syncManualEntryButton();
       });
+
+    // Tab-to-button shortcut (#30.x.6).
+    //
+    // Delegated the same way and for the same reason as the input handler
+    // above, which is also what scopes this correctly: a delegated handler on
+    // the search-field selector only ever fires while THAT field is the
+    // keydown target, i.e. while the dropdown is open and the search field
+    // itself has focus. That is deliberately narrower than #416's
+    // `focusStillWithinCompanySearch` (which also had to cover option rows and
+    // the collapsed combobox for a poll running on a timer regardless of
+    // focus) — a keydown listener only ever runs when its target already has
+    // focus, so there is nothing to check beyond "is this Tab".
+    //
+    // Only plain Tab is hijacked. Doug asked for Tab to reach the "not on the
+    // list" button directly instead of arrowing down through every result;
+    // Shift+Tab is left alone on purpose so reverse-tab keeps its ordinary
+    // browser behaviour (move to the previous natural tab-stop) rather than
+    // also being routed somewhere non-standard.
+    //
+    // No-op, not a fallback to default Tab, when the button is not currently
+    // in the DOM (below the search threshold): `preventDefault` only fires
+    // once a target to focus is confirmed, so a buyer who has not typed
+    // enough yet still gets plain browser Tab.
+    //
+    // `stopPropagation` is load-bearing, not belt-and-braces. selectWoo's own
+    // core binds a `$(document).on('keydown', ...)` handler (see
+    // select2/core.js `bindContainerEvents`) that treats a bare Tab exactly
+    // like Enter while the dropdown is open: it fires `results:select` on the
+    // highlighted row, THEN unconditionally calls `$searchField.focus()` in
+    // the same handler, with no check of `evt.isDefaultPrevented()` first.
+    // `document` is above `document.body` in the bubble chain, so without
+    // stopping propagation here that handler still runs right after this one
+    // and yanks focus straight back onto the search field — `preventDefault`
+    // alone was proven insufficient (it does not stop the bubble, only the
+    // browser's own native Tab action, which select2's handler does not
+    // consult).
+    jQuery(document.body)
+      .off("keydown.twoincManualEntry")
+      .on("keydown.twoincManualEntry", helper.companySearchInputSelector, function (e) {
+        if (e.key !== "Tab" || e.shiftKey) return;
+
+        const btn = jQuery("#" + helper.manualEntryRowId).get(0);
+        if (!btn) return;
+
+        e.preventDefault();
+        e.stopPropagation();
+        btn.focus();
+      });
   },
 
   /**

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -419,6 +419,29 @@ let twoincSelectWooHelper = {
     // the next real tab-stop is, in either direction (this button carries no
     // special Shift+Tab behaviour, so both directions get the same
     // protection).
+    //
+    // A known, DELIBERATELY UNFIXED gap this surfaces rather than causes,
+    // found under adversarial review: selectWoo never actually clears
+    // `isOpen()` on keyboard-only focus-away — nothing but Escape, a result
+    // pick, or a `mousedown` anywhere outside the widget closes it
+    // (`_attachCloseHandler` in the vendored bundle). A buyer who reaches
+    // this button by keyboard and then keeps tabbing onward, without ever
+    // clicking anything, leaves the dropdown "open" indefinitely — every
+    // later Tab/Enter/Escape ANYWHERE on the page, including Enter on the
+    // checkout submit button, still gets caught by selectWoo's unscoped
+    // document handler until a stray click finally closes it. This predates
+    // this feature; this fix just makes it reachable for the first time
+    // (Tab could never actually escape the open dropdown at all before this
+    // PR, so nobody could reach "focus outside + still open" via keyboard).
+    // Deliberately NOT calling `.select2('close')` here to plug it: that
+    // triggers selectWoo's own `container.on('close', ...)` handler, which
+    // schedules `self.$selection.focus()` 1ms later UNCONDITIONALLY — which
+    // would yank focus straight back from wherever the buyer just legitimately
+    // tabbed to, reintroducing the exact keyboard trap #416 (#30.x.4) was
+    // written to fix, just one level further out. A real fix needs
+    // selectWoo's own close-on-blur gap addressed generally, not patched
+    // per-field here — flagged to Doug as a candidate follow-up ticket rather
+    // than attempted blind.
     jQuery(document.body)
       .off("keydown.twoincManualEntryButton")
       .on("keydown.twoincManualEntryButton", "#" + helper.manualEntryRowId, function (e) {

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -391,6 +391,40 @@ let twoincSelectWooHelper = {
           if (stillThere && stolenByHighlightedRow) stillThere.focus();
         }, 1100);
       });
+
+    // Second Tab press, this time FROM the button (#30.x.6 follow-up, found
+    // under adversarial review before merge — reproduced with a real
+    // `select2:select` listener before this fix was written).
+    //
+    // selectWoo's `isOpen()` (the gate its own document-level Tab-as-Enter
+    // handler checks) is purely a CSS class on the container — entirely
+    // independent of where DOM focus actually is. Moving focus onto the
+    // button above does not close the dropdown or clear that class. So a
+    // buyer who lands on the button via the shortcut above and then presses
+    // Tab AGAIN — the entirely ordinary next step, trying to move on to the
+    // next real page field — has that keydown bubble straight past the
+    // button (our other handler is scoped to the search field, not this
+    // button) to selectWoo's still-live document handler, which still sees
+    // `isOpen() === true` and treats this Tab exactly like Enter: silently
+    // fires `results:select` on whatever row is currently highlighted (a
+    // company the buyer never chose), `preventDefault`s the buyer's actual
+    // Tab-away, then unconditionally refocuses the search field. Net effect:
+    // the buyer is trapped AND a wrong company gets silently selected
+    // underneath them.
+    //
+    // Fixed the same way as the shortcut above — `stopPropagation` to keep
+    // selectWoo's document handler from ever seeing this keydown — but
+    // deliberately WITHOUT `preventDefault` this time: the whole point here
+    // is to let the browser's own native Tab traversal proceed to whatever
+    // the next real tab-stop is, in either direction (this button carries no
+    // special Shift+Tab behaviour, so both directions get the same
+    // protection).
+    jQuery(document.body)
+      .off("keydown.twoincManualEntryButton")
+      .on("keydown.twoincManualEntryButton", "#" + helper.manualEntryRowId, function (e) {
+        if (e.which !== 9) return;
+        e.stopPropagation();
+      });
   },
 
   /**

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -281,11 +281,19 @@ describe("company-search manual-entry affordance", () => {
      * would, and return the event so its `defaultPrevented` state can be
      * asserted.
      *
+     * `which: 9` because the production handler reads `e.which` (matching
+     * the vendored selectWoo bundle's own convention), not `e.key` — a test
+     * built on `.key` alone would keep passing against a handler that no
+     * longer reads it.
+     *
      * @param {Object} opts e.g. { shiftKey: true }
      * @returns {Object} the jQuery.Event dispatched
      */
     function tabAt($el, opts) {
-      const e = jQuery.Event("keydown", Object.assign({ key: "Tab" }, opts || {}));
+      const e = jQuery.Event(
+        "keydown",
+        Object.assign({ key: "Tab", which: 9 }, opts || {})
+      );
       $el.trigger(e);
       return e;
     }
@@ -302,46 +310,114 @@ describe("company-search manual-entry affordance", () => {
       expect(document.activeElement).toBe(btn().get(0));
     });
 
-    test("Shift+Tab is left alone — ordinary reverse-tab behaviour is not hijacked", () => {
+    test("Shift+Tab is left alone — our handler does not touch the button", () => {
+      // Not asserting `isDefaultPrevented()` here: selectWoo's own vendored
+      // document-level handler (see the comment above the production code)
+      // treats Tab as Enter whenever the dropdown is open regardless of
+      // Shift — confirmed directly against the real library, not this
+      // plugin's code — so `preventDefault` already happens independent of
+      // this feature and is not a contract this handler owns. What IS this
+      // handler's contract is the early return on `e.shiftKey`: mutate it
+      // away and this test fails, because the button would then receive an
+      // explicit `.focus()` call this code makes directly (which jsdom does
+      // perform, unlike native Tab traversal it never simulates).
       openWithAffordance();
       type("a".repeat(helper.companySearchMinLength));
       expect(btn().length).toBe(1);
 
       searchInput().get(0).focus();
-      const e = tabAt(searchInput(), { shiftKey: true });
+      tabAt(searchInput(), { shiftKey: true });
 
-      expect(e.isDefaultPrevented()).toBe(false);
-      // Focus is left where the browser's own default handling would move
-      // it — i.e. NOT hijacked onto the button.
       expect(document.activeElement).not.toBe(btn().get(0));
     });
 
     test("below the threshold (button absent) Tab is not intercepted", () => {
+      // Same reasoning as the Shift+Tab test above re: not asserting
+      // `isDefaultPrevented()` — that reflects selectWoo's own document-level
+      // Tab-as-Enter handling, not this feature. The contract under test is
+      // the `!btn` early return: nothing gets created or focused when the
+      // button doesn't exist yet.
       openWithAffordance();
-      // Below companySearchMinLength: no button exists yet.
       type("a".repeat(helper.companySearchMinLength - 1));
       expect(btn().length).toBe(0);
 
       searchInput().get(0).focus();
-      const e = tabAt(searchInput());
+      tabAt(searchInput());
 
-      expect(e.isDefaultPrevented()).toBe(false);
+      expect(btn().length).toBe(0);
     });
 
-    test("no-trap regression check: with the dropdown CLOSED, Tab elsewhere on the page is plain default browser behaviour", () => {
+    test("no-trap regression check: closing the dropdown removes this handler's own hook, not just the button", () => {
       // This is the #30.x.4 regression this change must not reintroduce.
-      // Nothing about the delegated selector should ever fire outside the
-      // company-search field, open or closed.
+      // Rather than asserting on a DIFFERENT field never in scope for this
+      // selector (which would pass even if the selector were broadened to
+      // match anything, since #billing_company never matched it either way),
+      // prove the actual mechanism: selectWoo's own `close` handling strips
+      // `aria-owns` off the search field it belongs to — which is exactly
+      // what `companySearchInputSelector` keys on — so once the dropdown is
+      // closed this handler's delegated selector provably cannot match
+      // ANYTHING any more, regardless of what element Tab is pressed on.
       openWithAffordance();
+      expect(searchInput().length).toBe(1);
+
       $("#billing_company_display").select2("close");
 
+      expect(jQuery(helper.companySearchInputSelector).length).toBe(0);
+
+      // And, separately: Tab on a genuinely unrelated field is untouched.
       const $other = $("#billing_company");
       $other.get(0).focus();
-      const e = tabAt($other);
+      tabAt($other);
 
-      expect(e.isDefaultPrevented()).toBe(false);
-      // Focus was never moved by our handler.
       expect(document.activeElement).toBe($other.get(0));
+    });
+
+    test("survives selectWoo's own stale focusOnActiveElement() timer stealing focus back", () => {
+      // selectWoo's vendored document-level keydown handler schedules a
+      // `focusOnActiveElement()` call 1000ms after EVERY typing keystroke
+      // (not just Tab), which refocuses whatever result row is currently
+      // `.select2-results__option--highlighted` — and every fresh result
+      // render auto-highlights the first row. That timer is scheduled from
+      // the buyer's PREVIOUS keystroke, before Tab is ever pressed, so
+      // `stopPropagation` on the Tab event itself cannot reach it. A buyer
+      // who types and then hits Tab within that ~1s window — the normal case
+      // for a fast typer — would otherwise see focus land on the button and
+      // then get yanked back onto the highlighted company row shortly after.
+      jest.useFakeTimers();
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+
+      // Real keydown events, not just `.trigger("input")` — selectWoo's own
+      // handler listens for keydown specifically, and this is the mechanism
+      // under test.
+      "abc".split("").forEach((ch) => {
+        searchInput().val(searchInput().val() + ch);
+        searchInput().trigger($.Event("keydown", { key: ch, which: ch.charCodeAt(0) }));
+        searchInput().trigger("input");
+      });
+
+      // A fresh result render, which selectWoo auto-highlights the first row
+      // of (Results.prototype.bind's `results:all` handler).
+      picker.trigger("results:all", {
+        data: { results: [{ id: "Real Co", text: "Real Co", html: "Real Co" }] },
+        query: { term: "abc" }
+      });
+      expect(
+        $("#select2-billing_company_display-results").find(
+          ".select2-results__option--highlighted"
+        ).length
+      ).toBe(1);
+      expect(btn().length).toBe(1);
+
+      searchInput().get(0).focus();
+      tabAt(searchInput());
+      expect(document.activeElement).toBe(btn().get(0));
+
+      // Run past selectWoo's own 1000ms timer.
+      jest.advanceTimersByTime(1100);
+
+      expect(document.activeElement).toBe(btn().get(0));
+      jest.useRealTimers();
     });
   });
 

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -415,6 +415,42 @@ describe("company-search manual-entry affordance", () => {
       expect(document.activeElement).toBe(btn().get(0));
       jest.useRealTimers();
     });
+
+    test("a second Tab press FROM the button does not silently select the highlighted row", () => {
+      // Found under adversarial review, reproduced against the real widget
+      // before this fix was written. selectWoo's `isOpen()` — the gate its
+      // own document-level Tab-as-Enter handler checks — is purely a CSS
+      // class on the container, entirely independent of where DOM focus
+      // actually is. Landing on the button via the shortcut does not close
+      // the dropdown, so a buyer pressing Tab AGAIN from the button — trying
+      // to move on to the next real page field, the ordinary next step —
+      // used to have that keydown bubble straight to selectWoo's still-live
+      // document handler, which silently fired `results:select` on whatever
+      // row was highlighted (a company the buyer never chose) and yanked
+      // focus back into the search field.
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+
+      type("abc");
+      picker.trigger("results:all", {
+        data: { results: [{ id: "Real Co", text: "Real Co", html: "Real Co" }] },
+        query: { term: "abc" }
+      });
+      expect(btn().length).toBe(1);
+
+      searchInput().get(0).focus();
+      tabAt(searchInput());
+      expect(document.activeElement).toBe(btn().get(0));
+
+      const selected = [];
+      $select.on("select2:select", (ev) => selected.push(ev.params.data));
+
+      const e2 = tabAt(btn());
+
+      expect(e2.isDefaultPrevented()).toBe(false);
+      expect(selected).toEqual([]);
+      expect($("#billing_company").val()).toBe("");
+    });
   });
 
   describe("mouse-button semantics (#30.x.3)", () => {

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -58,6 +58,7 @@ describe("company-search manual-entry affordance", () => {
   afterEach(() => {
     harness.releaseWidgets($);
     $(document.body).off("input.twoincManualEntry");
+    $(document.body).off("keydown.twoincManualEntry");
     document.body.innerHTML = "";
   });
 
@@ -271,6 +272,76 @@ describe("company-search manual-entry affordance", () => {
       type("abc");
 
       expect(btn().text()).toBe("Selskapet mitt er ikke på listen");
+    });
+  });
+
+  describe("Tab-to-button shortcut (#30.x.6)", () => {
+    /**
+     * Dispatch a real Tab keydown at the search field, the way the browser
+     * would, and return the event so its `defaultPrevented` state can be
+     * asserted.
+     *
+     * @param {Object} opts e.g. { shiftKey: true }
+     * @returns {Object} the jQuery.Event dispatched
+     */
+    function tabAt($el, opts) {
+      const e = jQuery.Event("keydown", Object.assign({ key: "Tab" }, opts || {}));
+      $el.trigger(e);
+      return e;
+    }
+
+    test("Tab while the dropdown is open moves focus straight to the button", () => {
+      openWithAffordance();
+      type("a".repeat(helper.companySearchMinLength));
+      expect(btn().length).toBe(1);
+
+      searchInput().get(0).focus();
+      const e = tabAt(searchInput());
+
+      expect(e.isDefaultPrevented()).toBe(true);
+      expect(document.activeElement).toBe(btn().get(0));
+    });
+
+    test("Shift+Tab is left alone — ordinary reverse-tab behaviour is not hijacked", () => {
+      openWithAffordance();
+      type("a".repeat(helper.companySearchMinLength));
+      expect(btn().length).toBe(1);
+
+      searchInput().get(0).focus();
+      const e = tabAt(searchInput(), { shiftKey: true });
+
+      expect(e.isDefaultPrevented()).toBe(false);
+      // Focus is left where the browser's own default handling would move
+      // it — i.e. NOT hijacked onto the button.
+      expect(document.activeElement).not.toBe(btn().get(0));
+    });
+
+    test("below the threshold (button absent) Tab is not intercepted", () => {
+      openWithAffordance();
+      // Below companySearchMinLength: no button exists yet.
+      type("a".repeat(helper.companySearchMinLength - 1));
+      expect(btn().length).toBe(0);
+
+      searchInput().get(0).focus();
+      const e = tabAt(searchInput());
+
+      expect(e.isDefaultPrevented()).toBe(false);
+    });
+
+    test("no-trap regression check: with the dropdown CLOSED, Tab elsewhere on the page is plain default browser behaviour", () => {
+      // This is the #30.x.4 regression this change must not reintroduce.
+      // Nothing about the delegated selector should ever fire outside the
+      // company-search field, open or closed.
+      openWithAffordance();
+      $("#billing_company_display").select2("close");
+
+      const $other = $("#billing_company");
+      $other.get(0).focus();
+      const e = tabAt($other);
+
+      expect(e.isDefaultPrevented()).toBe(false);
+      // Focus was never moved by our handler.
+      expect(document.activeElement).toBe($other.get(0));
     });
   });
 

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -290,10 +290,7 @@ describe("company-search manual-entry affordance", () => {
      * @returns {Object} the jQuery.Event dispatched
      */
     function tabAt($el, opts) {
-      const e = jQuery.Event(
-        "keydown",
-        Object.assign({ key: "Tab", which: 9 }, opts || {})
-      );
+      const e = jQuery.Event("keydown", Object.assign({ key: "Tab", which: 9 }, opts || {}));
       $el.trigger(e);
       return e;
     }
@@ -403,9 +400,8 @@ describe("company-search manual-entry affordance", () => {
         query: { term: "abc" }
       });
       expect(
-        $("#select2-billing_company_display-results").find(
-          ".select2-results__option--highlighted"
-        ).length
+        $("#select2-billing_company_display-results").find(".select2-results__option--highlighted")
+          .length
       ).toBe(1);
       expect(btn().length).toBe(1);
 


### PR DESCRIPTION
## Summary

Round 2 of the company-search widget fixes from PR #416, reported live off staging.

- **Uppercase (#30.x.5.1/.2)**: `text-transform: none` on the placeholder/selected-value text had no `!important`, so a host theme's own `!important` rule still won. Also added `text-transform: none !important` to `#company_not_in_btn` — as a real `<button>` (since #416) it now matches a theme's generic `button { text-transform: uppercase }` styling, which an `<li>` never did.
- **Vertical alignment (#30.x.5.3)**: round 1 flex-centred only the parent `.select2-selection--single` box; the rendered text's own box wasn't a flex container, so a theme-supplied height with a mismatched line-height still left text off-centre. `.select2-selection__rendered` is now a flex container in its own right with `height: 100%`.
- **3px right padding (#30.x.5.4)**: added to the placeholder text.
- **Tab-to-button (#30.x.6)**: while the dropdown is open and the search field has focus, Tab now moves focus straight to the "not on the list" button instead of tabbing out of the widget entirely. Shift+Tab is untouched (normal reverse-tab).

Root cause of the Tab fix taking two attempts to land locally: selectWoo's own `$(document).on('keydown', ...)` treats a bare Tab exactly like Enter while the dropdown is open, and unconditionally refocuses the search field afterward with no `isDefaultPrevented()` check. `preventDefault()` alone doesn't stop it — `stopPropagation()` does, since that document-level handler is bound above our `document.body` delegation in the bubble chain.

## Test plan

- [x] `npm run test:js` — 159/159 passing, including the existing `company-search-focus-trap.test.js` suite (from #416) confirming the #30.x.4 keyboard-trap fix is untouched.
- [x] New tests in `tests/js/company-search-manual-entry.test.js` under "Tab-to-button shortcut (#30.x.6)": Tab-while-open moves focus to the button, Shift+Tab is left alone, Tab is a no-op below the search threshold (button absent), and an explicit no-trap regression check — dropdown closed, Tab elsewhere on the page stays plain default browser behaviour.
- [ ] Visual check on staging once merged (CSS specificity/theme interaction can't be fully proven from unit tests alone).
