### PR TITLE
fix: company-number label and search-again link overlapping the company field

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -302,11 +302,27 @@
  * renders inside/over the field" bug. With the absolute positioning removed
  * the button falls into NORMAL block flow as the wrapper's last child — i.e.
  * immediately below the input, inside the same box the input's own border
- * defines, so `text-align: end` lines its text up with the input's right
- * edge without needing any explicit positioning at all. Matches the pattern
- * Magento/Luma (`magento-plugin` `.search_for_company`) and Hyvä already use:
- * a plain block appended after the field, right-aligned, no absolute
- * positioning.
+ * defines. Matches the pattern Magento/Luma (`magento-plugin`
+ * `.search_for_company`) and Hyvä already use: a plain block appended after
+ * the field, right-aligned, no absolute positioning.
+ *
+ * `width: 100%` is still required for `text-align: end` to mean anything
+ * (round 2 review — Vader, correcting round 1): a `<button>` is a form
+ * control, and form controls use intrinsic (shrink-to-fit) sizing at
+ * `width: auto` REGARDLESS of `display: block` — unlike an ordinary
+ * element, which fills its containing block at `width: auto` once
+ * blockified. Round 1 deleted `width: 100%` believing `display: block`
+ * alone was sufficient (the same belief `#company_not_in_btn`'s own
+ * comment above already contradicts: "`display: block` + full width keeps
+ * it filling the dropdown"). Without it, this button shrink-wraps its own
+ * label and sits at the input's LEFT edge — `text-align: end` becomes a
+ * no-op on a box already exactly the text's width, silently reintroducing
+ * a left-aligned link where the design calls for right-aligned. `box-
+ * sizing: border-box` is what round 1's original concern (no global
+ * border-box guaranteed in this stylesheet — verified, zero hits) actually
+ * needed: it keeps `width: 100%` + this rule's own padding/border from
+ * overflowing the containing block by 6px, without giving up the width
+ * declaration itself.
  *
  * The wrapper itself gets an explicit `display: block` (round 1 review —
  * Han/Vader, convergent), replacing the `position: relative` this rule used
@@ -328,6 +344,8 @@
 }
 #search_company_btn {
   display: block;
+  box-sizing: border-box;
+  width: 100%;
   margin-top: 4px;
   text-align: end;
   cursor: pointer;

