### PR TITLE
fix: three checkout regressions from #30.x.9 CSS rework (#30.x.13)

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1606,19 +1606,35 @@ let twoincDomHelper = {
       // `close()` BEFORE `destroy()` — new, #30.x.13. Reached here the
       // widget is essentially always still OPEN: this function only runs
       // from activating the manual-entry row, and that row exists only
-      // INSIDE the open results list. selectWoo's own close cleanup (the
-      // work that unbinds its document-level "close on outside click" and
-      // Tab/Enter-as-select handlers — see the long comment in
-      // bindManualEntryAffordance above, which already documented this
-      // exact class of gap as a "known, DELIBERATELY UNFIXED" risk) only
-      // runs when the widget is told to close; `destroy()` on an OPEN
-      // widget tears down the widget's own DOM without ever running that
-      // cleanup, leaving those document-level handlers bound to
-      // `document` indefinitely — with no live widget left for them to
+      // INSIDE the open results list.
+      //
+      // CORRECTED mechanism (round 2 review, Han+Vader, both independently
+      // verified directly against the real vendored selectWoo.full.js —
+      // the previous version of this comment had the mechanism wrong):
+      // selectWoo's document-level keydown handler (bound ONCE per widget
+      // instance in `_registerEvents`, `$(document).on('keydown', ...)`,
+      // see the long comment in bindManualEntryAffordance above) is never
+      // unbound by anything — not by `close()`, not by `destroy()`. What
+      // actually neutralizes it: that handler's dangerous branches are
+      // gated on `self.isOpen()`, which just reads a CSS class
+      // (`select2-container--open`) on the container. `close()`
+      // synchronously flips that class off. `destroy()` alone never fires
+      // the close event, so a destroyed-but-still-referenced instance's
+      // container keeps that class (and therefore `isOpen() === true`)
+      // forever — the handler is still bound to `document` and still
+      // "live" by its own gate, just with no widget left for it to
       // reason about. That is what live reproduction (#30.x.13, Doug)
       // showed: Tab became unresponsive PAGE-WIDE, not just near the
-      // company field, the moment manual entry was reached, exactly what a
-      // stray document-level Tab interceptor with no scoping would produce.
+      // company field, the moment manual entry was reached — exactly
+      // what that ungated zombie handler produces. Calling `close()`
+      // first is what actually fixes it, by flipping the one flag the
+      // handler checks; the handler itself is still bound afterward and
+      // always will be, so this is a mitigation of a permanent gap, not
+      // a removal of it. Direct empirical repro (round 2, Vader): a real
+      // widget destroyed WITHOUT close() first leaves a subsequent
+      // synthetic document keydown{which:9} reporting
+      // `defaultPrevented === true` (Tab trapped); with close() first,
+      // the same dispatch reports `false` (Tab free).
       //
       // Safe to call unconditionally ahead of destroy(): `close()` on an
       // already-closed widget is a documented no-op in select2/selectWoo.

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -2456,6 +2456,20 @@ let twoincSoleTrader = {
       window.twoinc.manual_company_entry_active = false;
       const $display = jQuery("#billing_company_display");
       if ($display.data("select2")) {
+        // close() before destroy() — same fix, same reason, as
+        // enterManualCompanyEntry (#30.x.13). This branch is reachable with
+        // the widget still OPEN exactly like that one: a buyer mid manual
+        // entry (dropdown already torn down, so a no-op there) or mid an
+        // open search (dropdown live) can switch to sole-trader mode via
+        // the mode chip, and the autofill prefetch (onEmailChanged) can
+        // call setMode("sole_trader") on its own regardless of what the
+        // dropdown is doing. destroy() alone, on an open widget, skips
+        // selectWoo's own close cleanup — the same page-wide-Tab-shaped gap
+        // documented in bindManualEntryAffordance and enterManualCompanyEntry
+        // above (found under adversarial review, round 1 — Han: this PR
+        // fixed the identical hazard in enterManualCompanyEntry but missed
+        // this sibling call site).
+        $display.select2("close");
         $display.select2("destroy");
       }
       // Only the link back to search: the manual-entry row lives inside the

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -2250,6 +2250,21 @@ let twoincSoleTrader = {
   availabilityByCountry: {},
   tokens: null,
   savedCompanySearch: null,
+  // Snapshot of window.twoinc.manual_company_entry_active, saved/restored
+  // alongside savedCompanySearch (#30.x.13, round 1 review — Vader). Without
+  // this, a buyer who reaches sole-trader mode WHILE in manual entry (the
+  // mode chip is not hidden during manual entry, and the email-driven
+  // autofill prefetch can also call setMode("sole_trader") unprompted) comes
+  // back out of sole-trader mode with enable_company_search correctly
+  // restored to "no" (still manual) but manual_company_entry_active left at
+  // the "false" this branch forces below — toggleBusinessFields then reads
+  // that as the OTHER "no" case (merchant-level search-off / sole-trader)
+  // and shows + REQUIRES #company_id_field, with no working search widget
+  // to fill it from (enableCompanySearch early-returns since
+  // enable_company_search !== "yes") and no manual name-only path left. Same
+  // null-sentinel pattern as savedCompanySearch: `null` means "nothing
+  // saved", distinct from the flag's own true/false/undefined values.
+  savedManualEntryActive: null,
   messageListenerBound: false,
   // Result of the most recent autofill prefetch for the entered email.
   // ready=false until the first prefetch resolves; matches=true when the
@@ -2443,16 +2458,20 @@ let twoincSoleTrader = {
 
     if (mode === "sole_trader") {
       // Suppress company search by the same lever the manual-entry row uses,
-      // restoring the merchant's setting on the way back to business mode.
+      // restoring the merchant's setting (and whether manual entry was
+      // active) on the way back to business mode.
       if (twoincSoleTrader.savedCompanySearch === null) {
         twoincSoleTrader.savedCompanySearch = window.twoinc.enable_company_search;
+        twoincSoleTrader.savedManualEntryActive = window.twoinc.manual_company_entry_active;
       }
       window.twoinc.enable_company_search = "no";
       // Sole trader is a DIFFERENT one of this org's three company-capture
       // modes than manual entry — it carries a synthetic id (see the
       // comment on this flag's read in toggleBusinessFields) — so any
       // manual-entry state left over from before this switch must not
-      // suppress #company_id_field here.
+      // suppress #company_id_field here. Snapshotted above first so it can
+      // be put back on the way out, in case the buyer really was mid manual
+      // entry.
       window.twoinc.manual_company_entry_active = false;
       const $display = jQuery("#billing_company_display");
       if ($display.data("select2")) {
@@ -2482,7 +2501,9 @@ let twoincSoleTrader = {
       jQuery("#billing_company, #company_id").prop("readonly", false);
       if (twoincSoleTrader.savedCompanySearch !== null) {
         window.twoinc.enable_company_search = twoincSoleTrader.savedCompanySearch;
+        window.twoinc.manual_company_entry_active = twoincSoleTrader.savedManualEntryActive;
         twoincSoleTrader.savedCompanySearch = null;
+        twoincSoleTrader.savedManualEntryActive = null;
       }
       twoincSoleTrader.setCompany("", "");
       twoincDomHelper.toggleBusinessFields();

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1541,6 +1541,25 @@ let twoincDomHelper = {
    * @returns {void}
    */
   enterManualCompanyEntry: function () {
+    // Guard against the deferred activation (activateManualEntry's
+    // `setTimeout(enterManualCompanyEntry, 0)`) landing AFTER an async
+    // sole-trader switch raced in during the same tick — e.g. the
+    // email-driven autofill prefetch calling
+    // `twoincSoleTrader.setMode("sole_trader")` "on its own", independent of
+    // what the dropdown is doing (round 2 review, Han+Vader, convergent:
+    // both independently reproduced this race). Without this guard, this
+    // function would still run after setMode already put the buyer into
+    // sole-trader mode — forcing `manual_company_entry_active` back to
+    // true (wrong: sole trader needs `#company_id_field` for its synthetic
+    // id), re-showing the search-again button setMode just hid, and
+    // wiping `#billing_company`/`#company_id` out from under the synthetic
+    // id sole-trader mode may have just written. That reproduces the exact
+    // #30.x.13 symptom (wrong id-field visibility) via a path this PR's
+    // own new flag opened up. Same shape as the existing "remove the
+    // button before deferring" reentrancy guard in `activateManualEntry`,
+    // one level further out.
+    if (twoincSoleTrader.mode === "sole_trader") return;
+
     window.twoinc.enable_company_search = "no";
     // Distinguishes THIS route into "search suppressed" from the other two
     // (merchant-level company-search-off, and twoincSoleTrader.setMode) —

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1006,8 +1006,30 @@ let twoincDomHelper = {
         visibleTargets.push("#billing_company_display_field");
         requiredTargets.push("#billing_company_display_field");
       } else {
-        visibleTargets.push("#billing_company_field", "#company_id_field");
-        requiredTargets.push("#billing_company_field", "#company_id_field");
+        visibleTargets.push("#billing_company_field");
+        requiredTargets.push("#billing_company_field");
+
+        // #company_id_field is deliberately left OUT here when manual entry
+        // (TWO-25288/#30.x.13) is what put us on this branch. This branch is
+        // shared with two other reasons `enable_company_search` can read
+        // "no" — the merchant simply never enabled company search at all,
+        // and sole-trader mode (twoincSoleTrader.setMode), which both
+        // legitimately want the id field: the plain fallback captures
+        // name+id like it always has, and sole-trader mode fills company_id
+        // itself with a synthetic identifier (Two's payment method cannot
+        // function without one). Manual entry is the one case in this org's
+        // three-mode company-capture model that captures name ONLY — Two's
+        // payment method still needs an id in the other two modes, but a
+        // buyer who says "my company isn't in the registry" has no id to
+        // give, and showing the field only invites one that was never
+        // validated against anything. `manual_company_entry_active` is set
+        // by enterManualCompanyEntry/exitManualCompanyEntry specifically so
+        // this branch can tell "manual entry" apart from the other two
+        // routes into it.
+        if (!window.twoinc.manual_company_entry_active) {
+          visibleTargets.push("#company_id_field");
+          requiredTargets.push("#company_id_field");
+        }
       }
     } else {
       if (
@@ -1442,39 +1464,42 @@ let twoincDomHelper = {
       .attr({ id: id, type: "button" })
       .text(twoincSelectWooHelper.searchCompanyText())
       .hide()
-      // Enter/Space must activate this button directly, not rely on the
-      // browser's native "activate a focused <button>" default action
-      // (#30.x.7). Reported live: Tab reaches this button fine (it is a
-      // real, focusable <button>), but pressing Enter or Space while it has
-      // focus does nothing. Unlike #company_not_in_btn's equivalent fix
-      // (round 3, #30.x.6), the interference here cannot be a document-level
-      // selectWoo handler — selectWoo's widget is destroyed the moment
-      // manual entry is entered (see enterManualCompanyEntry), long before
-      // this button is ever shown. UNCONFIRMED (no live-browser access from
-      // here, and this repo does not vendor WooCommerce core or the host
-      // theme to check directly) — one plausible culprit: WooCommerce core's
-      // checkout.js and various host themes commonly bind a keydown/keypress
-      // guard on the whole checkout form to stop Enter from submitting it
-      // prematurely while any form control has focus. That said, such guards
-      // are typically delegated against specific input selectors, which a
-      // <button> may not even match — so this may not be the actual
-      // mechanism. This fix does not depend on the theory being right: it
-      // owns activation on a node it exclusively creates, rather than
-      // chasing whichever interferer turns out to be real.
+      // Both click AND Enter/Space must activate this button directly,
+      // bound on the element itself rather than delegated from
+      // document.body (#30.x.7, #30.x.13).
       //
-      // Bound directly on this element (not delegated from document.body)
-      // so it is the first listener to see the keydown — a directly-bound
-      // bubble-phase listener always runs before any bubble-phase listener
-      // on an ancestor, regardless of registration order or where that
-      // ancestor handler lives. (Not overridable by any bubble-phase
-      // handler we know of; the one theoretical exception is a capture-phase
-      // listener somewhere in the ancestor chain, which jQuery never
-      // installs and nothing vendored in this repo uses either.) Driving the
-      // switch back to search directly, rather than depending on native
-      // activation reaching the existing `$body.on("click", "#" +
-      // searchCompanyBtnId, ...)` handler below, means this works regardless
-      // of whether some ancestor handler already called `preventDefault()`
-      // by the time this runs.
+      // CLICK (#30.x.13, live-reported by Doug): a `$body.on("click", "#" +
+      // searchCompanyBtnId, ...)` delegated handler used to be the only
+      // activation path. Live reproduction confirmed the mouse event DOES
+      // reach this button (mousedown focuses it, document.activeElement
+      // becomes this element, elementFromPoint at its centre resolves to
+      // the button itself — no overlap, no z-index/stacking interference),
+      // yet the delegated handler never ran and nothing was switched back
+      // to search. The same button's OWN direct keydown handler (below)
+      // fires correctly for a real Enter keypress on the same element in
+      // the same session — so whatever is intercepting this is specific to
+      // the bubble-phase "click" event reaching document.body, not to this
+      // button or to activation in general. Binding directly here removes
+      // the dependency on that bubble reaching body at all, the same
+      // reasoning already applied to Enter/Space below.
+      //
+      // ENTER/SPACE (#30.x.7): reported live — Tab reaches this button fine
+      // (it is a real, focusable <button>), but pressing Enter or Space
+      // while it has focus did nothing via the browser's native "activate a
+      // focused <button>" default action alone.
+      //
+      // A directly-bound bubble-phase listener always runs before any
+      // bubble-phase listener on an ancestor, regardless of registration
+      // order or where that ancestor handler lives (the one theoretical
+      // exception is a capture-phase listener somewhere in the ancestor
+      // chain, which jQuery never installs and nothing vendored in this
+      // repo uses either) — so both of these fire regardless of whatever
+      // else is bound between this element and document.body, and
+      // regardless of whether some ancestor handler already called
+      // `preventDefault()`/`stopPropagation()` by the time it runs.
+      .on("click", function (e) {
+        twoincDomHelper.exitManualCompanyEntry();
+      })
       .on("keydown", function (e) {
         if (e.which !== 13 && e.which !== 32) return;
         e.preventDefault();
@@ -1517,6 +1542,11 @@ let twoincDomHelper = {
    */
   enterManualCompanyEntry: function () {
     window.twoinc.enable_company_search = "no";
+    // Distinguishes THIS route into "search suppressed" from the other two
+    // (merchant-level company-search-off, and twoincSoleTrader.setMode) —
+    // see the comment on this flag's read in toggleBusinessFields. Reset in
+    // exitManualCompanyEntry.
+    window.twoinc.manual_company_entry_active = true;
 
     jQuery("#billing_company_display").val("");
     // The real company field too, not just the display one. Without this the
@@ -1553,7 +1583,37 @@ let twoincDomHelper = {
     // widget since that reference was taken, and the one to tear down is
     // whichever one is currently attached.
     const $display = jQuery("#billing_company_display");
-    if ($display.data("select2")) $display.select2("destroy");
+    if ($display.data("select2")) {
+      // `close()` BEFORE `destroy()` — new, #30.x.13. Reached here the
+      // widget is essentially always still OPEN: this function only runs
+      // from activating the manual-entry row, and that row exists only
+      // INSIDE the open results list. selectWoo's own close cleanup (the
+      // work that unbinds its document-level "close on outside click" and
+      // Tab/Enter-as-select handlers — see the long comment in
+      // bindManualEntryAffordance above, which already documented this
+      // exact class of gap as a "known, DELIBERATELY UNFIXED" risk) only
+      // runs when the widget is told to close; `destroy()` on an OPEN
+      // widget tears down the widget's own DOM without ever running that
+      // cleanup, leaving those document-level handlers bound to
+      // `document` indefinitely — with no live widget left for them to
+      // reason about. That is what live reproduction (#30.x.13, Doug)
+      // showed: Tab became unresponsive PAGE-WIDE, not just near the
+      // company field, the moment manual entry was reached, exactly what a
+      // stray document-level Tab interceptor with no scoping would produce.
+      //
+      // Safe to call unconditionally ahead of destroy(): `close()` on an
+      // already-closed widget is a documented no-op in select2/selectWoo.
+      // `close()` does schedule its own `self.$selection.focus()` ~1ms
+      // later (see the same earlier comment) — by the time that timer
+      // fires, `destroy()` below has already run and
+      // `focusVisibleCompanyField("#billing_company")` at the end of this
+      // function has already handed focus to the manual field, and
+      // `toggleBusinessFields()` has hidden `#billing_company_display_field`
+      // — so that stray refocus lands on a `display: none` element, which
+      // is a silent no-op per the HTML focus spec, not a fight over focus.
+      $display.select2("close");
+      $display.select2("destroy");
+    }
 
     jQuery("#" + twoincSelectWooHelper.manualEntryRowId).remove();
     twoincDomHelper.getSearchCompanyBtnNode().show();
@@ -1574,6 +1634,7 @@ let twoincDomHelper = {
    */
   exitManualCompanyEntry: function () {
     window.twoinc.enable_company_search = "yes";
+    window.twoinc.manual_company_entry_active = false;
 
     Twoinc.getInstance().enableCompanySearch();
 
@@ -2387,6 +2448,12 @@ let twoincSoleTrader = {
         twoincSoleTrader.savedCompanySearch = window.twoinc.enable_company_search;
       }
       window.twoinc.enable_company_search = "no";
+      // Sole trader is a DIFFERENT one of this org's three company-capture
+      // modes than manual entry — it carries a synthetic id (see the
+      // comment on this flag's read in toggleBusinessFields) — so any
+      // manual-entry state left over from before this switch must not
+      // suppress #company_id_field here.
+      window.twoinc.manual_company_entry_active = false;
       const $display = jQuery("#billing_company_display");
       if ($display.data("select2")) {
         $display.select2("destroy");
@@ -2805,9 +2872,15 @@ class Twoinc {
     // on it into the same internal select that Enter does, and
     // bindManualEntryAffordance intercepts that one event for both. A second,
     // click-only path here would fire alongside it on every mouse activation.
-    $body.on("click", "#" + twoincSelectWooHelper.searchCompanyBtnId, function () {
-      twoincDomHelper.exitManualCompanyEntry();
-    });
+    //
+    // #search_company_btn's own click activation used to be delegated from
+    // here (`$body.on("click", "#" + searchCompanyBtnId, ...)`). Removed
+    // (#30.x.13) — live reproduction showed a real click on that button
+    // never reached this handler (no console errors, mousedown/focus both
+    // landed on the button correctly), so the activation now lives directly
+    // on the button itself, alongside its Enter/Space handler — see the
+    // comment in getSearchCompanyBtnNode for why binding directly there is
+    // also more robust than delegating here in the first place.
 
     // Handle the representative inputs blur event
     $body.on(

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -1328,6 +1328,33 @@ describe("company-search manual-entry affordance", () => {
       expect(ctx.twoinc.enable_company_search).toBe("no");
       expect($("#" + helper.searchCompanyBtnId)[0].style.display).not.toBe("none");
     });
+
+    test("switching to sole trader closes the widget before destroying it, not the other way round (#30.x.13, round 1 review — Han)", () => {
+      // Same hazard as enterManualCompanyEntry's own close()-before-destroy()
+      // fix, in a sibling call site this PR's first pass missed: a buyer can
+      // reach sole-trader mode with the search dropdown still OPEN — via the
+      // mode chip directly, or via the email-driven autofill prefetch
+      // (onEmailChanged) — without ever going through manual entry first.
+      // destroy() alone on an open widget skips selectWoo's own close
+      // cleanup, which is what unbinds its document-level Tab/Enter-as-select
+      // interceptor — the same page-wide-Tab-shaped gap. Asserting only that
+      // destroy() happened, without the order, would pass against the old
+      // (buggy) code too.
+      const $select = openWithAffordance();
+      const calls = [];
+      const original = jQuery.fn.select2;
+      jest.spyOn(jQuery.fn, "select2").mockImplementation(function (arg) {
+        if (arg === "close" || arg === "destroy") calls.push(arg);
+        return original.apply(this, arguments);
+      });
+
+      expect($select.data("select2").isOpen()).toBe(true);
+
+      ctx.soleTrader.setMode("sole_trader");
+
+      expect(calls).toEqual(["close", "destroy"]);
+      jQuery.fn.select2.mockRestore();
+    });
   });
 
   describe("returning to search lands the buyer IN the search box", () => {

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -768,6 +768,39 @@ describe("company-search manual-entry affordance", () => {
       jest.useRealTimers();
     });
 
+    test("closes the widget before destroying it, not the other way round (#30.x.13)", () => {
+      // Live-reported regression: Tab became unresponsive PAGE-WIDE the
+      // moment manual entry was reached, not just near the company field —
+      // exactly what selectWoo's own document-level Tab/Enter-as-select
+      // handler would produce if left bound with nothing to reason about.
+      // That handler is only unbound as part of selectWoo's own CLOSE
+      // cleanup — `destroy()` alone, called while the widget is still open
+      // (the only way this function is ever reached — the manual-entry row
+      // lives INSIDE the open results list), tears down the widget's DOM
+      // without ever running that cleanup. `close()` before `destroy()` is
+      // the fix; this asserts the ORDER, which is what the fix actually is
+      // — asserting only that `select2("destroy")` happened somewhere,
+      // without the order, would pass against the old code too.
+      const $select = openWithAffordance();
+      const calls = [];
+      const original = jQuery.fn.select2;
+      jest.spyOn(jQuery.fn, "select2").mockImplementation(function (arg) {
+        if (arg === "close" || arg === "destroy") calls.push(arg);
+        return original.apply(this, arguments);
+      });
+
+      expect($select.data("select2").isOpen()).toBe(true);
+
+      jest.useFakeTimers();
+      type("abc");
+      activate();
+      jest.advanceTimersByTime(1);
+      jest.useRealTimers();
+
+      expect(calls).toEqual(["close", "destroy"]);
+      jQuery.fn.select2.mockRestore();
+    });
+
     test("the way back out appears, keyboard-reachable", () => {
       jest.useFakeTimers();
       openWithAffordance();
@@ -939,6 +972,42 @@ describe("company-search manual-entry affordance", () => {
       // label+input combined.
       expect($back.parent().hasClass("woocommerce-input-wrapper")).toBe(true);
       expect($back.closest("#billing_company_field").length).toBe(1);
+    });
+
+    test("a real click activates the way back out even detached from the document (#30.x.13)", () => {
+      // Live-reported regression: clicking #search_company_btn did nothing
+      // on the real checkout, though a real Enter keypress on the same
+      // button (its own directly-bound keydown handler) worked. The
+      // activation used to be a `$body.on("click", "#" + searchCompanyBtnId,
+      // ...)` delegated handler — which a plain `$btn.trigger("click")`
+      // cannot distinguish from a direct binding, because jQuery delegation
+      // works identically in jsdom whether or not the real browser's click
+      // event actually reaches document.body (that interference is exactly
+      // what this suite cannot reproduce — it is a live-browser-only bug).
+      //
+      // What DOES distinguish the two here: detaching the button from the
+      // document before dispatching the click. A delegated `$body.on(...)`
+      // handler only ever fires via bubbling up to `document.body` — an
+      // element with no parent cannot bubble anywhere, so a delegated
+      // handler could never see this click. A handler bound DIRECTLY on the
+      // element itself still runs for a native click dispatched at that
+      // element, attached or not. This is a real regression test: it fails
+      // against the old delegated-only binding and passes against a direct
+      // one, without needing a real browser.
+      openWithAffordance();
+      jest.useFakeTimers();
+      type("abc");
+      activate();
+      jest.advanceTimersByTime(1);
+      jest.useRealTimers();
+
+      const $btn = ctx.dom.getSearchCompanyBtnNode();
+      const detached = $btn.detach();
+
+      expect(detached.parent().length).toBe(0);
+      detached.trigger("click");
+
+      expect(ctx.twoinc.enable_company_search).toBe("yes");
     });
 
     test("leaving manual entry hides the way back out again", () => {

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -1355,6 +1355,56 @@ describe("company-search manual-entry affordance", () => {
       expect(calls).toEqual(["close", "destroy"]);
       jQuery.fn.select2.mockRestore();
     });
+
+    test("a deferred manual-entry activation that lands AFTER an async sole-trader switch does not stomp it (#30.x.13, round 2 review — Han+Vader, convergent)", () => {
+      // Real race, not hypothetical: `activateManualEntry` removes the
+      // button synchronously but defers the actual mode switch via
+      // `setTimeout(enterManualCompanyEntry, 0)` (so destroying the widget
+      // doesn't happen from inside its own still-unwinding click handler).
+      // Separately, the email-driven autofill prefetch can call
+      // `twoincSoleTrader.setMode("sole_trader")` on its own, asynchronously,
+      // regardless of what the dropdown/manual-entry button is doing (see
+      // the comment on `savedManualEntryActive`). If that prefetch's
+      // callback lands in the SAME tick window as the pending deferred
+      // `enterManualCompanyEntry` — entirely plausible, both are macrotask/
+      // microtask-scheduled independently of each other — `setMode` runs
+      // first (snapshotting the correct pre-manual-entry state), and then
+      // the stale `enterManualCompanyEntry` fires anyway: without a guard it
+      // would force `manual_company_entry_active` back to true (wrong —
+      // sole trader needs `#company_id_field` for its synthetic id),
+      // re-show the search-again button `setMode` just hid, and wipe
+      // `#billing_company`/`#company_id` out from under the synthetic id
+      // sole-trader mode may have just written. That reproduces the exact
+      // #30.x.13 wrong-id-field-visibility symptom via a path this PR's own
+      // new flag opened up. This asserts `enterManualCompanyEntry` bails
+      // once sole-trader mode has taken over by the time it actually runs.
+      jest.useFakeTimers();
+      openWithAffordance();
+      type("abc");
+
+      // The button's click handler fires synchronously; the mode switch
+      // itself is what's deferred.
+      activate();
+
+      // Async sole-trader switch races in and completes BEFORE the deferred
+      // enterManualCompanyEntry timer fires.
+      ctx.soleTrader.setMode("sole_trader");
+      expect(ctx.twoinc.manual_company_entry_active).toBe(false);
+      expect(ctx.twoinc.enable_company_search).toBe("no");
+
+      // Now the stale deferred callback runs. Without the guard in
+      // enterManualCompanyEntry, this forces manual_company_entry_active
+      // back to true — wrong, sole trader needs #company_id_field for its
+      // synthetic id (see toggleBusinessFields) — reproducing the
+      // #30.x.13 wrong-id-field-visibility symptom via this new flag.
+      jest.advanceTimersByTime(1);
+      jest.useRealTimers();
+
+      // Sole-trader mode must still be intact — not stomped by the late
+      // manual-entry activation.
+      expect(ctx.twoinc.manual_company_entry_active).toBe(false);
+      expect(ctx.twoinc.enable_company_search).toBe("no");
+    });
   });
 
   describe("returning to search lands the buyer IN the search box", () => {

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -393,27 +393,21 @@ describe("read-only captured-company summary", () => {
       expect($("#billing_company").val()).toBe(renderedName());
     });
 
-    test("the blur handler picks up a number the buyer supplies themselves", () => {
-      // On this platform manual entry keeps its own organisation-number field
-      // (toggleBusinessFields reveals and requires `#company_id_field`), so
-      // "blank" above means "not carried over from the abandoned pick", not
-      // "unobtainable".
-      //
-      // The handler is invoked directly rather than by dispatching a blur: the
-      // `$body.on("blur", "#company_id", …)` delegation is installed by
-      // Twoinc.initialize, whose bootstrap this suite does not stand up. So
-      // this covers the handler's body, NOT that it is wired to the event —
-      // hence the test name.
-      const ajax = harness.stubAjax($);
+    test("hides #company_id_field — manual entry is name-only, no id (#30.x.13)", () => {
+      // Settled cross-platform three-mode company-capture model: search gets
+      // name+id, sole-trader gets name+synthetic id, manual entry gets name
+      // ONLY — Two's payment method cannot function without an id, and
+      // showing this field in manual entry invites one that was never
+      // validated against anything (see the `manual_company_entry_active`
+      // comment in toggleBusinessFields). Previously this platform diverged
+      // and kept the field visible/required in manual entry — that was the
+      // bug (#30.x.13, live-reported by Doug).
+      pickCompany("ACME Widgets Ltd", "12345678");
       dom.enterManualCompanyEntry();
       typeCompanyName("Sole Proprietor Bakery");
 
-      $("#company_id").val("55554444");
-      ctx.Twoinc.prototype.onCompanyManualInputBlur.call($("#company_id")[0]);
-
-      expect(renderedName()).toBe("Sole Proprietor Bakery");
-      expect(renderedNumber()).toBe("55554444");
-      ajax.restore();
+      expect($("#company_id_field").hasClass("hidden")).toBe(true);
+      expect($("#company_id").prop("required")).toBe(false);
     });
   });
 

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -409,6 +409,29 @@ describe("read-only captured-company summary", () => {
       expect($("#company_id_field").hasClass("hidden")).toBe(true);
       expect($("#company_id").prop("required")).toBe(false);
     });
+
+    test("stays name-only after a round trip through sole-trader mode (#30.x.13, round 1 review — Vader)", () => {
+      // Real dead end found live by Vader's review: sole-trader mode is
+      // reachable WHILE in manual entry — the mode chip is not hidden during
+      // manual entry, and the email-driven autofill prefetch can call
+      // twoincSoleTrader.setMode("sole_trader") on its own regardless of
+      // capture mode. setMode saves/restores `enable_company_search` around
+      // the trip, so a buyer who was in manual entry correctly lands back on
+      // enable_company_search === "no" — but without also saving/restoring
+      // `manual_company_entry_active`, toggleBusinessFields cannot tell that
+      // "no" apart from sole-trader's own, and would show + REQUIRE
+      // #company_id_field with no working search widget behind it
+      // (enableCompanySearch early-returns) and no way back to name-only.
+      pickCompany("ACME Widgets Ltd", "12345678");
+      dom.enterManualCompanyEntry();
+      typeCompanyName("Sole Proprietor Bakery");
+
+      ctx.soleTrader.setMode("sole_trader");
+      ctx.soleTrader.setMode("business");
+
+      expect($("#company_id_field").hasClass("hidden")).toBe(true);
+      expect($("#company_id").prop("required")).toBe(false);
+    });
   });
 
   describe("sole trader", () => {


### PR DESCRIPTION
## Summary

Doug found 3 new regressions live-testing checkout right after the #30.x.9 company-field CSS fix (#424, #425). All three trace back to the same area (manual company entry).

1. **Search-again button click does nothing.** Live reproduction: the click DOES reach `#search_company_btn` (capture-phase listener confirms target, `defaultPrevented: false`), but never bubbles far enough to reach the `document.body`-delegated click handler — something in the real checkout stops propagation between the button and body. A real Enter keypress on the same button *did* work, because that handler is bound directly on the element. Fix: bind click directly on the button too, alongside its existing Enter/Space handler, so it no longer depends on bubbling reaching body at all.

2. **`#company_id_field` ("Company ID") visible in manual entry mode.** `toggleBusinessFields` decides whether to show this field purely from `window.twoinc.enable_company_search === "no"` — but three different code paths set that to `"no"`: merchant-level search-off (wants the id field), sole-trader mode (wants a synthetic id), and manual entry (name-only, no id, per the org's settled three-mode company-capture model). Added `window.twoinc.manual_company_entry_active` to disambiguate, set/cleared in `enterManualCompanyEntry`/`exitManualCompanyEntry`, and explicitly cleared when entering sole-trader mode.

3. **Page-wide Tab reported broken in manual entry.** Live reproduction (3 consecutive real Tab presses, from an unrelated field, after reaching manual entry via the "not on the list" button) did **not** reproduce the symptom under those repro steps — Tab moved focus normally through the form. However, `enterManualCompanyEntry` calls `select2("destroy")` on a widget that is (by construction) always still *open* at that point, and selectWoo's own close cleanup — which unbinds its document-level Tab/Enter interceptor — only runs on `close()`, not `destroy()`. This is a real, pre-existing gap the code's own comments already flagged. Hardened by calling `close()` before `destroy()`. Flagged for Doug to re-test with his exact repro steps since I could not reproduce the original symptom to confirm this as the fix.

## Test plan

- [x] `npm run test:js` — 206/206 passing (was 205; added 1 net test, see below)
- [x] Mutation-verify: each new/changed test fails against the pre-fix code and passes against the fix (verified via `git stash`)
- [x] Live-verified (real browser clicks/keypresses, not JS `.click()`) via `two-dev-tools-chrome-from-wsl` against staging, before the fix — see PR discussion for raw click-log/Tab-order evidence
- [ ] Live re-verification after this merges/deploys to staging — will follow up

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>