### PR TITLE
fix(TWO-33): sync WooCommerce's locale defaults with the country/company priority clamp

### DIFF
--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -27,6 +27,20 @@ if (!class_exists('WC_Twoinc_Checkout')) {
             add_filter('woocommerce_checkout_fields', [$this, 'add_tracking_fields'], 21);
             add_filter('woocommerce_checkout_fields', [$this, 'update_company_fields'], 23);
 
+            // WooCommerce's own address-i18n.js re-derives #billing_country's
+            // client-side priority from THIS locale default array on every
+            // checkout load (fired via country_to_state_changing at init, not
+            // only on country change) and then re-sorts the DOM — entirely
+            // independent of the woocommerce_checkout_fields chain above.
+            // Without this mirror, move_country_field()'s server-side fix is
+            // silently undone a few hundred ms after page load: JS resorts
+            // .form-row elements using the hardcoded core default
+            // (country priority 40) against company's 30, putting company
+            // back above country (#33 — live-staging-only regression, never
+            // reproduced against a local fixture because it depends on
+            // WooCommerce's own bundled JS, not this plugin's).
+            add_filter('woocommerce_get_country_locale_default', [$this, 'sync_locale_country_priority']);
+
             // Brand overlays add/modify checkout fields after the base set
             // is complete (priority 25 > the base mutations above)
             add_filter('woocommerce_checkout_fields', [$this, 'apply_brand_checkout_fields'], 25);
@@ -70,10 +84,63 @@ if (!class_exists('WC_Twoinc_Checkout')) {
             // than warning on an undefined array key. Clamped below 190: see
             // the matching clamp in update_company_fields() — country must
             // never be pushed at/above the optional-fields baseline (200).
-            $company_priority = min($fields['billing']['billing_company']['priority'] ?? 30, 190);
+            $company_priority = self::clamp_company_priority($fields['billing']['billing_company']['priority'] ?? 30);
             $fields['billing']['billing_country']['priority'] = $company_priority - 1;
 
             // Return the fields list
+            return $fields;
+        }
+
+        /**
+         * Shared clamp: never let a company-name priority (whatever its
+         * source — billing_company's own field, or WooCommerce's country
+         * locale defaults) push country/optionals out of their intended
+         * band. See move_country_field(), update_company_fields() and
+         * sync_locale_country_priority() — all three must agree on this
+         * number or the three field-order mechanisms drift apart (#33).
+         *
+         * @param $priority
+         *
+         * @return int
+         */
+        private static function clamp_company_priority($priority)
+        {
+            return min($priority, 190);
+        }
+
+        /**
+         * Keep WooCommerce's country-locale defaults in sync with the
+         * country/company priority clamp above.
+         *
+         * WooCommerce's address-i18n.js reads wc_address_i18n_params.locale
+         * (built from this exact filtered array — see
+         * WC_Countries::get_country_locale(), the 'default' entry) and,
+         * on EVERY checkout load — not only when the buyer changes country —
+         * resets #billing_country_field's client-side `data-priority` to
+         * whatever this array says, then physically re-sorts every
+         * `.form-row` in the billing wrapper by that priority
+         * (`rows.detach().appendTo(wrapper)` in address-i18n.js). Company/
+         * company_display are NOT in that JS's locale_fields list, so their
+         * priority is left alone at whatever the server rendered — only
+         * country gets overwritten. Left unfixed, this silently reverts
+         * move_country_field()'s server-side fix a few hundred ms after
+         * load, on every locale, because address-i18n.js always falls back
+         * to `locale.default` for any country without its own 'country'
+         * override (none of WooCommerce's built-in locales define one).
+         *
+         * @param $fields
+         *
+         * @return mixed
+         */
+        public function sync_locale_country_priority($fields)
+        {
+            // Keys here are unprefixed ('company', 'country') — this is
+            // WC_Countries::get_default_address_fields()'s own shape, not
+            // the 'billing_'-prefixed $checkout->get_checkout_fields() shape
+            // that move_country_field()/update_company_fields() operate on.
+            $company_priority = self::clamp_company_priority($fields['company']['priority'] ?? 30);
+            $fields['country']['priority'] = $company_priority - 1;
+
             return $fields;
         }
 
@@ -96,7 +163,7 @@ if (!class_exists('WC_Twoinc_Checkout')) {
             // Vader: this used to be a non-issue because the optionals rode
             // company's own priority; now they're fixed, so company's own
             // priority needs its own ceiling).
-            $company_name_priority = min($fields['billing']['billing_company']['priority'] ?? 30, 190);
+            $company_name_priority = self::clamp_company_priority($fields['billing']['billing_company']['priority'] ?? 30);
 
             if ($this->wc_twoinc->get_enable_company_search() === 'yes') {
                 $fields['billing']['billing_company_display'] = [

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -138,6 +138,30 @@ if (!class_exists('WC_Twoinc_Checkout')) {
             // WC_Countries::get_default_address_fields()'s own shape, not
             // the 'billing_'-prefixed $checkout->get_checkout_fields() shape
             // that move_country_field()/update_company_fields() operate on.
+            //
+            // Guard on 'country' actually being present (review finding):
+            // every WC core version we've checked includes it, but blind-
+            // writing $fields['country']['priority'] would auto-vivify a
+            // bare ['priority' => X] entry with no type/label/class if some
+            // future version ever omitted it — and that malformed entry
+            // would then be treated as the field's real locale definition
+            // downstream. Absence is a no-op, not a fallback construction:
+            // there is nothing sane to build here without WC's own field
+            // shape.
+            if (!isset($fields['country'])) {
+                return $fields;
+            }
+
+            // Reads WC core's own hardcoded 'company' default here (this
+            // array is never customized by a brand overlay — brands only
+            // hook woocommerce_checkout_fields, not
+            // woocommerce_get_country_locale_default), so it can drift from
+            // billing_company's real, possibly brand-adjusted priority in
+            // move_country_field()/update_company_fields(). No brand
+            // currently touches billing_company's priority (#33 review —
+            // Han), so this is a documented latent gap, not an active bug:
+            // if one ever does, this filter would need to read the live
+            // checkout-fields priority instead of the static default here.
             $company_priority = self::clamp_company_priority($fields['company']['priority'] ?? 30);
             $fields['country']['priority'] = $company_priority - 1;
 

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -564,6 +564,13 @@ final class BrandConfigSpec
         // its intended band either.
         $clamped = $checkout->sync_locale_country_priority(['company' => ['priority' => 1000]]);
         TinyAssert::true($clamped['country']['priority'] < 200, 'locale-default country priority must stay below the optional baseline even if company priority is huge');
+
+        // Review finding (Vader) — if 'country' is ever absent from the
+        // locale-default array, this must be a no-op, not an auto-vivified
+        // ['priority' => X] entry with no type/label/class that would then
+        // be treated as the field's real definition downstream.
+        $no_country = $checkout->sync_locale_country_priority(['company' => ['priority' => 30]]);
+        TinyAssert::true(!isset($no_country['country']), 'must not fabricate a country entry when WC did not provide one');
     }
 
     private static function testConfirmationUrlHookReceivesUrlAndOrderId(): void

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -35,6 +35,7 @@ final class BrandConfigSpec
             'testInvoiceEmailFieldHasNoPlaceholder',
             'testFieldPrioritiesMatchDesiredCheckoutOrder',
             'testCompanyPriorityClampPreventsInversionAboveOptionals',
+            'testLocaleDefaultCountryPriorityStaysBelowCompany',
             'testConfirmationUrlHookReceivesUrlAndOrderId',
             'testOrderPayloadHookAugmentsBody',
             'testPaymentTermsLineHookAdjustsLineItems',
@@ -443,9 +444,16 @@ final class BrandConfigSpec
             return $billing[$key]['priority'];
         };
 
-        // Country lands right after last name, before company.
+        // Country lands right after last name, before company — checked
+        // against BOTH the native (possibly-hidden) billing_company field
+        // and the visible billing_company_display select, not just one:
+        // the two are set independently (update_company_fields() derives
+        // company_display's priority from billing_company's, but nothing
+        // enforces they stay linked at every call site), so a regression
+        // that only re-inverts one of them must still fail this test (#33).
         TinyAssert::true($p('billing_last_name') < $p('billing_country'), 'country must be after last name');
-        TinyAssert::true($p('billing_country') < $p('billing_company_display'), 'country must be before company');
+        TinyAssert::true($p('billing_country') < $p('billing_company'), 'country must be before native billing_company');
+        TinyAssert::true($p('billing_country') < $p('billing_company_display'), 'country must be before billing_company_display');
 
         // Every optional field sits after native phone/email, i.e. at the
         // very bottom, regardless of company's own priority.
@@ -504,6 +512,58 @@ final class BrandConfigSpec
         TinyAssert::true($billing['billing_company_display']['priority'] < 200, 'company must stay below the optional baseline');
         TinyAssert::true($billing['company_id']['priority'] < 200, 'company_id must stay below the optional baseline');
         TinyAssert::true($billing['company_id']['priority'] < $billing['invoice_email']['priority'], 'company_id must sort before the optional fields');
+    }
+
+    /**
+     * #33 (live-staging regression, 2026-07-31) — WooCommerce's own
+     * address-i18n.js re-derives #billing_country_field's client-side
+     * priority from WC_Countries::get_country_locale()'s 'default' entry on
+     * EVERY checkout load (not only when the buyer changes country), then
+     * physically re-sorts the billing form's DOM by that priority —
+     * entirely independent of the woocommerce_checkout_fields chain that
+     * move_country_field()/update_company_fields() hook into. Confirmed
+     * live against the real woocom-dev.staging.two.inc pod: server-rendered
+     * HTML had country correctly above company, but the browser's own JS
+     * silently re-inverted them a few hundred ms after load, using the
+     * hardcoded core defaults (company priority 30, country priority 40)
+     * from that locale array — values this plugin never touched before.
+     * This never reproduced against a local fixture because it depends on
+     * WooCommerce's bundled JS reading server-localized JSON, not on
+     * anything this plugin's own tests exercised.
+     *
+     * sync_locale_country_priority() closes that second, independent path.
+     */
+    private static function testLocaleDefaultCountryPriorityStaysBelowCompany(): void
+    {
+        $gateway = new class () extends WC_Twoinc {
+            public function __construct()
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+            }
+        };
+
+        $checkout = new WC_Twoinc_Checkout($gateway);
+
+        // Shape mirrors WC_Countries::get_default_address_fields(): bare
+        // keys ('company', 'country'), not the 'billing_'-prefixed shape
+        // move_country_field()/update_company_fields() operate on.
+        $locale_default = [
+            'company' => ['priority' => 30],
+            'country' => ['priority' => 40],
+        ];
+
+        $fixed = $checkout->sync_locale_country_priority($locale_default);
+
+        TinyAssert::true(
+            $fixed['country']['priority'] < $fixed['company']['priority'],
+            'locale-default country priority must stay below company, or address-i18n.js re-inverts them client-side'
+        );
+
+        // Same clamp ceiling as the server-side fix: an unusually high
+        // company priority must not push country's derived value out of
+        // its intended band either.
+        $clamped = $checkout->sync_locale_country_priority(['company' => ['priority' => 1000]]);
+        TinyAssert::true($clamped['country']['priority'] < 200, 'locale-default country priority must stay below the optional baseline even if company priority is huge');
     }
 
     private static function testConfirmationUrlHookReceivesUrlAndOrderId(): void


### PR DESCRIPTION
## Summary

`#33` shipped a server-side fix (PR #422 / commit 547c004) so country renders above company on checkout. It works for the raw HTML — but WooCommerce core's own `address-i18n.js` independently re-derives `#billing_country_field`'s priority from `WC_Countries::get_country_locale()`'s `default` entry on **every** checkout load (not only on country change), then physically re-sorts the billing form's DOM. That locale array is untouched by this plugin's `woocommerce_checkout_fields` filters, so it still carries WooCommerce's hardcoded defaults (company priority 30, country priority 40) and silently re-inverts the order client-side a few hundred ms after load — undoing the #33 fix in the browser only.

Confirmed directly against the real `woocom-dev.staging.two.inc` deployment: server-rendered HTML had country above company; the live DOM did not, because this second, independent mechanism (WooCommerce's own bundled JS) reset it back. Never reproducible against a local fixture, since it depends on that bundled JS reading server-localized JSON rather than anything this plugin executes.

## Changes

- Adds `sync_locale_country_priority()`, hooked on `woocommerce_get_country_locale_default`, applying the same company/country clamp used by `move_country_field()`/`update_company_fields()`.
- Extracts the shared clamp into `clamp_company_priority()` so all three call sites can't drift apart.
- Strengthens the field-order regression test to assert country's priority is strictly below **both** `billing_company` and `billing_company_display`.
- Adds a new unit test covering `sync_locale_country_priority()` directly (including the 190 ceiling).

## Test plan

- [x] `make test-unit` (PHP 8.2, same as CI) — all tests pass, including the two new/updated ones
- [x] `npm run test:js` — 193 tests pass (no JS changes; included for completeness)
- [x] Live-verified root cause and (pending merge + git-sync) will re-verify the fix against the real staging URL