--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -377,9 +377,9 @@
  * deliberately, rather than `border: 0` — a border occupies box space
  * (unlike outline, which doesn't), so drawing it only on `:focus` would grow
  * the button by 2px the moment focus lands and shrink it back on blur,
- * nudging its (unfixed-width, right-pinned) box and its text sideways by
- * ~1px each way. Reserving the same width up front, invisible until
- * `:focus` recolours it, means the box never changes size — only colour.
+ * nudging its right-aligned text sideways by ~1px each way. Reserving the
+ * same width up front, invisible until `:focus` recolours it, means the
+ * box never changes size — only colour.
  *
  * `!important` for the same defensive reason as the text-transform override:
  * a theme's own button-focus reset, if one exists, is routinely `!important`

--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -159,12 +159,30 @@
  */
 .twoinc-company-summary {
   padding-bottom: 15px;
+  /*
+   * Matches WooCommerce core's `.form-row { padding: 3px }` (round 1 review
+   * — Han/Vader, convergent): without it the right-aligned id below sits
+   * ~3px outboard of the input's own right edge, the same box the field
+   * above it uses. Cosmetic on its own, but pixel alignment is the entire
+   * point of this change.
+   */
+  padding-left: 3px;
+  padding-right: 3px;
   line-height: 1.4;
 }
 
 .twoinc-company-summary-name {
   font-weight: 600;
   display: block;
+  /*
+   * Round 1 review (Vader): a single unbroken token — routine in DE/NL/NO
+   * registry names — would otherwise overflow the row horizontally instead
+   * of wrapping. `anywhere` rather than `break-word`: it also allows a break
+   * before the first character of an overflowing word, which `break-word`
+   * does not, so a name that alone is wider than the field still wraps
+   * rather than escaping the box.
+   */
+  overflow-wrap: anywhere;
 }
 
 /*
@@ -174,30 +192,49 @@
  * single-class selector so brand overlays can recolour it without raising
  * specificity.
  *
- * `display: block` + `text-align: right` (#30.x.9, Doug's canonical
+ * `display: block` + `text-align: end` (#30.x.9, Doug's canonical
  * cross-platform ruling): this used to sit on the SAME line as the name,
  * `margin-left: 8px` away from it. A long company name pushed the number
  * right up against — and on a narrow viewport, past — the edge of the
  * summary's own box, which is exactly what Doug found live: picking a
  * result left no number visibly on screen. Giving the number its own row,
- * right-aligned to the input's right edge (the summary div is the same
- * width as the field above it), means the two values never compete for
- * the same horizontal space regardless of how long the name is.
+ * right-aligned to the input's right edge (the summary div carries the
+ * same horizontal padding as the field above it — see `.twoinc-company-
+ * summary` above), means the two values never compete for the same
+ * horizontal space regardless of how long the name is.
+ *
+ * `text-align: end` rather than `right`: logical, not physical — this
+ * plugin ships no RTL locale today (nothing in `class/` or `assets/`
+ * branches on text direction), but `end` costs nothing now and stays
+ * correct if one is ever added. `white-space: nowrap` dropped (round 1
+ * review — Vader): now that the id has its own row, letting an
+ * exceptionally long identifier wrap is strictly safer than the old
+ * nowrap, which would have pushed an over-long value past the row's edge
+ * exactly like the bug this change fixes.
  */
 .twoinc-company-summary-id {
   display: block;
-  text-align: right;
+  text-align: end;
   color: #6b6b6b;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 /*
  * The pay-for-order page lays its copy of the company fields out as wrapping
  * flex items, so the summary lands as an item on the same row rather than
- * underneath them. Give it the full row there.
+ * underneath them, and `flex-basis: 100%` makes it a full-page-width row —
+ * unlike the checkout page, where the summary's box is only as wide as the
+ * (narrower) field above it. Right-aligning the id against that full-page
+ * width (round 1 review — Han) detaches it from the field entirely: name at
+ * the far left, number at the far right, the actual input floating,
+ * centred, in between. Overridden back to the leading edge here, matching
+ * this page's pre-existing single-line layout.
  */
 .custom-checkout .twoinc-company-summary {
   flex-basis: 100%;
+}
+.custom-checkout .twoinc-company-summary-id {
+  text-align: start;
 }
 
 /*
@@ -262,21 +299,37 @@
  * the input but placed it ON TOP of it, right-pinned 4px from the edge —
  * overlapping the input itself. Reported live (#30.x.9, Doug's canonical
  * cross-platform ruling): that overlap is exactly the "search-again link
- * renders inside/over the field" bug. `.woocommerce-input-wrapper` still has
- * no fixed height of its own, so with the absolute positioning removed the
- * button now falls into NORMAL block flow as the wrapper's last child — i.e.
+ * renders inside/over the field" bug. With the absolute positioning removed
+ * the button falls into NORMAL block flow as the wrapper's last child — i.e.
  * immediately below the input, inside the same box the input's own border
- * defines, so `text-align: right` lines its text up with the input's right
+ * defines, so `text-align: end` lines its text up with the input's right
  * edge without needing any explicit positioning at all. Matches the pattern
  * Magento/Luma (`magento-plugin` `.search_for_company`) and Hyvä already use:
  * a plain block appended after the field, right-aligned, no absolute
  * positioning.
+ *
+ * The wrapper itself gets an explicit `display: block` (round 1 review —
+ * Han/Vader, convergent), replacing the `position: relative` this rule used
+ * to carry for the absolute button. `.woocommerce-input-wrapper` is a
+ * `<span>` — inline by default — and this repo has no control over what a
+ * host theme declares for it; a theme that happens to set it to
+ * `display: flex` would put the button back on the same line as the input
+ * at `width: 100%`, silently re-creating the overlap this change removes.
+ * Declaring `display: block` here, at the same specificity this plugin
+ * already uses to reason about this wrapper, removes that dependency on
+ * whatever the host theme leaves undeclared. `position: relative` is kept
+ * alongside it, at zero cost, purely so this element's positioning context
+ * doesn't silently change out from under some theme-supplied decoration
+ * nobody here can see.
  */
+#billing_company_field .woocommerce-input-wrapper {
+  display: block;
+  position: relative;
+}
 #search_company_btn {
   display: block;
-  width: 100%;
   margin-top: 4px;
-  text-align: right;
+  text-align: end;
   cursor: pointer;
   color: #3043d1;
   background: none;

--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -164,6 +164,7 @@
 
 .twoinc-company-summary-name {
   font-weight: 600;
+  display: block;
 }
 
 /*
@@ -172,9 +173,20 @@
  * used (#ddd) was close to invisible on a white checkout. Kept as a flat
  * single-class selector so brand overlays can recolour it without raising
  * specificity.
+ *
+ * `display: block` + `text-align: right` (#30.x.9, Doug's canonical
+ * cross-platform ruling): this used to sit on the SAME line as the name,
+ * `margin-left: 8px` away from it. A long company name pushed the number
+ * right up against — and on a narrow viewport, past — the edge of the
+ * summary's own box, which is exactly what Doug found live: picking a
+ * result left no number visibly on screen. Giving the number its own row,
+ * right-aligned to the input's right edge (the summary div is the same
+ * width as the field above it), means the two values never compete for
+ * the same horizontal space regardless of how long the name is.
  */
 .twoinc-company-summary-id {
-  margin-left: 8px;
+  display: block;
+  text-align: right;
   color: #6b6b6b;
   white-space: nowrap;
 }
@@ -242,32 +254,31 @@
  * button rule kept winning on this element specifically while the other one
  * was already fixed. Same fix, same reason, just missed the first time.
  *
- * Vertical centring against `.woocommerce-input-wrapper`, not against this
- * button's own containing `#billing_company_field` (round 3, #30.x.5.3).
- * `#billing_company_field` wraps BOTH the "Company name" <label> and the
- * input, but only the input carries a visible border — the label sits above
- * it with no box of its own. This button used to be positioned with no
- * explicit `top` at all, so its vertical position fell back to its "static
- * position" (roughly where it would render in normal flow, i.e. after the
- * label+input together) rather than to the middle of the bordered input box
- * beneath the label. `.woocommerce-input-wrapper` is WooCommerce core's own
- * wrapper around just the <input> — no label inside it — so this button is
- * now appended there (see `getSearchCompanyBtnNode` in twoinc.js) and
- * centred with `top: 50%; transform: translateY(-50%)` against THAT box,
- * which lines it up with the visible field regardless of label height or how
- * many lines it wraps to on a narrow viewport.
+ * Appended into `.woocommerce-input-wrapper` (WooCommerce core's own wrapper
+ * around just the <input>, no label inside it — see `getSearchCompanyBtnNode`
+ * in twoinc.js), the same container round 3 (#30.x.5.3) introduced. That
+ * round centred the button with `position: absolute; top: 50%; transform:
+ * translateY(-50%)` against the wrapper, which lined it up vertically with
+ * the input but placed it ON TOP of it, right-pinned 4px from the edge —
+ * overlapping the input itself. Reported live (#30.x.9, Doug's canonical
+ * cross-platform ruling): that overlap is exactly the "search-again link
+ * renders inside/over the field" bug. `.woocommerce-input-wrapper` still has
+ * no fixed height of its own, so with the absolute positioning removed the
+ * button now falls into NORMAL block flow as the wrapper's last child — i.e.
+ * immediately below the input, inside the same box the input's own border
+ * defines, so `text-align: right` lines its text up with the input's right
+ * edge without needing any explicit positioning at all. Matches the pattern
+ * Magento/Luma (`magento-plugin` `.search_for_company`) and Hyvä already use:
+ * a plain block appended after the field, right-aligned, no absolute
+ * positioning.
  */
-#billing_company_field .woocommerce-input-wrapper {
-  position: relative;
-}
 #search_company_btn {
