### PR TITLE
fix: company summary self-heals position after WooCommerce's own field resort

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1270,11 +1270,23 @@ let twoincDomHelper = {
    * them. The plugin already carries two established fixes for exactly this
    * mechanism (for the country field) — this is the same class of bug for
    * the summary. `insertAfter` on an already-attached node MOVES it rather
-   * than cloning, so re-running it here on every `renderCompanySummary()`
-   * call (which already fires on every pick, payment-method switch, country
-   * change and re-render) snaps the summary back into place after any
-   * external resort, at the cost of one no-op DOM move on calls where
-   * nothing has drifted.
+   * than cloning, so re-checking the anchor here on every
+   * `renderCompanySummary()` call (which already fires on every pick,
+   * payment-method switch, country change and re-render) snaps the summary
+   * back into place after any external resort.
+   *
+   * Guarded on `$node.prev()` (round 1 review — Han): re-running
+   * `insertAfter` UNCONDITIONALLY, on every call, physically detaches and
+   * re-inserts the node even when nothing has drifted — measured with a
+   * MutationObserver, every "healthy" call still fires a childList removal
+   * + addition. That collapses any text selection inside the summary (the
+   * only interaction this read-only org-number display affords is
+   * selecting it to copy), forces a reflow, and would restart any CSS
+   * transition a brand overlay puts on this element (`.custom-checkout
+   * .twoinc-company-summary` in twoinc.css proves overlays do style it).
+   * `.prev()` is element-only (ignores text nodes), so "prev is already the
+   * anchor" reliably implies "already positioned, same parent, nothing to
+   * do" — the move only runs when the anchor actually changed.
    *
    * @returns {Object} jQuery-wrapped summary, or an empty set on a page with
    *   no company fields at all
@@ -1299,7 +1311,8 @@ let twoincDomHelper = {
     }
 
     const $wrapper = $field.closest(".twoinc-inp-container");
-    $node.insertAfter($wrapper.length ? $wrapper : $field);
+    const $anchor = $wrapper.length ? $wrapper : $field;
+    if ($node.prev()[0] !== $anchor[0]) $node.insertAfter($anchor);
     return $node;
   },
 

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1257,25 +1257,47 @@ let twoincDomHelper = {
    * invisible on that page in exactly the search mode it matters most for. The
    * checkout page has no wrappers and the anchor falls through to the field.
    *
+   * Re-anchored on EVERY call, not just on first creation (#30.x.9, found by
+   * live post-merge verification — reported live: the summary rendered ABOVE
+   * the company field instead of below it). Root cause is documented in
+   * `WC_Twoinc_Checkout.php`, above `move_country_field()` and
+   * `sync_locale_country_priority()`: WooCommerce core's own
+   * `address-i18n.js` detaches and re-appends every `.form-row` in the
+   * billing wrapper by priority, on EVERY checkout load — not only on
+   * country change. This summary is a plain `<div>`, not a `.form-row`, so
+   * it never takes part in that resort; once WC moves the real fields past
+   * it, it stays stranded wherever it was first inserted, above all of
+   * them. The plugin already carries two established fixes for exactly this
+   * mechanism (for the country field) — this is the same class of bug for
+   * the summary. `insertAfter` on an already-attached node MOVES it rather
+   * than cloning, so re-running it here on every `renderCompanySummary()`
+   * call (which already fires on every pick, payment-method switch, country
+   * change and re-render) snaps the summary back into place after any
+   * external resort, at the cost of one no-op DOM move on calls where
+   * nothing has drifted.
+   *
    * @returns {Object} jQuery-wrapped summary, or an empty set on a page with
    *   no company fields at all
    */
   getCompanySummaryNode: function () {
     let $node = jQuery("#" + twoincDomHelper.companySummaryId);
-    if ($node.length) return $node;
+    const isNew = !$node.length;
 
     let $field = jQuery("#company_id_field");
     if (!$field.length) $field = jQuery("#billing_company_field");
-    if (!$field.length) return jQuery();
+    if (!$field.length) return isNew ? jQuery() : $node;
 
-    $node = jQuery(
-      '<div id="' +
-        twoincDomHelper.companySummaryId +
-        '" class="twoinc-company-summary hidden">' +
-        '<span class="twoinc-company-summary-name"></span>' +
-        '<span class="twoinc-company-summary-id"></span>' +
-        "</div>"
-    );
+    if (isNew) {
+      $node = jQuery(
+        '<div id="' +
+          twoincDomHelper.companySummaryId +
+          '" class="twoinc-company-summary hidden">' +
+          '<span class="twoinc-company-summary-name"></span>' +
+          '<span class="twoinc-company-summary-id"></span>' +
+          "</div>"
+      );
+    }
+
     const $wrapper = $field.closest(".twoinc-inp-container");
     $node.insertAfter($wrapper.length ? $wrapper : $field);
     return $node;

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1297,7 +1297,12 @@ let twoincDomHelper = {
 
     let $field = jQuery("#company_id_field");
     if (!$field.length) $field = jQuery("#billing_company_field");
-    if (!$field.length) return isNew ? jQuery() : $node;
+    // Dead ternary removed (round 2 review — Vader): `isNew` is exactly
+    // `!$node.length`, and `$node` is never reassigned before this line, so
+    // `isNew ? jQuery() : $node` and plain `$node` are the same value in
+    // both branches — an equivalent mutant proved it. Reads as if it guards
+    // something it doesn't.
+    if (!$field.length) return $node;
 
     if (isNew) {
       $node = jQuery(

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -162,6 +162,41 @@ describe("read-only captured-company summary", () => {
       expect($("#company_id").val()).toBe("12345678");
     });
 
+    test("self-heals its position after WooCommerce core's own field resort (#30.x.9, found by live post-merge verification)", () => {
+      // Reported live: after picking a company, the summary rendered ABOVE
+      // the company field instead of below it. Root cause, documented in
+      // WC_Twoinc_Checkout.php above move_country_field(): WooCommerce
+      // core's own address-i18n.js detaches and re-appends every
+      // `.form-row` in the billing wrapper by priority, on EVERY checkout
+      // load — not only on country change. This summary is a plain <div>,
+      // not a `.form-row`, so it never takes part in that resort; the OLD
+      // code positioned it once on first creation and never again, so once
+      // WC moved the real fields past it, it stayed stranded above all of
+      // them for the rest of the page's life.
+      pickCompany("ACME Widgets Ltd", "12345678");
+      expect(summary().prev().is("#company_id_field")).toBe(true);
+
+      // Simulate WC's own resort: detach the real fields and re-append them
+      // AFTER the summary — exactly what `rows.detach().appendTo(wrapper)`
+      // does, and exactly the shape of the reported bug (summary now
+      // precedes the fields it's meant to sit below).
+      const $form = $("form[name='checkout']");
+      $("#billing_company_display_field, #billing_company_field, #company_id_field")
+        .detach()
+        .appendTo($form);
+      const children = () => $form.children().toArray();
+      const indexOf = (sel) => children().indexOf($(sel)[0]);
+      expect(indexOf("#" + dom.companySummaryId)).toBeLessThan(indexOf("#billing_company_display_field"));
+
+      // Any subsequent render (payment-method switch, country change,
+      // another pick — toggleBusinessFields is the common path for all of
+      // them) must snap the summary back into place, not leave it stranded.
+      dom.renderCompanySummary();
+
+      expect(summary().prev().is("#company_id_field")).toBe(true);
+      expect(indexOf("#" + dom.companySummaryId)).toBeGreaterThan(indexOf("#billing_company_display_field"));
+    });
+
     test("nothing inside the summary posts a value of its own", () => {
       pickCompany("ACME Widgets Ltd", "12345678");
 

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -186,7 +186,9 @@ describe("read-only captured-company summary", () => {
         .appendTo($form);
       const children = () => $form.children().toArray();
       const indexOf = (sel) => children().indexOf($(sel)[0]);
-      expect(indexOf("#" + dom.companySummaryId)).toBeLessThan(indexOf("#billing_company_display_field"));
+      expect(indexOf("#" + dom.companySummaryId)).toBeLessThan(
+        indexOf("#billing_company_display_field")
+      );
 
       // Any subsequent render (payment-method switch, country change,
       // another pick — toggleBusinessFields is the common path for all of
@@ -194,7 +196,9 @@ describe("read-only captured-company summary", () => {
       dom.renderCompanySummary();
 
       expect(summary().prev().is("#company_id_field")).toBe(true);
-      expect(indexOf("#" + dom.companySummaryId)).toBeGreaterThan(indexOf("#billing_company_display_field"));
+      expect(indexOf("#" + dom.companySummaryId)).toBeGreaterThan(
+        indexOf("#billing_company_display_field")
+      );
     });
 
     test("does not physically move the node when it is already correctly positioned (round 1 review — Han)", () => {

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -197,6 +197,27 @@ describe("read-only captured-company summary", () => {
       expect(indexOf("#" + dom.companySummaryId)).toBeGreaterThan(indexOf("#billing_company_display_field"));
     });
 
+    test("does not physically move the node when it is already correctly positioned (round 1 review — Han)", () => {
+      // Repositioning unconditionally on every call — the first version of
+      // this fix — physically detaches and re-inserts the node even when
+      // nothing has drifted, which collapses any text selection inside the
+      // summary (the only interaction this read-only display affords is
+      // selecting the org number to copy it) and forces an avoidable
+      // reflow. Guarded on `$node.prev()` matching the anchor: spy on
+      // jQuery's own `insertAfter` and assert it is NOT called on an
+      // ordinary re-render once the summary is already positioned right —
+      // a plain node-identity check can't tell "moved but same reference"
+      // from "never touched", since jQuery never clones the element either
+      // way.
+      pickCompany("ACME Widgets Ltd", "12345678");
+
+      const insertAfterSpy = jest.spyOn($.fn, "insertAfter");
+      dom.renderCompanySummary();
+
+      expect(insertAfterSpy).not.toHaveBeenCalled();
+      insertAfterSpy.mockRestore();
+    });
+
     test("nothing inside the summary posts a value of its own", () => {
       pickCompany("ACME Widgets Ltd", "12345678");
 


### PR DESCRIPTION
## Summary

Follow-up to PR #424 (TWO-25324). The mandated post-merge live-verify on woocom-dev.staging.two.inc/checkout/ found a real gap: the company-number summary now renders as a correctly right-aligned block (pixel-confirmed against the input's right edge), but the whole summary block sat **above** the company field instead of below it — failing the literal acceptance criterion for #1.1.

Root cause: `WC_Twoinc_Checkout.php` already documents (in the comments above `move_country_field()` and `sync_locale_country_priority()`) that WooCommerce core's own `address-i18n.js` detaches and re-appends every `.form-row` in the billing wrapper by priority, on **every** checkout load — not only on country change. `getCompanySummaryNode()` positioned the summary `<div>` once, on first creation, and never again — but the summary isn't a `.form-row`, so it never takes part in that resort. Once WC moved the real fields past it, it stayed stranded above all of them for the rest of the page's life. The plugin already carries two established fixes for exactly this mechanism (for the country field); this is the same class of bug for the summary.

Fix: re-run the anchor's `insertAfter` on every `getCompanySummaryNode()` call, not just on creation. `insertAfter` on an already-attached node moves it rather than cloning, so any `renderCompanySummary()` call (pick, payment-method switch, country change, re-render — all of which already call it) snaps the summary back into place, at the cost of one no-op DOM move when nothing has drifted.

## Test plan

- [x] `npm run test:js` — 203/203 passing (added 1 new test)
- [x] New test simulates WooCommerce's own field resort (detach + re-append the real fields past the summary) and asserts the next `renderCompanySummary()` call snaps the summary back into place
- [x] Mutation-verified: reverted the fix, confirmed the new test fails, restored
- [ ] Live-verify post-merge on staging

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>