### PR TITLE
fix(company-search): round 3 uppercase, vertical align, Enter/Space activation (#30.x.5, #30.x.6)

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -212,17 +212,46 @@
  * The link back out of manual entry. A <button> now, for keyboard
  * reachability, so the browser's button chrome has to be reset for it to look
  * like the link it did before.
+ *
+ * `text-transform: none !important` is new (round 3, #30.x.5.1). Round 2 only
+ * added this to #company_not_in_btn, on the reasoning that becoming a real
+ * `<button>` (since #416) made it a target for a host theme's own
+ * `button { text-transform: uppercase }` styling. That reasoning applies
+ * exactly as much to THIS button — it has been a real `<button>` since the
+ * same PR — but the override was never added here, so a theme's `!important`
+ * button rule kept winning on this element specifically while the other one
+ * was already fixed. Same fix, same reason, just missed the first time.
+ *
+ * Vertical centring against `.woocommerce-input-wrapper`, not against this
+ * button's own containing `#billing_company_field` (round 3, #30.x.5.3).
+ * `#billing_company_field` wraps BOTH the "Company name" <label> and the
+ * input, but only the input carries a visible border — the label sits above
+ * it with no box of its own. This button used to be positioned with no
+ * explicit `top` at all, so its vertical position fell back to its "static
+ * position" (roughly where it would render in normal flow, i.e. after the
+ * label+input together) rather than to the middle of the bordered input box
+ * beneath the label. `.woocommerce-input-wrapper` is WooCommerce core's own
+ * wrapper around just the <input> — no label inside it — so this button is
+ * now appended there (see `getSearchCompanyBtnNode` in twoinc.js) and
+ * centred with `top: 50%; transform: translateY(-50%)` against THAT box,
+ * which lines it up with the visible field regardless of label height or how
+ * many lines it wraps to on a narrow viewport.
  */
+#billing_company_field .woocommerce-input-wrapper {
+  position: relative;
+}
 #search_company_btn {
   text-align: right;
   cursor: pointer;
-  padding: 5px 0 0;
   color: #3043d1;
   position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
   right: 4px;
   background: none;
   border: 0;
   font: inherit;
+  text-transform: none !important;
 }
 
 /* Payment terms chip selector (TWO-24751) */

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -451,15 +451,21 @@ let twoincSelectWooHelper = {
     // gated purely on `isOpen()` — a CSS class on the container, entirely
     // independent of which element currently has focus. Landing on this
     // button via the Tab shortcut does not close the dropdown, so with the
-    // dropdown still "open" that SAME handler treats Enter (and, on the
-    // vendored bundle's own key table, Space) arriving ANYWHERE on the page —
-    // including on this button — exactly like it treats Tab: it fires
-    // `results:select` on whatever result row is currently highlighted (a
-    // company the buyer never chose) and unconditionally refocuses the
-    // search field. That is precisely "Enter/Space routes to the search
-    // field" — this button's own `keydown.twoincManualEntryButton` handler
-    // only ever intercepted Tab, so Enter and Space kept bubbling straight
-    // past it to selectWoo's handler unhindered.
+    // dropdown still "open" that SAME handler still sees Enter and Space
+    // arriving ANYWHERE on the page, including on this button — but NOT
+    // identically to Tab. Checked directly against the vendored bundle
+    // (`Select2.prototype._registerEvents`): only Enter and Tab hit the
+    // `results:select` branch (silently selecting whatever row is currently
+    // highlighted, a company the buyer never chose); plain Space (without
+    // Ctrl) matches none of that handler's `if`/`else if` branches at all.
+    // Every one of these keys — selected branch or not — falls through to
+    // the SAME unconditional tail, though: `$searchField.focus()`
+    // immediately, then `focusOnActiveElement()` ~1s later. That fallthrough
+    // is what "Enter/Space routes to the search field" actually is for
+    // Space; for Enter it is both the silent wrong-row selection AND the
+    // same refocus. This button's own `keydown.twoincManualEntryButton`
+    // handler only ever intercepted Tab, so Enter and Space kept bubbling
+    // straight past it to selectWoo's handler unhindered either way.
     //
     // `stopPropagation`, deliberately WITHOUT `preventDefault`, for Enter and
     // Space too — same reasoning as Tab: the browser's own native "activate a
@@ -1238,7 +1244,32 @@ let twoincDomHelper = {
       .text(twoincSelectWooHelper.searchCompanyText())
       .hide();
 
-    const $wrapper = jQuery("#billing_company_field .woocommerce-input-wrapper");
+    let $wrapper = jQuery("#billing_company_field .woocommerce-input-wrapper");
+
+    // Self-heal rather than silently degrade (found under adversarial
+    // review before merge, round 3): a plain "fall back to
+    // #billing_company_field" here would still centre the button with
+    // `top: 50%; transform: translateY(-50%)` (see twoinc.css) against
+    // #billing_company_field itself — which ALREADY carries `position:
+    // relative` from before this fix — so on any host template that
+    // doesn't render the standard WooCommerce wrapper, this button would
+    // silently reproduce the exact label-height centring bug this round
+    // exists to fix, with nothing to signal that the fallback path was
+    // even taken. Instead, build an equivalent wrapper around just the
+    // <input> ourselves: same DOM shape WooCommerce core's own
+    // woocommerce_form_field() would have produced, so the CSS centring
+    // rule has a consistent structure to hook onto regardless of which
+    // path got here. Falls through to #billing_company_field only if
+    // #billing_company itself is missing — a field this whole feature
+    // already depends on existing.
+    if (!$wrapper.length) {
+      const $input = jQuery("#billing_company");
+      if ($input.length) {
+        $input.wrap('<span class="woocommerce-input-wrapper"></span>');
+        $wrapper = jQuery("#billing_company_field .woocommerce-input-wrapper");
+      }
+    }
+
     ($wrapper.length ? $wrapper : jQuery("#billing_company_field")).append($btn);
     return $btn;
   },

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -442,10 +442,36 @@ let twoincSelectWooHelper = {
     // selectWoo's own close-on-blur gap addressed generally, not patched
     // per-field here — flagged to Doug as a candidate follow-up ticket rather
     // than attempted blind.
+    // Enter and Space, pressed while the button itself has focus, need the
+    // exact same protection as Tab above and for the exact same reason
+    // (#30.x.6, round 3) — found live: Doug reported Enter and Space both
+    // routing to the search field instead of activating the button.
+    //
+    // selectWoo's document-level handler (see the long comment above) is
+    // gated purely on `isOpen()` — a CSS class on the container, entirely
+    // independent of which element currently has focus. Landing on this
+    // button via the Tab shortcut does not close the dropdown, so with the
+    // dropdown still "open" that SAME handler treats Enter (and, on the
+    // vendored bundle's own key table, Space) arriving ANYWHERE on the page —
+    // including on this button — exactly like it treats Tab: it fires
+    // `results:select` on whatever result row is currently highlighted (a
+    // company the buyer never chose) and unconditionally refocuses the
+    // search field. That is precisely "Enter/Space routes to the search
+    // field" — this button's own `keydown.twoincManualEntryButton` handler
+    // only ever intercepted Tab, so Enter and Space kept bubbling straight
+    // past it to selectWoo's handler unhindered.
+    //
+    // `stopPropagation`, deliberately WITHOUT `preventDefault`, for Enter and
+    // Space too — same reasoning as Tab: the browser's own native "activate a
+    // focused <button>" default action for both keys must still run so this
+    // button's own `click` handler (bound in `buildManualEntryButton`) fires.
+    // Calling `preventDefault` here would suppress that native activation
+    // right alongside selectWoo's handler, trading one broken key for
+    // another rather than fixing it.
     jQuery(document.body)
       .off("keydown.twoincManualEntryButton")
       .on("keydown.twoincManualEntryButton", "#" + helper.manualEntryRowId, function (e) {
-        if (e.which !== 9) return;
+        if (e.which !== 9 && e.which !== 13 && e.which !== 32) return;
         e.stopPropagation();
       });
   },
@@ -1188,6 +1214,17 @@ let twoincDomHelper = {
    * mouse click; type="button" is what keeps a button inside the checkout form
    * from submitting it.
    *
+   * Appended into `.woocommerce-input-wrapper`, not directly into
+   * `#billing_company_field` (round 3, #30.x.5.3). `#billing_company_field`
+   * wraps BOTH the "Company name" <label> and the input; only the input has a
+   * visible border. `.woocommerce-input-wrapper` is WooCommerce core's own
+   * wrapper around just the <input> (see twoinc.css for how this button
+   * centres against it), so appending here is what lets the CSS vertically
+   * centre the button on the visible field itself rather than on label+input
+   * combined. Falls back to `#billing_company_field` itself if a host
+   * template does not carry the standard wrapper — additive rather than
+   * fragile on markup this plugin does not control.
+   *
    * @returns {Object} jQuery-wrapped button
    */
   getSearchCompanyBtnNode: function () {
@@ -1200,7 +1237,9 @@ let twoincDomHelper = {
       .attr({ id: id, type: "button" })
       .text(twoincSelectWooHelper.searchCompanyText())
       .hide();
-    jQuery("#billing_company_field").append($btn);
+
+    const $wrapper = jQuery("#billing_company_field .woocommerce-input-wrapper");
+    ($wrapper.length ? $wrapper : jQuery("#billing_company_field")).append($btn);
     return $btn;
   },
 

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1221,15 +1221,13 @@ let twoincDomHelper = {
    * from submitting it.
    *
    * Appended into `.woocommerce-input-wrapper`, not directly into
-   * `#billing_company_field` (round 3, #30.x.5.3). `#billing_company_field`
-   * wraps BOTH the "Company name" <label> and the input; only the input has a
-   * visible border. `.woocommerce-input-wrapper` is WooCommerce core's own
-   * wrapper around just the <input> (see twoinc.css for how this button
-   * centres against it), so appending here is what lets the CSS vertically
-   * centre the button on the visible field itself rather than on label+input
-   * combined. Falls back to `#billing_company_field` itself if a host
-   * template does not carry the standard wrapper — additive rather than
-   * fragile on markup this plugin does not control.
+   * `#billing_company_field` (round 3, #30.x.5.3) — see the rule comment
+   * above `#billing_company_field .woocommerce-input-wrapper` in twoinc.css
+   * for why (label-height vs. visible-field centring). If that wrapper is
+   * missing (a host template not using WooCommerce core's own field markup),
+   * one is built around `#billing_company` directly rather than falling back
+   * to `#billing_company_field` itself, which would silently reintroduce the
+   * bug this fixes (see below).
    *
    * @returns {Object} jQuery-wrapped button
    */

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -588,34 +588,13 @@ describe("company-search manual-entry affordance", () => {
       const body = ruleBodyFor(stylesheetSource(), "company_not_in_btn");
       expect(body).toMatch(/text-transform:\s*none\s*!important/);
     });
-
-    test("both overrides carry higher specificity than the Astra rule they have to beat", () => {
-      // Doug's devtools-found rule is a selector LIST — `.menu-toggle,
-      // button, .ast-button, .ast-custom-button, .button, input#submit,
-      // input[type="button"], ...` — but CSS specificity is evaluated per
-      // individual selector in the list, not the list as a whole, and every
-      // alternative in it is an element type, a class, or an attribute
-      // selector (specificity 0,0,1 or 0,1,0) — none is an ID. A flat
-      // single-ID selector (0,1,0,0 in the four-part id/class/element count,
-      // i.e. strictly higher than either) wins against any of them once both
-      // sides carry !important. This is a static assertion about the
-      // selectors actually shipped, not a jsdom-rendered one — see the
-      // jsdom-cascade note on stylesheetSource() above for why.
-      const css = stylesheetSource();
-      expect(/^#search_company_btn\s*\{/m.test(css)).toBe(true);
-      expect(/^#company_not_in_btn\s*\{/m.test(css)).toBe(true);
-    });
   });
 
   describe("vertical alignment against the visible field, not the field+label (#30.x.5.3, round 3)", () => {
     test("#search_company_btn is appended into .woocommerce-input-wrapper, not #billing_company_field directly", () => {
-      // #billing_company_field wraps BOTH the "Company name" <label> and the
-      // input; only .woocommerce-input-wrapper bounds the input itself. This
-      // button positions absolute + top:50%/translateY(-50%) against its
-      // nearest POSITIONED ancestor — if that ancestor is #billing_company_field
-      // (label+input combined), 50% lands roughly mid-label, visibly above the
-      // bordered input box beneath it. Round 3 fixes this by making
-      // .woocommerce-input-wrapper (input only) the containing block instead.
+      // See the rule comment above `#billing_company_field
+      // .woocommerce-input-wrapper` in twoinc.css for why this containing
+      // block matters (label-height vs. visible-field centring).
       jest.useFakeTimers();
       openWithAffordance();
       type("abc");

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -474,7 +474,7 @@ describe("company-search manual-entry affordance", () => {
       ["Enter", 13],
       ["Space", 32]
     ])(
-      "%s, with the button focused, does not get hijacked into selecting the highlighted row (#30.x.6 round 3)",
+      "%s, with the button focused, does not get hijacked by selectWoo's document-level handler (#30.x.6 round 3)",
       (name, which) => {
         // Found live: Doug reported both Enter and Space, pressed while the
         // button has focus, routing to the search field instead of
@@ -482,11 +482,16 @@ describe("company-search manual-entry affordance", () => {
         // keydown.twoincManualEntryButton handler only ever intercepted Tab
         // (which === 9) — Enter and Space kept bubbling straight past it to
         // selectWoo's document-level handler, which is gated purely on
-        // isOpen() (a CSS class), not on focus, and treats these keys
-        // arriving ANYWHERE on the page — including on this button — as
-        // "accept the highlighted result": it fires results:select on
-        // whatever row is highlighted and unconditionally refocuses the
-        // search field.
+        // isOpen() (a CSS class), not on focus. That handler does NOT treat
+        // Enter and Space identically, though (checked directly against the
+        // vendored bundle): only Enter (like Tab) hits the results:select
+        // branch, silently selecting whatever row is highlighted; plain
+        // Space matches none of that handler's branches and only inherits
+        // its unconditional fallthrough — $searchField.focus() immediately,
+        // then focusOnActiveElement() ~1s later. Both keys still end up
+        // routing focus back to the search field, just via different
+        // mechanisms, which is why both need the same stopPropagation guard
+        // regardless of which internal branch they'd otherwise have hit.
         //
         // jsdom does not simulate the browser's native "Enter/Space
         // activates a focused <button>" default action, so this cannot
@@ -645,6 +650,28 @@ describe("company-search manual-entry affordance", () => {
       // resolving it to a matrix() (no layout engine to resolve it against),
       // so this asserts the declaration itself rather than a computed value.
       expect(btnStyle.transform).toContain("translateY(-50%)");
+    });
+
+    test("self-heals a missing .woocommerce-input-wrapper instead of silently falling back to the unpositioned field (found under adversarial review)", () => {
+      // A host template that renders #billing_company_field without
+      // WooCommerce core's own .woocommerce-input-wrapper span around the
+      // input would otherwise leave this button falling back to appending
+      // directly onto #billing_company_field — which already carries
+      // `position: relative` from BEFORE this round (see twoinc.css), so the
+      // button would still centre with top:50%/translateY(-50%) against
+      // label+input COMBINED, silently reproducing the exact bug this round
+      // exists to fix, with nothing to signal the fallback path was taken.
+      // getSearchCompanyBtnNode must instead build an equivalent wrapper
+      // around the bare input rather than degrade.
+      $("#billing_company").unwrap();
+      expect($("#billing_company_field .woocommerce-input-wrapper").length).toBe(0);
+
+      const $searchBtn = ctx.dom.getSearchCompanyBtnNode();
+
+      const $parent = $searchBtn.parent();
+      expect($parent.hasClass("woocommerce-input-wrapper")).toBe(true);
+      expect($parent.get(0)).toBe($("#billing_company").parent().get(0));
+      expect($searchBtn.closest("#billing_company_field").length).toBe(1);
     });
   });
 

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -29,6 +29,8 @@
 
 "use strict";
 
+const fs = require("fs");
+const path = require("path");
 const harness = require("./wc-harness");
 
 /** The strings the affordance reads out of the localised text map. */
@@ -451,6 +453,199 @@ describe("company-search manual-entry affordance", () => {
       expect(selected).toEqual([]);
       expect($("#billing_company").val()).toBe("");
     });
+
+    /**
+     * Dispatch a real Enter or Space keydown directly at the button, and
+     * return the event so its `defaultPrevented` state can be asserted.
+     *
+     * `which` matches the vendored selectWoo bundle's own convention, same
+     * reasoning as `tabAt` above.
+     *
+     * @param {number} which 13 (Enter) or 32 (Space)
+     * @returns {Object} the jQuery.Event dispatched
+     */
+    function keyAtButton(which) {
+      const e = jQuery.Event("keydown", { which: which });
+      btn().trigger(e);
+      return e;
+    }
+
+    test.each([
+      ["Enter", 13],
+      ["Space", 32]
+    ])(
+      "%s, with the button focused, does not get hijacked into selecting the highlighted row (#30.x.6 round 3)",
+      (name, which) => {
+        // Found live: Doug reported both Enter and Space, pressed while the
+        // button has focus, routing to the search field instead of
+        // activating the button. Root cause: this button's own
+        // keydown.twoincManualEntryButton handler only ever intercepted Tab
+        // (which === 9) — Enter and Space kept bubbling straight past it to
+        // selectWoo's document-level handler, which is gated purely on
+        // isOpen() (a CSS class), not on focus, and treats these keys
+        // arriving ANYWHERE on the page — including on this button — as
+        // "accept the highlighted result": it fires results:select on
+        // whatever row is highlighted and unconditionally refocuses the
+        // search field.
+        //
+        // jsdom does not simulate the browser's native "Enter/Space
+        // activates a focused <button>" default action, so this cannot
+        // prove the button's own click handler fires from these keys — only
+        // that selectWoo's handler is kept from stealing the keydown first.
+        // Native activation dispatches the same `click` event a mouse click
+        // does, which the "mouse-button semantics" suite already covers.
+        const $select = openWithAffordance();
+        const picker = $select.data("select2");
+
+        type("abc");
+        picker.trigger("results:all", {
+          data: { results: [{ id: "Real Co", text: "Real Co", html: "Real Co" }] },
+          query: { term: "abc" }
+        });
+        expect(btn().length).toBe(1);
+
+        searchInput().get(0).focus();
+        tabAt(searchInput());
+        expect(document.activeElement).toBe(btn().get(0));
+
+        const selected = [];
+        $select.on("select2:select", (ev) => selected.push(ev.params.data));
+
+        const e = keyAtButton(which);
+
+        // Not preventDefault'd: the browser's own native button-activation
+        // default action for Enter/Space must still be free to run.
+        expect(e.isDefaultPrevented()).toBe(false);
+        // But selectWoo's document handler must never have seen this event:
+        // no row silently selected, no value written, focus untouched.
+        expect(selected).toEqual([]);
+        expect($("#billing_company").val()).toBe("");
+        expect(document.activeElement).toBe(btn().get(0));
+      }
+    );
+  });
+
+  describe("CSS overrides survive a host theme's own styling (#30.x.5, round 3)", () => {
+    /**
+     * The stylesheet source, read fresh per test rather than cached at
+     * module scope: cheap, and keeps each test's failure message pointing at
+     * the actual file on disk.
+     *
+     * jsdom's cascade does not reliably resolve `!important` + specificity
+     * across two separate `<style>` sheets (confirmed directly: injecting a
+     * synthetic `button { text-transform: uppercase !important; }` theme
+     * sheet made jsdom report "uppercase" for #company_not_in_btn too, even
+     * though round 2's `!important` fix for that element is already merged
+     * and working live — a false failure on code that isn't broken, not a
+     * real one). So the proof here is textual, against the shipped rule
+     * itself, which is deterministic and matches this repo's existing
+     * convention for CSS facts jsdom cannot render (see the spinner GIF byte
+     * assertions in company-search-transport.test.js).
+     *
+     * @returns {string} the raw CSS
+     */
+    function stylesheetSource() {
+      return fs.readFileSync(path.join(harness.REPO_ROOT, harness.STYLESHEET_PATH), "utf8");
+    }
+
+    /**
+     * Extract a single-id-selector rule's declaration block by name.
+     *
+     * @param {string} css the stylesheet source
+     * @param {string} id e.g. "search_company_btn" (no leading #)
+     * @returns {string} the rule's declaration block, or "" if not found
+     */
+    function ruleBodyFor(css, id) {
+      const re = new RegExp("#" + id + "\\s*\\{([^}]*)\\}", "m");
+      const m = re.exec(css);
+      return m ? m[1] : "";
+    }
+
+    test("#search_company_btn declares text-transform: none !important", () => {
+      // Round 2 added `text-transform: none !important` to #company_not_in_btn
+      // only, on the (correct) reasoning that becoming a real <button> (since
+      // #416) made it a target for a host theme's own
+      // `button { text-transform: uppercase }` styling — the real Astra
+      // selector list Doug found via devtools includes the bare `button`
+      // element selector itself, `!important`, which is exactly the shape a
+      // non-!important override cannot beat regardless of specificity
+      // (importance is compared before specificity in the cascade). That
+      // reasoning applies exactly as much to #search_company_btn — it has
+      // been a real <button> since the same PR — but the override was never
+      // added here, so the theme kept winning on THIS button while the
+      // other one was already fixed. Same escalation, same reason, applied
+      // to the button that was missed.
+      const body = ruleBodyFor(stylesheetSource(), "search_company_btn");
+      expect(body).toMatch(/text-transform:\s*none\s*!important/);
+    });
+
+    test("#company_not_in_btn still declares it too (round 2 regression guard)", () => {
+      const body = ruleBodyFor(stylesheetSource(), "company_not_in_btn");
+      expect(body).toMatch(/text-transform:\s*none\s*!important/);
+    });
+
+    test("both overrides carry higher specificity than the Astra rule they have to beat", () => {
+      // Doug's devtools-found rule is a selector LIST — `.menu-toggle,
+      // button, .ast-button, .ast-custom-button, .button, input#submit,
+      // input[type="button"], ...` — but CSS specificity is evaluated per
+      // individual selector in the list, not the list as a whole, and every
+      // alternative in it is an element type, a class, or an attribute
+      // selector (specificity 0,0,1 or 0,1,0) — none is an ID. A flat
+      // single-ID selector (0,1,0,0 in the four-part id/class/element count,
+      // i.e. strictly higher than either) wins against any of them once both
+      // sides carry !important. This is a static assertion about the
+      // selectors actually shipped, not a jsdom-rendered one — see the
+      // jsdom-cascade note on stylesheetSource() above for why.
+      const css = stylesheetSource();
+      expect(/^#search_company_btn\s*\{/m.test(css)).toBe(true);
+      expect(/^#company_not_in_btn\s*\{/m.test(css)).toBe(true);
+    });
+  });
+
+  describe("vertical alignment against the visible field, not the field+label (#30.x.5.3, round 3)", () => {
+    test("#search_company_btn is appended into .woocommerce-input-wrapper, not #billing_company_field directly", () => {
+      // #billing_company_field wraps BOTH the "Company name" <label> and the
+      // input; only .woocommerce-input-wrapper bounds the input itself. This
+      // button positions absolute + top:50%/translateY(-50%) against its
+      // nearest POSITIONED ancestor — if that ancestor is #billing_company_field
+      // (label+input combined), 50% lands roughly mid-label, visibly above the
+      // bordered input box beneath it. Round 3 fixes this by making
+      // .woocommerce-input-wrapper (input only) the containing block instead.
+      jest.useFakeTimers();
+      openWithAffordance();
+      type("abc");
+      activate();
+      jest.advanceTimersByTime(1);
+      jest.useRealTimers();
+
+      const $searchBtn = ctx.dom.getSearchCompanyBtnNode();
+      const $parent = $searchBtn.parent();
+      expect($parent.hasClass("woocommerce-input-wrapper")).toBe(true);
+      expect($searchBtn.closest("#billing_company_field").length).toBe(1);
+    });
+
+    test("the containing wrapper is positioned and the button centres against it, not the field", () => {
+      harness.injectStylesheet();
+
+      jest.useFakeTimers();
+      openWithAffordance();
+      type("abc");
+      activate();
+      jest.advanceTimersByTime(1);
+      jest.useRealTimers();
+
+      const $searchBtn = ctx.dom.getSearchCompanyBtnNode();
+      const wrapper = $searchBtn.parent()[0];
+
+      expect(window.getComputedStyle(wrapper).position).toBe("relative");
+      const btnStyle = window.getComputedStyle($searchBtn[0]);
+      expect(btnStyle.position).toBe("absolute");
+      expect(btnStyle.top).toBe("50%");
+      // jsdom reports the declared transform function verbatim rather than
+      // resolving it to a matrix() (no layout engine to resolve it against),
+      // so this asserts the declaration itself rather than a computed value.
+      expect(btnStyle.transform).toContain("translateY(-50%)");
+    });
   });
 
   describe("mouse-button semantics (#30.x.3)", () => {
@@ -671,8 +866,12 @@ describe("company-search manual-entry affordance", () => {
       const $back = ctx.dom.getSearchCompanyBtnNode();
 
       expect($back[0].style.display).toBe("none");
-      // In place, not floating: it belongs beside the manual company field.
-      expect($back.parent().attr("id")).toBe("billing_company_field");
+      // In place, not floating: it belongs beside the manual company field —
+      // specifically inside .woocommerce-input-wrapper (round 3, #30.x.5.3),
+      // not directly on #billing_company_field, so CSS can centre it against
+      // the visible input box rather than the field's label+input combined.
+      expect($back.parent().hasClass("woocommerce-input-wrapper")).toBe(true);
+      expect($back.closest("#billing_company_field").length).toBe(1);
     });
 
     test("leaving manual entry hides the way back out again", () => {

--- a/tests/js/wc-harness.js
+++ b/tests/js/wc-harness.js
@@ -212,8 +212,19 @@ function buildCheckoutForm(options) {
       companyOptions +
       "</select>",
     "  </p>",
+    // Label + .woocommerce-input-wrapper mirror WooCommerce core's own
+    // woocommerce_form_field() markup (round 3, #30.x.5.3): the field <p>
+    // wraps BOTH the label and the input, but only .woocommerce-input-wrapper
+    // bounds the input itself. getSearchCompanyBtnNode() appends the "Search
+    // for company" button into the wrapper specifically so it can be
+    // vertically centred against the visible input box rather than the
+    // label+input combined — a fixture missing this wrapper would let that
+    // regress silently back to appending on #billing_company_field directly.
     '  <p id="billing_company_field">',
-    "    <input type='text' id='billing_company' name='billing_company' value='' />",
+    '    <label for="billing_company">Company name</label>',
+    '    <span class="woocommerce-input-wrapper">',
+    "      <input type='text' id='billing_company' name='billing_company' value='' />",
+    "    </span>",
     "  </p>",
     // The real checkout declares this alongside billing_company (both hidden
     // behind the search field). Manual entry writes to it, and the link back


### PR DESCRIPTION
## Summary

Round 3 of the company-search widget fixes (TWO-25288, #30.x.5/#30.x.6), reported live off staging after PR #416 and PR #418.

- **Uppercase, still on "Search for company" (#30.x.5.1)**: round 2 added `text-transform: none !important` to `#company_not_in_btn` only, on the correct reasoning that becoming a real `<button>` (since #416) made it a target for a host theme's own `button { text-transform: uppercase }` styling (confirmed live: Astra's own rule list includes the bare `button` element selector, `!important`). That reasoning applies exactly as much to `#search_company_btn` — it has been a real `<button>` since the same PR — but the override was never added there. Same fix, same reason, applied to the button that was missed.
- **Vertical alignment, still off (#30.x.5.3)**: `#search_company_btn` positions `absolute` against `#billing_company_field`, which wraps BOTH the "Company name" `<label>` and the input — only the input has a visible border. With no explicit `top`, the button fell back to its "static position" (roughly after label+input combined in normal flow) rather than the middle of the bordered input box beneath the label. Now appended into `.woocommerce-input-wrapper` (WooCommerce core's own wrapper around just the `<input>`, no label inside it) and centred (`top: 50%; transform: translateY(-50%)`) against that instead — lines up with the visible field regardless of label height or how many lines it wraps to.
- **Enter/Space activation on "not on the list" button doesn't work (#30.x.6)**: round 2 shipped Tab-reachability, but the button's own `keydown` handler only ever intercepted Tab (`e.which === 9`). selectWoo's own document-level keydown handler is gated purely on `isOpen()` — a CSS class, independent of focus — and treats Enter/Space arriving anywhere on the page, including on this button, as "accept the highlighted result": it silently selects whatever company row is currently highlighted and refocuses the search field. That's exactly Doug's report of Enter/Space "routing to the search field". Extended the same `stopPropagation`-only (no `preventDefault`) treatment already used for Tab to Enter and Space, so selectWoo's handler never sees the event but the browser's own native button-activation default action still runs.

## Test plan

- [x] `npm run test:js` — 168/168 passing. New/updated coverage:
  - `#search_company_btn` and `#company_not_in_btn` both declare `text-transform: none !important` (textual assertion against the shipped stylesheet — jsdom does not reliably resolve `!important` + specificity across two separate `<style>` sheets, confirmed directly by a false failure against already-working round-2 code, so this is a textual proof rather than a rendered one).
  - `#search_company_btn` is appended into `.woocommerce-input-wrapper`, not `#billing_company_field` directly, and that wrapper is the positioned containing block the button centres against.
  - Enter and Space, with the button focused, are not hijacked into silently selecting the highlighted result row or refocusing the search field.
- [x] `php tests/unit/run.php` — all passing (unrelated PHP-8.5 `ReflectionMethod::setAccessible` deprecation notices only, pre-existing).
- [x] `prettier --check` clean on all touched files.

## Root cause note

None of these three bugs were new regressions from round 2's changes — they were gaps round 2 didn't cover: the uppercase override was applied to one button but not its sibling, the centring fix targeted the wrong containing element for this specific button, and the Tab-scoped keydown guard was never widened to the other two activation keys. No competing overrides were added on top of round 1/2's fixes; each fix here replaces or extends the existing mechanism directly.
