### PR TITLE
fix(checkout): stop billing field reorder, move optionals to the bottom

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -888,7 +888,15 @@ let twoincDomHelper = {
   },
 
   /**
-   * Move the fields to their original or Twoinc template location
+   * Move the fields to their original or Twoinc template location.
+   *
+   * Phone and email used to be pulled up here too (into the pre-billing
+   * "representative" wrapper, alongside first/last name), so a buyer would
+   * see one field order on first paint and a different one ~1s later once
+   * this fired. That grouping's own visual cue (an h3 heading) was commented
+   * out back in 2021 and never replaced with CSS, so nothing distinguishes
+   * the wrapper today — it was pure reorder with no remaining display
+   * purpose. Phone/email now stay in their native WC position (#33).
    */
   positionFields: function () {
     setTimeout(function () {
@@ -896,13 +904,9 @@ let twoincDomHelper = {
       if (twoincDomHelper.isTwoincSelected()) {
         twoincDomHelper.moveField("billing_first_name_field", "fn");
         twoincDomHelper.moveField("billing_last_name_field", "ln");
-        twoincDomHelper.moveField("billing_phone_field", "ph");
-        twoincDomHelper.moveField("billing_email_field", "em");
       } else {
         twoincDomHelper.revertField("billing_first_name_field", "fn");
         twoincDomHelper.revertField("billing_last_name_field", "ln");
-        twoincDomHelper.revertField("billing_phone_field", "ph");
-        twoincDomHelper.revertField("billing_email_field", "em");
       }
 
       twoincDomHelper.toggleTooltip(

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -67,8 +67,10 @@ if (!class_exists('WC_Twoinc_Checkout')) {
             // Change the priority for the country field. billing_company may
             // be absent (e.g. WooCommerce's own "Company name" field toggle
             // disabled) — fall back to core's default priority (30) rather
-            // than warning on an undefined array key.
-            $company_priority = $fields['billing']['billing_company']['priority'] ?? 30;
+            // than warning on an undefined array key. Clamped below 190: see
+            // the matching clamp in update_company_fields() — country must
+            // never be pushed at/above the optional-fields baseline (200).
+            $company_priority = min($fields['billing']['billing_company']['priority'] ?? 30, 190);
             $fields['billing']['billing_country']['priority'] = $company_priority - 1;
 
             // Return the fields list
@@ -87,7 +89,14 @@ if (!class_exists('WC_Twoinc_Checkout')) {
         {
 
             // billing_company may be absent (see move_country_field above).
-            $company_name_priority = $fields['billing']['billing_company']['priority'] ?? 30;
+            // Clamped below the optional-fields baseline (200, below) so
+            // company/company_id can never invert above invoice_email/PO/
+            // project/department if a future brand overlay ever pushes
+            // billing_company's own priority unusually high (#33 review —
+            // Vader: this used to be a non-issue because the optionals rode
+            // company's own priority; now they're fixed, so company's own
+            // priority needs its own ceiling).
+            $company_name_priority = min($fields['billing']['billing_company']['priority'] ?? 30, 190);
 
             if ($this->wc_twoinc->get_enable_company_search() === 'yes') {
                 $fields['billing']['billing_company_display'] = [

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -129,6 +129,15 @@ if (!class_exists('WC_Twoinc_Checkout')) {
             // invoice email, purchase order number, project, department. The order
             // note is WooCommerce core's own `order_comments` and stays where core
             // puts it (the "Additional information" block, after billing). TWO-25263.
+            //
+            // These sit BELOW every native address/contact field (city/postcode
+            // 70-90, phone 100, email 110 — see WC_Countries default priorities)
+            // rather than riding on company's priority, so they land at the very
+            // bottom of the form regardless of whether company search/company
+            // name is on, off, or absent (#33 — Doug: optionals belong below
+            // town/city, not interleaved near the top).
+            $optional_field_priority = 200;
+
             if ($this->wc_twoinc->get_option('add_field_invoice_email') === 'yes') {
                 $fields['billing']['invoice_email'] = [
                     'label'       => __('Invoice email address', 'twoinc-payment-gateway'),
@@ -136,7 +145,7 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                     'type'        => 'email',
                     'validate'    => array('email'),
                     'required'    => false,
-                    'priority'    => $company_name_priority + 2
+                    'priority'    => $optional_field_priority + 1
                 ];
             }
 
@@ -145,7 +154,7 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                     'label' => __('PO Number', 'twoinc-payment-gateway'),
                     'class' => array('hidden'),
                     'required' => false,
-                    'priority' => $company_name_priority + 3
+                    'priority' => $optional_field_priority + 2
                 ];
             }
 
@@ -154,7 +163,7 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                     'label' => __('Project', 'twoinc-payment-gateway'),
                     'class' => array('hidden'),
                     'required' => false,
-                    'priority' => $company_name_priority + 4
+                    'priority' => $optional_field_priority + 3
                 ];
             }
 
@@ -163,7 +172,7 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                     'label' => __('Department', 'twoinc-payment-gateway'),
                     'class' => array('hidden'),
                     'required' => false,
-                    'priority' => $company_name_priority + 5
+                    'priority' => $optional_field_priority + 4
                 ];
             }
 

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -34,6 +34,7 @@ final class BrandConfigSpec
             'testCheckoutFieldsHookFires',
             'testInvoiceEmailFieldHasNoPlaceholder',
             'testFieldPrioritiesMatchDesiredCheckoutOrder',
+            'testCompanyPriorityClampPreventsInversionAboveOptionals',
             'testConfirmationUrlHookReceivesUrlAndOrderId',
             'testOrderPayloadHookAugmentsBody',
             'testPaymentTermsLineHookAdjustsLineItems',
@@ -459,6 +460,50 @@ final class BrandConfigSpec
         TinyAssert::true($p('invoice_email') < $p('purchase_order_number'));
         TinyAssert::true($p('purchase_order_number') < $p('project'));
         TinyAssert::true($p('project') < $p('department'));
+    }
+
+    /**
+     * #33 review (Vader) — if a future brand overlay ever pushes
+     * billing_company's own priority unusually high, company/company_id/
+     * country must not invert above the fixed optional-fields baseline
+     * (200). Both move_country_field() and update_company_fields() clamp
+     * their read of company's priority at 190 to guarantee this.
+     */
+    private static function testCompanyPriorityClampPreventsInversionAboveOptionals(): void
+    {
+        $gateway = new class () extends WC_Twoinc {
+            public function __construct()
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $key === 'add_field_invoice_email' ? 'yes' : '';
+            }
+
+            public function get_enable_company_search()
+            {
+                return 'yes';
+            }
+        };
+
+        $checkout = new WC_Twoinc_Checkout($gateway);
+
+        // A brand overlay pushing billing_company's priority far above the
+        // optional baseline — this used to be safe (optionals rode this
+        // same value), now it must stay safe via the clamp.
+        $fields = ['billing' => ['billing_company' => ['priority' => 1000]]];
+
+        $fields = $checkout->move_country_field($fields);
+        $fields = $checkout->update_company_fields($fields);
+
+        $billing = $fields['billing'];
+
+        TinyAssert::true($billing['billing_country']['priority'] < 200, 'country must stay below the optional baseline');
+        TinyAssert::true($billing['billing_company_display']['priority'] < 200, 'company must stay below the optional baseline');
+        TinyAssert::true($billing['company_id']['priority'] < 200, 'company_id must stay below the optional baseline');
+        TinyAssert::true($billing['company_id']['priority'] < $billing['invoice_email']['priority'], 'company_id must sort before the optional fields');
     }
 
     private static function testConfirmationUrlHookReceivesUrlAndOrderId(): void

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -33,6 +33,7 @@ final class BrandConfigSpec
             'testEnvVarCannotEscapeBrandsDirectory',
             'testCheckoutFieldsHookFires',
             'testInvoiceEmailFieldHasNoPlaceholder',
+            'testFieldPrioritiesMatchDesiredCheckoutOrder',
             'testConfirmationUrlHookReceivesUrlAndOrderId',
             'testOrderPayloadHookAugmentsBody',
             'testPaymentTermsLineHookAdjustsLineItems',
@@ -383,6 +384,81 @@ final class BrandConfigSpec
             !array_key_exists('placeholder', $fields['billing']['invoice_email']),
             'invoice_email must not define a placeholder'
         );
+    }
+
+    /**
+     * #33 — Doug's desired checkout field order: name -> country -> company
+     * -> native address fields -> phone/email -> every optional field at the
+     * bottom. The optional fields must land after phone/email (WC's native
+     * priorities 100/110) regardless of company's own priority, so they
+     * can't drift back up if company's position ever changes.
+     */
+    private static function testFieldPrioritiesMatchDesiredCheckoutOrder(): void
+    {
+        $gateway = new class () extends WC_Twoinc {
+            public function __construct()
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                $enabled = [
+                    'add_field_invoice_email',
+                    'add_field_purchase_order_number',
+                    'add_field_project',
+                    'add_field_department',
+                ];
+                return in_array($key, $enabled, true) ? 'yes' : '';
+            }
+
+            public function get_enable_company_search()
+            {
+                return 'yes';
+            }
+        };
+
+        $checkout = new WC_Twoinc_Checkout($gateway);
+
+        $fields = [
+            'billing' => [
+                'billing_first_name' => ['priority' => 10],
+                'billing_last_name' => ['priority' => 20],
+                'billing_company' => ['priority' => 30],
+                'billing_address_1' => ['priority' => 50],
+                'billing_address_2' => ['priority' => 60],
+                'billing_city' => ['priority' => 70],
+                'billing_postcode' => ['priority' => 90],
+                'billing_phone' => ['priority' => 100],
+                'billing_email' => ['priority' => 110],
+            ],
+        ];
+
+        $fields = $checkout->move_country_field($fields);
+        $fields = $checkout->update_company_fields($fields);
+
+        $billing = $fields['billing'];
+        $p = static function (string $key) use ($billing) {
+            return $billing[$key]['priority'];
+        };
+
+        // Country lands right after last name, before company.
+        TinyAssert::true($p('billing_last_name') < $p('billing_country'), 'country must be after last name');
+        TinyAssert::true($p('billing_country') < $p('billing_company_display'), 'country must be before company');
+
+        // Every optional field sits after native phone/email, i.e. at the
+        // very bottom, regardless of company's own priority.
+        foreach (['invoice_email', 'purchase_order_number', 'project', 'department'] as $optional) {
+            TinyAssert::true(
+                $p('billing_email') < $p($optional),
+                $optional . ' must sit after billing_email (native priority 110)'
+            );
+        }
+
+        // And they preserve their own documented mutual order.
+        TinyAssert::true($p('invoice_email') < $p('purchase_order_number'));
+        TinyAssert::true($p('purchase_order_number') < $p('project'));
+        TinyAssert::true($p('project') < $p('department'));
     }
 
     private static function testConfirmationUrlHookReceivesUrlAndOrderId(): void