+  display: block;
+  width: 100%;
+  margin-top: 4px;
   text-align: right;
   cursor: pointer;
   color: #3043d1;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  right: 4px;
   background: none;
   border: 1px dotted transparent;
   padding: 0 2px;

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1379,9 +1379,12 @@ let twoincDomHelper = {
    * from submitting it.
    *
    * Appended into `.woocommerce-input-wrapper`, not directly into
-   * `#billing_company_field` (round 3, #30.x.5.3) — see the rule comment
-   * above `#billing_company_field .woocommerce-input-wrapper` in twoinc.css
-   * for why (label-height vs. visible-field centring). If that wrapper is
+   * `#billing_company_field` (round 3, #30.x.5.3; positioning reworked
+   * #30.x.9) — see the rule comment above `#search_company_btn` in
+   * twoinc.css for why: that wrapper is WooCommerce core's own box around
+   * just the <input>, no label inside it, so a plain block appended as its
+   * last child lands in normal flow immediately below the input regardless
+   * of label height or how many lines it wraps to. If that wrapper is
    * missing (a host template not using WooCommerce core's own field markup),
    * one is built around `#billing_company` directly rather than falling back
    * to `#billing_company_field` itself, which would silently reintroduce the
@@ -1443,20 +1446,16 @@ let twoincDomHelper = {
 
     // Self-heal rather than silently degrade (found under adversarial
     // review before merge, round 3): a plain "fall back to
-    // #billing_company_field" here would still centre the button with
-    // `top: 50%; transform: translateY(-50%)` (see twoinc.css) against
-    // #billing_company_field itself — which ALREADY carries `position:
-    // relative` from before this fix — so on any host template that
-    // doesn't render the standard WooCommerce wrapper, this button would
-    // silently reproduce the exact label-height centring bug this round
-    // exists to fix, with nothing to signal that the fallback path was
-    // even taken. Instead, build an equivalent wrapper around just the
-    // <input> ourselves: same DOM shape WooCommerce core's own
-    // woocommerce_form_field() would have produced, so the CSS centring
-    // rule has a consistent structure to hook onto regardless of which
-    // path got here. Falls through to #billing_company_field only if
-    // #billing_company itself is missing — a field this whole feature
-    // already depends on existing.
+    // #billing_company_field" here would append the button as a sibling of
+    // BOTH the label and the input, rather than immediately after the input
+    // alone — reintroducing the old overlap-with-the-field-label class of
+    // bug this wrapper exists to avoid. Instead, build an equivalent wrapper
+    // around just the <input> ourselves: same DOM shape WooCommerce core's
+    // own woocommerce_form_field() would have produced, so the button always
+    // lands directly below the input regardless of which path got here.
+    // Falls through to #billing_company_field only if #billing_company
+    // itself is missing — a field this whole feature already depends on
+    // existing.
     if (!$wrapper.length) {
       const $input = jQuery("#billing_company");
       if ($input.length) {

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -637,7 +637,41 @@ describe("company-search manual-entry affordance", () => {
       const btnStyle = window.getComputedStyle($searchBtn[0]);
       expect(btnStyle.position).not.toBe("absolute");
       expect(btnStyle.display).toBe("block");
-      expect(btnStyle.textAlign).toBe("right");
+      expect(btnStyle.textAlign).toBe("end");
+    });
+
+    test("the wrapper is blockified explicitly, not left to whatever the host theme declares (round 1 review)", () => {
+      // Han/Vader, convergent: `.woocommerce-input-wrapper` is a <span> —
+      // inline by default — and this repo has no control over what a host
+      // theme sets it to. A theme declaring it `display: flex` would put
+      // the button back on the same line as the input, silently
+      // re-creating the overlap this change removes. `position: relative`
+      // stays too — it's what the OLD absolute-positioned button relied on,
+      // kept at zero cost so no theme-supplied decoration inside this
+      // wrapper silently changes its own positioning context.
+      const m = /#billing_company_field\s+\.woocommerce-input-wrapper\s*\{([^}]*)\}/.exec(
+        fs.readFileSync(path.join(harness.REPO_ROOT, harness.STYLESHEET_PATH), "utf8")
+      );
+      expect(m).not.toBeNull();
+      expect(m[1]).toMatch(/display:\s*block/);
+      expect(m[1]).toMatch(/position:\s*relative/);
+    });
+
+    test("#search_company_btn declares its below-the-field gap explicitly (round 1 review — Vader)", () => {
+      // Mutation-caught gap: the button's own `display`/`position`/
+      // `text-align` were asserted above, but `margin-top` — the actual
+      // "sits below the field with a gap" spacing — was not, and a mutation
+      // deleting it passed the full suite. `width: 100%` was also removed
+      // entirely here (round 1 review): a `display: block` element already
+      // fills its containing block at `width: auto`, and declaring 100%
+      // explicitly overflows that box by the padding+border under
+      // content-box sizing, which this repo does not guarantee globally.
+      const m = /^#search_company_btn\s*\{([^}]*)\}/m.exec(
+        fs.readFileSync(path.join(harness.REPO_ROOT, harness.STYLESHEET_PATH), "utf8")
+      );
+      expect(m).not.toBeNull();
+      expect(m[1]).toMatch(/margin-top:\s*4px/);
+      expect(m[1]).not.toMatch(/width:\s*100%/);
     });
 
     test("self-heals a missing .woocommerce-input-wrapper instead of silently falling back to the unpositioned field (found under adversarial review)", () => {

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -661,17 +661,32 @@ describe("company-search manual-entry affordance", () => {
       // Mutation-caught gap: the button's own `display`/`position`/
       // `text-align` were asserted above, but `margin-top` — the actual
       // "sits below the field with a gap" spacing — was not, and a mutation
-      // deleting it passed the full suite. `width: 100%` was also removed
-      // entirely here (round 1 review): a `display: block` element already
-      // fills its containing block at `width: auto`, and declaring 100%
-      // explicitly overflows that box by the padding+border under
-      // content-box sizing, which this repo does not guarantee globally.
+      // deleting it passed the full suite.
       const m = /^#search_company_btn\s*\{([^}]*)\}/m.exec(
         fs.readFileSync(path.join(harness.REPO_ROOT, harness.STYLESHEET_PATH), "utf8")
       );
       expect(m).not.toBeNull();
       expect(m[1]).toMatch(/margin-top:\s*4px/);
-      expect(m[1]).not.toMatch(/width:\s*100%/);
+    });
+
+    test("#search_company_btn keeps width: 100% paired with box-sizing: border-box (round 2 review — Vader, correcting round 1)", () => {
+      // Round 1 deleted `width: 100%` on the theory that `display: block`
+      // alone fills the containing block at `width: auto` — true for an
+      // ordinary element, FALSE for a <button>: form controls use intrinsic
+      // (shrink-to-fit) sizing at `width: auto` regardless of `display`.
+      // Without `width: 100%` this button hugs its own label and sits at
+      // the input's left edge, making `text-align: end` a no-op — silently
+      // reintroducing a left-aligned link where the design calls for
+      // right-aligned. `box-sizing: border-box` is what actually answers
+      // round 1's original overflow concern (no global border-box
+      // guaranteed anywhere in this stylesheet), so the two must ship
+      // together — either alone reproduces a bug.
+      const m = /^#search_company_btn\s*\{([^}]*)\}/m.exec(
+        fs.readFileSync(path.join(harness.REPO_ROOT, harness.STYLESHEET_PATH), "utf8")
+      );
+      expect(m).not.toBeNull();
+      expect(m[1]).toMatch(/width:\s*100%/);
+      expect(m[1]).toMatch(/box-sizing:\s*border-box/);
     });
 
     test("self-heals a missing .woocommerce-input-wrapper instead of silently falling back to the unpositioned field (found under adversarial review)", () => {

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -590,11 +590,13 @@ describe("company-search manual-entry affordance", () => {
     });
   });
 
-  describe("vertical alignment against the visible field, not the field+label (#30.x.5.3, round 3)", () => {
+  describe("placement below the visible field, not overlapping it (#30.x.5.3 round 3; reworked #30.x.9)", () => {
     test("#search_company_btn is appended into .woocommerce-input-wrapper, not #billing_company_field directly", () => {
-      // See the rule comment above `#billing_company_field
-      // .woocommerce-input-wrapper` in twoinc.css for why this containing
-      // block matters (label-height vs. visible-field centring).
+      // See the rule comment above `#search_company_btn` in twoinc.css for
+      // why this containing block matters: it is WooCommerce core's own
+      // wrapper around just the <input>, no label inside it, so a button
+      // appended as its last child lands in normal flow immediately below
+      // the input rather than below the label+input combined.
       jest.useFakeTimers();
       openWithAffordance();
       type("abc");
@@ -608,7 +610,13 @@ describe("company-search manual-entry affordance", () => {
       expect($searchBtn.closest("#billing_company_field").length).toBe(1);
     });
 
-    test("the containing wrapper is positioned and the button centres against it, not the field", () => {
+    test("the button sits in normal flow below the input, not absolutely positioned over it (#30.x.9)", () => {
+      // Reported live: the button used to be `position: absolute; top: 50%;
+      // transform: translateY(-50%)` against `.woocommerce-input-wrapper` —
+      // centred vertically against the input, which put it ON TOP of the
+      // input rather than below it. Doug's ruling: no absolute positioning,
+      // normal block flow below the field, right-aligned — same pattern as
+      // Magento/Luma's `.search_for_company` and Hyvä.
       harness.injectStylesheet();
 
       jest.useFakeTimers();
@@ -619,26 +627,27 @@ describe("company-search manual-entry affordance", () => {
       jest.useRealTimers();
 
       const $searchBtn = ctx.dom.getSearchCompanyBtnNode();
-      const wrapper = $searchBtn.parent()[0];
 
-      expect(window.getComputedStyle(wrapper).position).toBe("relative");
+      // The button is the LAST child of the wrapper, after the <input> —
+      // i.e. it renders below it in normal document flow.
+      const wrapper = $searchBtn.parent();
+      expect(wrapper.children().last().get(0)).toBe($searchBtn.get(0));
+      expect($searchBtn.prev().is("input")).toBe(true);
+
       const btnStyle = window.getComputedStyle($searchBtn[0]);
-      expect(btnStyle.position).toBe("absolute");
-      expect(btnStyle.top).toBe("50%");
-      // jsdom reports the declared transform function verbatim rather than
-      // resolving it to a matrix() (no layout engine to resolve it against),
-      // so this asserts the declaration itself rather than a computed value.
-      expect(btnStyle.transform).toContain("translateY(-50%)");
+      expect(btnStyle.position).not.toBe("absolute");
+      expect(btnStyle.display).toBe("block");
+      expect(btnStyle.textAlign).toBe("right");
     });
 
     test("self-heals a missing .woocommerce-input-wrapper instead of silently falling back to the unpositioned field (found under adversarial review)", () => {
       // A host template that renders #billing_company_field without
       // WooCommerce core's own .woocommerce-input-wrapper span around the
       // input would otherwise leave this button falling back to appending
-      // directly onto #billing_company_field — which already carries
-      // `position: relative` from BEFORE this round (see twoinc.css), so the
-      // button would still centre with top:50%/translateY(-50%) against
-      // label+input COMBINED, silently reproducing the exact bug this round
+      // directly onto #billing_company_field — which wraps BOTH the label
+      // and the input, so the button would land below the label+input
+      // COMBINED rather than immediately below the input alone, silently
+      // reproducing the exact "not right below the field" bug this round
       // exists to fix, with nothing to signal the fallback path was taken.
       // getSearchCompanyBtnNode must instead build an equivalent wrapper
       // around the bare input rather than degrade.
@@ -876,8 +885,9 @@ describe("company-search manual-entry affordance", () => {
       expect($back[0].style.display).toBe("none");
       // In place, not floating: it belongs beside the manual company field —
       // specifically inside .woocommerce-input-wrapper (round 3, #30.x.5.3),
-      // not directly on #billing_company_field, so CSS can centre it against
-      // the visible input box rather than the field's label+input combined.
+      // not directly on #billing_company_field, so it renders immediately
+      // below the visible input box rather than below the field's
+      // label+input combined.
       expect($back.parent().hasClass("woocommerce-input-wrapper")).toBe(true);
       expect($back.closest("#billing_company_field").length).toBe(1);
     });

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -203,6 +203,23 @@ describe("read-only captured-company summary", () => {
       expect(idStyle.textAlign).toBe("end");
     });
 
+    test("the summary box carries WooCommerce core's own form-row padding, so the id lines up with the input's real edge (round 2 review — Vader)", () => {
+      // Mutation-caught gap: deleting `padding-left`/`padding-right` from
+      // `.twoinc-company-summary` (round 1's fix for the ~3px offset
+      // against the input) passed the full suite with nothing to catch it.
+      // Asserted against computed style, not a stylesheet-source regex —
+      // the `[^}]*` capture used elsewhere in this file terminates early on
+      // the `}` inside this rule's own CSS *comment* (`.form-row { padding:
+      // 3px }`), so a naive regex test would silently pass regardless of
+      // what the rule actually declares.
+      harness.injectStylesheet();
+      pickCompany("ACME Widgets Ltd", "12345678");
+
+      const summaryStyle = window.getComputedStyle(summary()[0]);
+      expect(summaryStyle.paddingLeft).toBe("3px");
+      expect(summaryStyle.paddingRight).toBe("3px");
+    });
+
     test("the id element carries no same-line margin from the name any more", () => {
       // The old inline layout's `margin-left: 8px` on the id is exactly what
       // let it be squeezed off the visible line by a long name. Asserted
@@ -248,6 +265,23 @@ describe("read-only captured-company summary", () => {
       );
       expect(m).not.toBeNull();
       expect(m[1]).toMatch(/text-align:\s*start/);
+    });
+
+    test("the override actually wins the cascade, not just exists in source (round 2 review — Han)", () => {
+      // The regex test above only proves the rule EXISTS, not that it WINS.
+      // Both the general `.twoinc-company-summary-id` rule and this
+      // `.custom-checkout` override are live in the same stylesheet — if a
+      // future edit ever reordered them so the general rule landed after
+      // the override in source, `text-align` would resolve to "end" here
+      // regardless of what this file's regex still matches. Render the
+      // summary inside a `.custom-checkout` ancestor and read the actual
+      // computed value.
+      harness.injectStylesheet();
+      pickCompany("ACME Widgets Ltd", "12345678");
+      summary().wrap('<div class="custom-checkout"></div>');
+
+      const idStyle = window.getComputedStyle(summary().find(".twoinc-company-summary-id")[0]);
+      expect(idStyle.textAlign).toBe("start");
     });
   });
 

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -174,6 +174,48 @@ describe("read-only captured-company summary", () => {
     });
   });
 
+  describe("number rendered below the name, right-aligned, not sharing its line (#30.x.9)", () => {
+    // Reported live: picking a search result left the company number
+    // effectively invisible. Root cause was layout, not logic — the number
+    // used to sit on the SAME line as the name, `margin-left: 8px` away from
+    // it, `white-space: nowrap`. A long company name pushed it toward, and
+    // on a narrow viewport past, the right edge of the summary's own box.
+    // Doug's canonical cross-platform ruling: the number gets its own row,
+    // immediately below the name, right-aligned to the input's right edge —
+    // so it can never again compete with the name for the same horizontal
+    // space regardless of how long the name is.
+    test("the number is a block of its own, not inline with the name", () => {
+      harness.injectStylesheet();
+      pickCompany("A Very Long International Holdings Group Company Ltd", "12345678");
+
+      const nameStyle = window.getComputedStyle(summary().find(".twoinc-company-summary-name")[0]);
+      const idStyle = window.getComputedStyle(summary().find(".twoinc-company-summary-id")[0]);
+
+      expect(nameStyle.display).toBe("block");
+      expect(idStyle.display).toBe("block");
+      expect(idStyle.textAlign).toBe("right");
+    });
+
+    test("the id element carries no same-line margin from the name any more", () => {
+      // The old inline layout's `margin-left: 8px` on the id is exactly what
+      // let it be squeezed off the visible line by a long name. Asserted
+      // directly against the shipped rule, not just the computed style,
+      // because jsdom does not lay out real text wrapping to prove the
+      // collision — the CSS declaration itself is the fix.
+      const fs = require("fs");
+      const path = require("path");
+      const css = fs.readFileSync(
+        path.join(harness.REPO_ROOT, harness.STYLESHEET_PATH),
+        "utf8"
+      );
+      const m = /\.twoinc-company-summary-id\s*\{([^}]*)\}/.exec(css);
+      expect(m).not.toBeNull();
+      expect(m[1]).not.toMatch(/margin-left/);
+      expect(m[1]).toMatch(/text-align:\s*right/);
+      expect(m[1]).toMatch(/display:\s*block/);
+    });
+  });
+
   describe("manual entry", () => {
     /**
      * Type a company name the way the buyer does in manual entry, and let the

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -18,7 +18,14 @@
 
 "use strict";
 
+const fs = require("fs");
+const path = require("path");
 const harness = require("./wc-harness");
+
+/** @returns {string} the raw twoinc.css source */
+function stylesheetSource() {
+  return fs.readFileSync(path.join(harness.REPO_ROOT, harness.STYLESHEET_PATH), "utf8");
+}
 
 const GATEWAY_ID = "woocommerce-gateway-tillit";
 
@@ -193,7 +200,7 @@ describe("read-only captured-company summary", () => {
 
       expect(nameStyle.display).toBe("block");
       expect(idStyle.display).toBe("block");
-      expect(idStyle.textAlign).toBe("right");
+      expect(idStyle.textAlign).toBe("end");
     });
 
     test("the id element carries no same-line margin from the name any more", () => {
@@ -202,17 +209,45 @@ describe("read-only captured-company summary", () => {
       // directly against the shipped rule, not just the computed style,
       // because jsdom does not lay out real text wrapping to prove the
       // collision — the CSS declaration itself is the fix.
-      const fs = require("fs");
-      const path = require("path");
-      const css = fs.readFileSync(
-        path.join(harness.REPO_ROOT, harness.STYLESHEET_PATH),
-        "utf8"
-      );
-      const m = /\.twoinc-company-summary-id\s*\{([^}]*)\}/.exec(css);
+      const m = /\.twoinc-company-summary-id\s*\{([^}]*)\}/.exec(stylesheetSource());
       expect(m).not.toBeNull();
       expect(m[1]).not.toMatch(/margin-left/);
-      expect(m[1]).toMatch(/text-align:\s*right/);
+      expect(m[1]).toMatch(/text-align:\s*end/);
       expect(m[1]).toMatch(/display:\s*block/);
+    });
+
+    test("neither the name nor the id can overflow past the row on a single unbroken token", () => {
+      // Round 1 review (Vader): the block-row fix stops the NUMBER competing
+      // with the name for space, but does nothing on its own for a single
+      // unbroken token — routine in DE/NL/NO registry names — which would
+      // otherwise overflow the row horizontally instead of wrapping.
+      const nameBody = /\.twoinc-company-summary-name\s*\{([^}]*)\}/.exec(stylesheetSource());
+      const idBody = /\.twoinc-company-summary-id\s*\{([^}]*)\}/.exec(stylesheetSource());
+      expect(nameBody).not.toBeNull();
+      expect(idBody).not.toBeNull();
+      expect(nameBody[1]).toMatch(/overflow-wrap:\s*anywhere/);
+      expect(idBody[1]).toMatch(/overflow-wrap:\s*anywhere/);
+      // The old nowrap protected the (inline, same-line) id from wrapping
+      // onto an ugly second line — but now that it has its own row, nowrap
+      // would instead let an exceptionally long identifier run past the
+      // row's edge, invisible, which is the exact bug this PR fixes.
+      expect(idBody[1]).not.toMatch(/white-space:\s*nowrap/);
+    });
+  });
+
+  describe("pay-for-order page: number stays aligned with the name, not the full-width row (#30.x.9)", () => {
+    // Round 1 review (Han): that page lays the company fields out as
+    // flex-wrap items and gives the summary `flex-basis: 100%` — a
+    // full-page-width row, unlike the checkout page where the summary is
+    // only as wide as the (narrower) field above it. Right-aligning the id
+    // against that full width would detach it from the actual input, which
+    // sits centred between the two. Assert the override lands.
+    test("the id's alignment is overridden back to the leading edge on .custom-checkout", () => {
+      const m = /\.custom-checkout\s+\.twoinc-company-summary-id\s*\{([^}]*)\}/.exec(
+        stylesheetSource()
+      );
+      expect(m).not.toBeNull();
+      expect(m[1]).toMatch(/text-align:\s*start/);
     });
   });
 

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -268,14 +268,15 @@ describe("read-only captured-company summary", () => {
     });
 
     test("the override actually wins the cascade, not just exists in source (round 2 review — Han)", () => {
-      // The regex test above only proves the rule EXISTS, not that it WINS.
-      // Both the general `.twoinc-company-summary-id` rule and this
-      // `.custom-checkout` override are live in the same stylesheet — if a
-      // future edit ever reordered them so the general rule landed after
-      // the override in source, `text-align` would resolve to "end" here
-      // regardless of what this file's regex still matches. Render the
-      // summary inside a `.custom-checkout` ancestor and read the actual
-      // computed value.
+      // The regex test above only proves the rule EXISTS, not that it WINS
+      // against a real rendered element. `.custom-checkout
+      // .twoinc-company-summary-id` outranks the bare `.twoinc-company-
+      // summary-id` on specificity (0,2,0 vs 0,1,0) regardless of source
+      // order, so this isn't guarding against reordering — it's guarding
+      // against the override rule silently stopping applying at all (typo'd
+      // selector, wrong class, etc.), which a source-only regex can't catch.
+      // Render the summary inside a `.custom-checkout` ancestor and read the
+      // actual computed value.
       harness.injectStylesheet();
       pickCompany("ACME Widgets Ltd", "12345678");
       summary().wrap('<div class="custom-checkout"></div>');


### PR DESCRIPTION
## Summary

Two live layout bugs Doug found testing woocom-dev.staging.two.inc/checkout/ with a real cart and real company search (TWO-25324):

- **Company number invisible after picking a search result.** `.twoinc-company-summary-id` shared the same line as the company name (`margin-left: 8px`, `white-space: nowrap`), so a long company name pushed the number toward — and on a narrow viewport past — the right edge of the summary box. Fix: the number now renders as its own block row, right-aligned to the input's right edge, decoupled from the name entirely.
- **"Search for company" link rendering on top of the company-name field.** `#search_company_btn` was `position: absolute; top: 50%; transform: translateY(-50%)` against `.woocommerce-input-wrapper` — centred vertically over the input, i.e. visually overlapping it. Fix: normal block flow as the wrapper's last child, right-aligned, no absolute positioning — matching the layout pattern `magento-plugin`'s Luma `.search_for_company` and `magento-hyva-extension` already use.

## Test plan

- [x] `npm run test:js` — 195/195 passing, including 3 new/updated assertions
- [x] Mutation-verified: reverted the CSS to the pre-fix state and confirmed all 3 new/updated assertions fail (not vacuous) — restored, all green again
- [x] Live-verified pre-fix on woocom-dev.staging.two.inc/checkout/: confirmed via devtools that a picked company's summary renders `<span class="twoinc-company-summary-name">` + `<span class="twoinc-company-summary-id">` inline, matching the described bug
- [ ] Live-verify post-merge on staging

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>