--- a/views/woocommerce_after_checkout_billing_form.php
+++ b/views/woocommerce_after_checkout_billing_form.php
@@ -3,8 +3,15 @@
     <div class="woocommerce-billing-fields__field-wrapper">
         <div id="twoinc-fn-target" class="twoinc-target"></div>
         <div id="twoinc-ln-target" class="twoinc-target"></div>
-        <div id="twoinc-em-target" class="twoinc-target"></div>
-        <div id="twoinc-ph-target" class="twoinc-target"></div>
+        <?php
+        /*
+         * Phone/email used to have targets here too (twoinc-em-target,
+         * twoinc-ph-target), moved up by positionFields() in twoinc.js.
+         * Removed for #33 — that pull-up produced a visible ~1s field
+         * reorder Doug did not want; phone/email now stay in their native
+         * WC position after town/city.
+         */
+        ?>
     </div>
     <?php
     /*


### PR DESCRIPTION
## Summary
- Stop `positionFields()` pulling `billing_phone`/`billing_email` into the pre-billing "representative" wrapper — this ~100ms move was the cause of the ~1s visible field reorder (fields jumped from server-rendered order into a different order once JS ran).
- That wrapper's own visual cue (an `<h3>` heading) was commented out in 2021 with no CSS replacement, so the grouping has no remaining display purpose today. First/last name still move there (a no-op position-wise, since they're already first).
- Move the optional fields (invoice email, PO number, project, department) off company's own priority onto a fixed baseline below phone/email, so they always land at the bottom regardless of company field state.

Final order: first/last name -> country -> company -> street address x2 -> postcode/city -> phone -> email -> optional fields.

## Test plan
- [x] `make test-unit` — all pass, including new `testFieldPrioritiesMatchDesiredCheckoutOrder`
- [x] `npm run test:js` — 193 passed
- [x] Live-verified via Chrome against a local dev checkout (company search + all optional fields enabled): billing field order identical between initial paint and t+2s — no reorder
