### PR TITLE
fix(company-search): five checkout-control defects from the TWO-25326 checklist [DRAFT — not live-verified]

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -149,13 +149,19 @@
 }
 
 /*
- * Read-only summary of the captured company (TWO-25288).
+ * Read-only label carrying the captured company NUMBER (TWO-25288; narrowed
+ * from name+number to number-only by TWO-25326 §7).
  *
  * Replaces the floating company-id overlay, which was absolutely positioned
  * over the picker's selection box and so could only ever hold one short value.
- * This sits in normal flow underneath the company fields and carries both the
- * name and the number, so neither has to compete with the other for the same
- * few pixels of the combobox.
+ * This sits in normal flow underneath the company fields, where §5 requires
+ * the number to be.
+ *
+ * The captured NAME no longer renders here. §7 rules out any company name or
+ * number text in the address area beyond the company-name field itself and
+ * this number label — the name was a second copy of what the control directly
+ * above already shows. It moved to the payment tile
+ * (`.twoinc-company-tile-label`).
  */
 .twoinc-company-summary {
   padding-bottom: 15px;
@@ -169,20 +175,6 @@
   padding-left: 3px;
   padding-right: 3px;
   line-height: 1.4;
-}
-
-.twoinc-company-summary-name {
-  font-weight: 600;
-  display: block;
-  /*
-   * Round 1 review (Vader): a single unbroken token — routine in DE/NL/NO
-   * registry names — would otherwise overflow the row horizontally instead
-   * of wrapping. `anywhere` rather than `break-word`: it also allows a break
-   * before the first character of an overflowing word, which `break-word`
-   * does not, so a name that alone is wider than the field still wraps
-   * rather than escaping the box.
-   */
-  overflow-wrap: anywhere;
 }
 
 /*
@@ -594,6 +586,35 @@
   margin: 12px 0;
 }
 .twoinc-sole-trader-toggle.hidden {
+  display: none;
+}
+
+/*
+ * The captured company, as `<name> (<number>)`, in the payment tile
+ * (TWO-25326 §7).
+ *
+ * A text label, deliberately styled as one: no border, no background, nothing
+ * that reads as a control. The buyer cannot act on this — it restates what
+ * they already picked in the address form — and anything that looks clickable
+ * here invites them to try to edit it in the tile, which is the exact failure
+ * mode the ticket records against the Magento implementations.
+ *
+ * Semibold rather than a colour change, so it stays legible on any brand
+ * overlay's tile background without this rule having to know what colour that
+ * is.
+ *
+ * `overflow-wrap: anywhere` for the same reason the number label under the
+ * address field carries it: registry names in DE/NL/NO routinely contain a
+ * single unbroken token longer than the tile is wide, and the tile is
+ * narrower than the address column.
+ */
+.twoinc-company-tile-label {
+  margin: 12px 0;
+  font-weight: 600;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+.twoinc-company-tile-label.hidden {
   display: none;
 }
 .twoinc-mode-selector {

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -690,7 +690,7 @@ let twoincSelectWooHelper = {
       if (this.tabIndex < 0) return;
       if (jQuery(this).closest(".select2-container--open, .select2-dropdown").length) return;
       if (twoincSelectWooHelper.isHiddenForTabbing(this)) return;
-      if (!(anchor.compareDocumentPosition(this) & 4 /* DOCUMENT_POSITION_FOLLOWING */)) return;
+      if (!((anchor.compareDocumentPosition(this) & 4) /* DOCUMENT_POSITION_FOLLOWING */)) return;
       next = this;
     });
 

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -254,26 +254,47 @@ let twoincSelectWooHelper = {
    * results list lives in — so it reads as part of the same panel, just
    * beneath the scrollable area rather than the last row inside it.
    *
-   * Visibility rule unchanged from the pseudo-option version: the search
-   * threshold and nothing else — no "has a search completed" gate. The
-   * button appears the moment the buyer has typed enough for a search to be
-   * worth running, which is BEFORE the debounced request goes out, so a
-   * buyer who already knows their company is not in the registry never has
-   * to wait for a round trip to find that out.
+   * Visibility rule is "search UI active and nothing captured yet", NOT the
+   * search threshold (TWO-25326 §2, found live 2026-08-02).
+   *
+   * It used to be the threshold and nothing else, which meant the button did
+   * not exist in the DOM at all until the buyer had typed three characters.
+   * Doug's requirement is the opposite: a buyer who already knows their
+   * company is not in the registry must have a route into manual entry
+   * WITHOUT typing a doomed query first, so the button is present from the
+   * moment the dropdown opens. `bindManualEntryAffordance` therefore also
+   * calls this on `select2:open`, not only on `input` — with a threshold gate
+   * an open-with-nothing-typed dropdown had nothing to sync.
+   *
+   * The one thing that DOES hide it is a company already being captured: the
+   * gate reads the display select's own value, which is written by the
+   * picker's select handler and cleared by `clearSelectedCompany`. A buyer
+   * who picks a company and then reopens the dropdown to change it is past
+   * the point where "not on the list" means anything, and the ticket calls
+   * that state out explicitly.
+   *
+   * Note this leaves the button in the dropdown's subtree while the dropdown
+   * is closed. That is not a stray tab-stop: selectWoo's AttachBody decorator
+   * DETACHES the whole dropdown container from the document on close, so a
+   * node inside it is not focusable, not rendered and not reachable by Tab
+   * until the dropdown is attached again.
    *
    * @returns {void}
    */
   syncManualEntryButton: function () {
     const helper = twoincSelectWooHelper;
 
-    const picker = jQuery("#billing_company_display").data("select2");
+    const $display = jQuery("#billing_company_display");
+    const picker = $display.data("select2");
     if (!picker || !picker.$results || !picker.$results.length) return;
 
     const $list = picker.$results;
     const $existing = jQuery("#" + helper.manualEntryRowId);
-    const term = jQuery(helper.companySearchInputSelector).val() || "";
 
-    if (term.length < helper.companySearchMinLength) {
+    // The empty option's label is a non-breaking space, so an unselected
+    // picker reads back as " " rather than "" — the same trap
+    // renderCompanySummary documents. blankToEmpty collapses both.
+    if (twoincUtilHelper.blankToEmpty($display.val())) {
       $existing.remove();
       return;
     }
@@ -319,6 +340,28 @@ let twoincSelectWooHelper = {
       .off("input.twoincManualEntry")
       .on("input.twoincManualEntry", helper.companySearchInputSelector, function () {
         helper.syncManualEntryButton();
+      });
+
+    // Open, as well as input (TWO-25326 §2). The button's visibility rule is
+    // no longer "the buyer has typed enough", so an `input` handler alone can
+    // never place it: a buyer who opens the dropdown and types nothing fires
+    // no input event at all, and that is precisely the case the requirement
+    // is about.
+    //
+    // Delegated on <body> keyed on the SELECT, not bound to the select2
+    // instance, for the same reason the two handlers above are: the instance
+    // is thrown away and rebuilt by `clearSelectedCompany` and by every
+    // return out of manual entry, and a handler bound to an instance dies
+    // with it. `select2:open` is a jQuery event triggered on the original
+    // <select>, so it bubbles to <body> like any other.
+    //
+    // Deferred a tick: `select2:open` fires while the open is still
+    // unwinding, and `syncManualEntryButton` needs the results list to be its
+    // post-open self before it anchors anything after it.
+    jQuery(document.body)
+      .off("select2:open.twoincManualEntry")
+      .on("select2:open.twoincManualEntry", "#billing_company_display", function () {
+        setTimeout(helper.syncManualEntryButton, 0);
       });
 
     // Tab-to-button shortcut (#30.x.6).
@@ -434,36 +477,46 @@ let twoincSelectWooHelper = {
     // the buyer is trapped AND a wrong company gets silently selected
     // underneath them.
     //
-    // Fixed the same way as the shortcut above — `stopPropagation` to keep
-    // selectWoo's document handler from ever seeing this keydown — but
-    // deliberately WITHOUT `preventDefault` this time: the whole point here
-    // is to let the browser's own native Tab traversal proceed to whatever
-    // the next real tab-stop is, in either direction (this button carries no
-    // special Shift+Tab behaviour, so both directions get the same
-    // protection).
+    // `stopPropagation` keeps selectWoo's document handler from ever seeing
+    // this keydown. That alone is not enough, and the previous revision of
+    // this handler stopped there — which left the two defects TWO-25326 §1
+    // and §4 record against WC, both confirmed live 2026-08-02:
     //
-    // A known, DELIBERATELY UNFIXED gap this surfaces rather than causes,
-    // found under adversarial review: selectWoo never actually clears
-    // `isOpen()` on keyboard-only focus-away — nothing but Escape, a result
-    // pick, or a `mousedown` anywhere outside the widget closes it
-    // (`_attachCloseHandler` in the vendored bundle). A buyer who reaches
-    // this button by keyboard and then keeps tabbing onward, without ever
-    // clicking anything, leaves the dropdown "open" indefinitely — every
-    // later Tab/Enter/Escape ANYWHERE on the page, including Enter on the
-    // checkout submit button, still gets caught by selectWoo's unscoped
-    // document handler until a stray click finally closes it. This predates
-    // this feature; this fix just makes it reachable for the first time
-    // (Tab could never actually escape the open dropdown at all before this
-    // PR, so nobody could reach "focus outside + still open" via keyboard).
-    // Deliberately NOT calling `.select2('close')` here to plug it: that
-    // triggers selectWoo's own `container.on('close', ...)` handler, which
-    // schedules `self.$selection.focus()` 1ms later UNCONDITIONALLY — which
-    // would yank focus straight back from wherever the buyer just legitimately
-    // tabbed to, reintroducing the exact keyboard trap #416 (#30.x.4) was
-    // written to fix, just one level further out. A real fix needs
-    // selectWoo's own close-on-blur gap addressed generally, not patched
-    // per-field here — flagged to Doug as a candidate follow-up ticket rather
-    // than attempted blind.
+    //   1. The dropdown stayed open. selectWoo never clears `isOpen()` on
+    //      keyboard-only focus-away — nothing but Escape, a result pick, or a
+    //      `mousedown` outside the widget closes it (`_attachCloseHandler` in
+    //      the vendored bundle) — so every later Tab/Enter/Escape ANYWHERE on
+    //      the page, including Enter on the checkout submit button, kept
+    //      getting caught by selectWoo's unscoped document handler until a
+    //      stray click finally closed it.
+    //   2. Native Tab from here does not reach the next form field. The
+    //      dropdown is attached to the END of <body> by selectWoo's AttachBody
+    //      decorator, so this button is the last tabbable element in the
+    //      document: plain Tab fell off the end of the page and landed on
+    //      <body>. Measured, not assumed.
+    //
+    // Both are fixed together, because fixing either alone cannot work. Tab
+    // is now `preventDefault`ed and driven by hand: resolve the next real
+    // tab-stop after the company-name control FIRST (while the dropdown is
+    // still up and the anchor is still in the document), then close, then
+    // focus it.
+    //
+    // The re-assert on a timer is the part that earns its keep. Closing fires
+    // selectWoo's own `container.on('close', ...)`, which schedules
+    // `self.$selection.focus()` ~1ms later UNCONDITIONALLY — the exact
+    // behaviour the previous revision cited as its reason not to close at all,
+    // since it yanks focus back from wherever the buyer legitimately went.
+    // Rather than avoid the close, outlast the steal: re-focus the intended
+    // target just past that window, and only if the steal actually won, so a
+    // buyer who has moved on under their own steam is never fought. That
+    // "only if it won" guard is the same shape as the one the search-field
+    // Tab shortcut above already uses against selectWoo's other timer.
+    //
+    // Shift+Tab is deliberately untouched (beyond `stopPropagation`): reverse
+    // Tab from here should go back to the query field, which sits immediately
+    // before this button inside the same dropdown, and native traversal
+    // already does exactly that. Hijacking it would close the dropdown the
+    // buyer is trying to move back into.
     // Enter and Space, pressed while the button itself has focus, need the
     // exact same protection as Tab above and for the exact same reason
     // (#30.x.6, round 3) — found live: Doug reported Enter and Space both
@@ -501,6 +554,24 @@ let twoincSelectWooHelper = {
       .on("keydown.twoincManualEntryButton", "#" + helper.manualEntryRowId, function (e) {
         if (e.which !== 9 && e.which !== 13 && e.which !== 32) return;
         e.stopPropagation();
+
+        // Enter and Space stop here: their native "activate a focused
+        // <button>" default action must still run so this button's own click
+        // handler fires. Shift+Tab stops here too — see above.
+        if (e.which !== 9 || e.shiftKey) return;
+
+        // Resolved BEFORE the close, while the company-name control this is
+        // measured from is still the one on screen.
+        const next = helper.nextTabbableAfterCompanyField();
+
+        e.preventDefault();
+        helper.closeCompanySearchDropdown();
+
+        if (!next) return;
+        next.focus();
+        setTimeout(function () {
+          if (document.activeElement !== next) next.focus();
+        }, 20);
       });
     // NOTE: #search_company_btn's equivalent Enter/Space fix (round 4,
     // #30.x.7, in getSearchCompanyBtnNode) looks different on purpose — it
@@ -510,6 +581,150 @@ let twoincSelectWooHelper = {
     // interferers (selectWoo's document handler here; something unconfirmed
     // and external there, since selectWoo isn't even alive at that point),
     // so the fix shape differs — see that function's own comment.
+  },
+
+  /**
+   * Close the company-search dropdown, if one is open (TWO-25326).
+   *
+   * Goes through the instance rather than `.select2('close')` so it is a
+   * no-op — not a thrown "select2 is not a function" — on a page where the
+   * widget was never attached, which is every page the buyer reaches with
+   * company search disabled.
+   *
+   * @returns {void}
+   */
+  closeCompanySearchDropdown: function () {
+    const picker = jQuery("#billing_company_display").data("select2");
+    if (picker && typeof picker.close === "function") picker.close();
+  },
+
+  /**
+   * Elements the browser will stop on during Tab traversal.
+   *
+   * Deliberately a superset — `[tabindex]` catches both the select2 combobox
+   * span (`tabindex="0"`, not a natively focusable element) and rows that
+   * carry `tabindex="-1"` to opt OUT — which is why the caller filters on the
+   * live `tabIndex` property rather than trusting the selector alone.
+   */
+  tabbableSelector:
+    "a[href], area[href], input:not([disabled]):not([type=hidden]), " +
+    "select:not([disabled]), textarea:not([disabled]), button:not([disabled]), " +
+    "iframe, object, embed, [tabindex], [contenteditable]",
+
+  /**
+   * Is this element hidden, for the purpose of choosing a Tab target?
+   *
+   * Deliberately NOT jQuery's `:visible`. That is the more accurate answer in
+   * a browser and the wrong tool here for one reason: it is a LAYOUT query
+   * (`offsetWidth || offsetHeight || getClientRects().length`), and jsdom
+   * implements no layout at all, so under Jest it reports every element in
+   * the document as hidden. A caller filtered on `:visible` would find no tab
+   * target ever, and the test proving the fix works would pass against a
+   * function that always returns null.
+   *
+   * The three checks below are the ways this checkout actually hides a field,
+   * and all of them are readable without layout:
+   *
+   *   - the `hidden` CLASS on the field or any ancestor — the plugin's and
+   *     WooCommerce's own convention, and how every company field on this
+   *     form is toggled (`#billing_company_field.hidden`, the tile's boxes,
+   *     `toggleBusinessFields`);
+   *   - the `hidden` ATTRIBUTE, for anything a theme hides declaratively;
+   *   - an inline `display: none`, for anything hidden by a script.
+   *
+   * The residual gap is a field hidden by a stylesheet rule that is neither
+   * of those — a theme with its own `.foo { display: none }`. Landing focus
+   * on such a field would be wrong, but it fails safe: the buyer sees focus
+   * apparently vanish and Tabs again, which is where they were before this
+   * function existed. Worth revisiting if a theme is ever found doing it.
+   *
+   * @param {HTMLElement} el
+   * @returns {boolean}
+   */
+  isHiddenForTabbing: function (el) {
+    const $el = jQuery(el);
+    if ($el.closest(".hidden, [hidden]").length) return true;
+    return Boolean(el.style && el.style.display === "none");
+  },
+
+  /**
+   * The next real tab-stop after the company-name control (TWO-25326 §4).
+   *
+   * Needed because the dropdown is not where the buyer thinks it is: selectWoo
+   * attaches it to the END of `<body>`, so native Tab out of anything inside
+   * it walks off the end of the document instead of continuing through the
+   * address form. To put focus where the buyer expects it, the traversal has
+   * to be recomputed from the control's position in the FORM, not from the
+   * focused element's position in the document.
+   *
+   * Anchored on the select2 combobox in search mode and on `#billing_company`
+   * otherwise, so the same function answers correctly in both capture modes.
+   *
+   * Everything inside an open select2 is excluded from the candidate list.
+   * Without that the answer would be the query field or this very button —
+   * both of which follow the anchor in document order, both of which are
+   * about to be detached by the close, and neither of which is "the next
+   * control in the tab order" in any sense the buyer would recognise.
+   *
+   * Uses `compareDocumentPosition` rather than an index into the candidate
+   * list on purpose: selectWoo flips the combobox's own `tabindex` while the
+   * dropdown is open, so the anchor is not reliably a member of the list it
+   * is being located within, and an index lookup would return -1 exactly when
+   * this is called.
+   *
+   * @returns {HTMLElement|null} the element to focus, or null if there is
+   *   nothing after the company field (last control on the page)
+   */
+  nextTabbableAfterCompanyField: function () {
+    let $anchor = jQuery("#billing_company_display_field").find(".select2-selection").first();
+    if (!$anchor.length) $anchor = jQuery("#billing_company").first();
+    if (!$anchor.length) return null;
+
+    const anchor = $anchor.get(0);
+    let next = null;
+
+    // jQuery returns a multi-element selector's matches in document order, so
+    // the FIRST candidate that follows the anchor is the one Tab would reach.
+    jQuery(twoincSelectWooHelper.tabbableSelector).each(function () {
+      if (next) return;
+      if (this.tabIndex < 0) return;
+      if (jQuery(this).closest(".select2-container--open, .select2-dropdown").length) return;
+      if (twoincSelectWooHelper.isHiddenForTabbing(this)) return;
+      if (!(anchor.compareDocumentPosition(this) & 4 /* DOCUMENT_POSITION_FOLLOWING */)) return;
+      next = this;
+    });
+
+    return next;
+  },
+
+  /**
+   * The dropdown's query-field wrapper — where the spinner belongs
+   * (TWO-25326).
+   *
+   * Two lookups, because the primary one is conditional on widget state in a
+   * way that is easy to miss: selectWoo sets `aria-owns` on the query field
+   * in its `container.on('open')` handler and REMOVES it again on close, so
+   * `companySearchInputSelector` matches nothing whenever the dropdown is
+   * shut. That is correct for the spinner (there is nothing to paint on a
+   * closed dropdown) but it makes the selector a state check masquerading as
+   * an element lookup, and a caller that runs a tick early or a tick late
+   * gets a silent no-op rather than a spinner.
+   *
+   * The fallback is anchored on the results list's id instead, which is
+   * static markup: it identifies THIS field's dropdown specifically, so it
+   * can never pick up the country picker's search field, which sits in an
+   * identically-classed wrapper whenever that dropdown happens to be open.
+   *
+   * @returns {Object} jQuery-wrapped wrapper, empty if there is no dropdown
+   */
+  getCompanySearchFieldContainer: function () {
+    const $byAria = jQuery(twoincSelectWooHelper.companySearchInputSelector).parent();
+    if ($byAria.length) return $byAria;
+
+    return jQuery("#select2-billing_company_display-results")
+      .closest(".select2-dropdown")
+      .find(".select2-search--dropdown")
+      .first();
   },
 
   /**
@@ -528,7 +743,7 @@ let twoincSelectWooHelper = {
    * animating element running behind a closed dropdown.
    */
   toggleCompanySearchSpinner: function (isSearching) {
-    const $search = jQuery('input[aria-owns="select2-billing_company_display-results"]').parent();
+    const $search = twoincSelectWooHelper.getCompanySearchFieldContainer();
     if ($search.length === 0) return;
     $search.find(".twoinc-search-spinner").remove();
     if (isSearching) {
@@ -725,6 +940,54 @@ let twoincSelectWooHelper = {
         billingCompanyDisplay.on("results:message", function (e) {
           this.dropdown._resizeDropdown();
           this.dropdown._positionDropdown();
+        });
+
+        // Spinner, driven off the widget's own query lifecycle as well as off
+        // the ajax transport (TWO-25326 §1).
+        //
+        // The transport hooks in genSelectWooParams stay — they are the
+        // accurate signal, and they are what the supersession guard is built
+        // around. These are additive, and they buy two things the transport
+        // cannot:
+        //
+        //   - Coverage of the debounce. `query` fires on the keystroke;
+        //     the transport does not run until 300ms later. To the buyer, the
+        //     search is "in progress" for that whole time — this bullet asks
+        //     for a spinner "while a search query is in progress", and a third
+        //     of a second of dead field before it appears is the visible part
+        //     of the wait.
+        //   - Independence from the transport actually being reached. Live
+        //     verification on 2026-08-02 found no spinner during a real
+        //     search on staging, while the identical path driven through the
+        //     real selectWoo widget under Jest shows it correctly — so the
+        //     transport hook demonstrably does not always land in a real
+        //     browser, and the root cause is not yet established. Hanging the
+        //     spinner off the widget's own events as well means it no longer
+        //     depends on which of the two paths runs.
+        //
+        // `results:all` and `results:message` are the two terminal states of a
+        // query — a rendered result set, or a message row ("No matches found",
+        // "search unavailable"). Both mean the search is over.
+        //
+        // The threshold check is load-bearing, not a tidy-up. Handlers run in
+        // registration order and the widget registered its own `query`
+        // handler at construction, so by the time this one runs the data
+        // adapter has ALREADY been asked for results — and for a below-minimum
+        // term the minimumInputLength decorator answers it synchronously with
+        // `results:message`, meaning the hide below has already fired before
+        // this show would run. Without the guard, every keystroke under three
+        // characters would leave a spinner running forever over a "Please
+        // enter 3 or more characters" hint with no request in flight.
+        billingCompanyDisplay.on("query", function (params) {
+          const term = (params && params.term) || "";
+          if (term.length < twoincSelectWooHelper.companySearchMinLength) return;
+          twoincSelectWooHelper.toggleCompanySearchSpinner(true);
+        });
+        billingCompanyDisplay.on("results:all", function () {
+          twoincSelectWooHelper.toggleCompanySearchSpinner(false);
+        });
+        billingCompanyDisplay.on("results:message", function () {
+          twoincSelectWooHelper.toggleCompanySearchSpinner(false);
         });
       }
     }
@@ -1257,20 +1520,41 @@ let twoincDomHelper = {
     }, 3000);
   },
 
-  /** DOM id of the read-only captured-company summary (TWO-25288). */
+  /**
+   * DOM id of the company-number label under the company-name field
+   * (TWO-25288, narrowed to number-only by TWO-25326 §7).
+   *
+   * Id and class kept as `twoinc_company_summary` / `.twoinc-company-summary`
+   * even though it no longer summarises anything but the number: brand
+   * overlays style this element by class (`.custom-checkout
+   * .twoinc-company-summary` in twoinc.css is one in this repo alone), and
+   * renaming it would silently drop their styling on a change whose whole
+   * purpose is cosmetic.
+   */
   companySummaryId: "twoinc_company_summary",
 
   /**
-   * The read-only summary of the captured company, built hidden on first use
-   * (TWO-25288).
+   * The read-only company-number label, built hidden on first use
+   * (TWO-25288; scope narrowed TWO-25326 §7).
    *
-   * Two <span>s and no <input>: the captured identity is a value the buyer is
+   * ONE <span> and no <input>: the captured number is a value the buyer is
    * shown, not a field they fill in, so there is deliberately nothing here to
    * type into and no control that removes it. `readonly` inputs are this
    * plugin's convention for a field that still carries a value the buyer must
    * not change (sole-trader mode readonly-locks #billing_company and
    * #company_id) — but those are the SUBMITTED fields, and they keep that job
-   * untouched. This is a display beside them, so spans are the right shape.
+   * untouched. This is a display beside them, so a span is the right shape.
+   *
+   * It used to render the captured NAME here too, in a
+   * `.twoinc-company-summary-name` span above the number. That span is gone
+   * (TWO-25326 §7): the name is already on screen in the company-name control
+   * immediately above, and the ticket rules out any additional company name
+   * or number text in the address area beyond the company-name field itself
+   * and this number label. The number stays because §5 requires exactly this
+   * — the number as a plain right-aligned text label immediately below the
+   * name field, never as an input — and this element is the only thing on WC
+   * providing it. The name moved to the payment tile instead, where §7 wants
+   * it; see `renderCompanyTileLabel`.
    *
    * Anchored after the company-id field's enclosing `.twoinc-inp-container`
    * where there is one, NOT inside it. The pay-for-order page wraps every
@@ -1331,7 +1615,6 @@ let twoincDomHelper = {
         '<div id="' +
           twoincDomHelper.companySummaryId +
           '" class="twoinc-company-summary hidden">' +
-          '<span class="twoinc-company-summary-name"></span>' +
           '<span class="twoinc-company-summary-id"></span>' +
           "</div>"
       );
@@ -1369,30 +1652,80 @@ let twoincDomHelper = {
    * @returns {void}
    */
   renderCompanySummary: function (companyName, companyId) {
-    const $node = twoincDomHelper.getCompanySummaryNode();
-    if (!$node.length) return;
-
     const data =
       companyName === undefined && companyId === undefined
         ? twoincDomHelper.readCapturedCompany()
         : { company_name: companyName, organization_number: companyId };
 
     // The empty selectWoo option's label is a non-breaking space, so an
-    // unselected picker reads back as " " rather than "" — which would
-    // render as a summary with an invisible name in it.
+    // unselected picker reads back as " " rather than "" — which would
+    // render as a label with an invisible value in it.
     const name = twoincUtilHelper.blankToEmpty(data.company_name);
     const number = twoincUtilHelper.blankToEmpty(data.organization_number);
 
-    $node.find(".twoinc-company-summary-name").text(name);
+    // Rendered from the same resolved pair, in the same call, so the tile and
+    // the address area can never disagree about what was captured
+    // (TWO-25326 §7).
+    twoincDomHelper.renderCompanyTileLabel(name, number);
+
+    const $node = twoincDomHelper.getCompanySummaryNode();
+    if (!$node.length) return;
+
     $node.find(".twoinc-company-summary-id").text(number);
 
-    // Shown only for a Two purchase with something captured. A buyer paying by
-    // another method may well have typed a company name into WooCommerce's own
-    // field, and echoing it back at them under Two's styling is noise.
+    // Keyed on the NUMBER alone now, not on "name or number" (TWO-25326 §5,
+    // §7). This element renders nothing but the number, so a captured company
+    // with no number — which is exactly what manual entry produces, since it
+    // clears #company_id — must leave no empty block behind occupying vertical
+    // space under the field. §5 states it outright: manual-entry mode shows no
+    // company-number field or label at all.
+    //
+    // Shown only for a Two purchase. A buyer paying by another method may well
+    // have a company number sitting in the field, and echoing it back at them
+    // under Two's styling is noise.
     const visible = Boolean(
-      (name || number) && twoincDomHelper.isTwoincVisible() && twoincDomHelper.isTwoincSelected()
+      number && twoincDomHelper.isTwoincVisible() && twoincDomHelper.isTwoincSelected()
     );
     $node.toggleClass("hidden", !visible);
+  },
+
+  /** DOM class of the payment tile's captured-company label (TWO-25326 §7). */
+  companyTileLabelClass: "twoinc-company-tile-label",
+
+  /**
+   * Render the captured company inside the payment tile (TWO-25326 §7).
+   *
+   * The ticket asks for `<name> (<number>)` as a text label in the tile,
+   * "between the chips and the intent message (if rendered) or else the
+   * optional fields". On WooCommerce the second half of that has no referent:
+   * the optional fields (invoice email, project, department) are checkout
+   * form fields in the billing column, not tile content, so there is nothing
+   * in the tile for the label to sit above if the intent message is switched
+   * off. The container is therefore server-rendered as the last element of
+   * the tile block before the intent loader/notice, which satisfies the
+   * position in both cases — see the block comment on that markup in
+   * WC_Twoinc.php.
+   *
+   * Nothing here creates DOM. The container is server-rendered, so a brand
+   * overlay that removes or repositions it in its own template simply gets no
+   * label, rather than having one injected back underneath it.
+   *
+   * Falls back to the bare name when the capture carries no number, which is
+   * manual entry. `<name> ()` would read as a rendering fault, and the number
+   * is genuinely absent rather than pending.
+   *
+   * @param {string} name already blank-collapsed
+   * @param {string} number already blank-collapsed
+   * @returns {void}
+   */
+  renderCompanyTileLabel: function (name, number) {
+    const $label = jQuery("." + twoincDomHelper.companyTileLabelClass);
+    if (!$label.length) return;
+
+    const text = name && number ? name + " (" + number + ")" : name;
+
+    $label.text(text);
+    $label.toggleClass("hidden", !text);
   },
 
   /**

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -917,12 +917,34 @@ if (!class_exists('WC_Twoinc')) {
             // would report an invalid brand value twice per render.
             $notice_enabled = $this->is_intent_approved_notice_enabled();
 
+            // The captured company, as `<name> (<number>)` (TWO-25326 §7).
+            //
+            // Position is the ticket's, read literally: "between the chips and
+            // the intent message (if rendered) or else the optional fields".
+            // On WooCommerce the fallback half of that has no referent — the
+            // optional fields (invoice email, project, department) are billing
+            // form fields, not tile content — so the only anchor that exists
+            // here is the intent message, and this sits immediately before the
+            // intent loader/notice pair. That also keeps it last in the tile
+            // when the notice is switched off, which is where the fallback
+            // would have put it anyway.
+            //
+            // Empty and `hidden` on render, filled by renderCompanyTileLabel()
+            // in twoinc.js. Server-side it cannot be filled at all: the
+            // captured company is chosen client-side after this markup is
+            // generated, and this same block is re-rendered by every
+            // `update_checkout` regardless of whether a company was picked.
+            //
+            // A <div>, not a <p>: some themes give `.payment_box p` its own
+            // margins, and this must not pick up spacing the chips and notices
+            // around it do not have.
             return sprintf(
                 '<div>
                     %s
                     <label class="twoinc-term-chips-heading hidden"></label>
                     <div class="twoinc-term-chips hidden" role="radiogroup"></div>
                     <div class="twoinc-sole-trader-toggle hidden" role="radiogroup"></div>
+                    <div class="twoinc-company-tile-label hidden"></div>
                     %s
                     %s
                     <div class="twoinc-pay-box twoinc-err-payment-default hidden">%s</div>

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -159,9 +159,20 @@ about the company-search helper, so the bootstrap is left to no-op.
 - `data-selected="true"` is specifically pinned as wrong: the picker routes activation of an
   already-selected row to closing the dropdown, so the row would look reachable and do
   nothing. The mutation that flips it takes the activation tests down.
-- visibility is the search threshold and nothing else. The row is present at the threshold
-  with **zero** requests made, which is what rules out a "has a search run" gate, and the
-  threshold assertion injects a different number so a leftover literal `3` cannot pass.
+- visibility is capture state, **not** the search threshold (TWO-25326 §2, reversed from the
+  original rule after Doug found the old one live). The button is in the dropdown from the
+  moment it opens, before a single keystroke — the requirement is a route into manual entry
+  that does not make the buyer type a doomed query first — it stays put when the term drops
+  back under the threshold, and the only thing that removes it is a company actually being
+  captured. Placement is asserted through the delegated `select2:open` handler with no input
+  event anywhere near it, since an `input`-only binding is exactly what the old rule allowed.
+- Tab **out** of the button is driven by hand, not by the browser (TWO-25326 §1/§4). The
+  dropdown is attached to the end of `<body>`, so native Tab from the button walks off the end
+  of the document — live, focus landed on `<body>` and the dropdown stayed open. The handler
+  resolves the next tabbable control in FORM order first, then closes, then focuses it, then
+  re-asserts that focus past selectWoo's own unconditional `$selection.focus()` 1ms after
+  close. All four steps are pinned, and the target resolution has its own describe covering
+  `hidden`-class wrappers, `tabindex="-1"`, hidden inputs, and manual-entry mode.
 - activation prevents the selection: no `select2:select`, no company name, no company id. A
   normal company row still selects, which is what stops the interception from being a
   blanket one.
@@ -201,15 +212,20 @@ about the company-search helper, so the bootstrap is left to no-op.
 
 `company-summary.test.js` — the read-only captured-company summary (TWO-25288):
 
-- all three capture modes render the right pair of values: the picked company's name and
-  organisation number in search mode, the name and number Two holds for a sole trader, and in
-  manual entry the typed name with **no** number, because entering manual entry clears the
-  number of the company the buyer has just disowned. A hit that carries no organisation number
-  at all renders its name alone.
+- the two halves render in two different places (TWO-25326 §7). The address area gets the
+  organisation **number** only, as a right-aligned text label under the company-name field;
+  the **name** renders in the payment tile, as `<name> (<number>)`. The name used to render in
+  the address area too, under the control that already showed it, which is what Doug found
+  live. Both are asserted for all three capture modes, and the address-area block is asserted
+  to contain no company name at all.
+- no number means no label, not an empty one: a registry hit with no organisation number, and
+  manual entry (which clears the number of the company the buyer just disowned), both leave
+  the address-area block hidden outright rather than occupying a row under the field. The tile
+  drops the parenthesised half in the same case rather than rendering `Name ()`.
 - search-mode rendering is driven through `enableCompanySearch`'s own `select2:select` binding
   rather than by calling the render function, so unwiring the two fails the test.
 - the display is genuinely read-only: no `input`, `select`, `textarea` or `contenteditable`
-  inside it, both values in `span`s, nothing tabbable, and — the affordance this reversal
+  inside either half, the number in a `span`, nothing tabbable, and — the affordance this reversal
   removes — no button, link, image, `onclick` or bound handler that would let the buyer delete
   a captured company. The overlay this replaces shipped an `<img>` with an inline `onclick`.
 - submission is unaffected. `#billing_company` and `#company_id` still carry the values

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -61,6 +61,8 @@ describe("company-search manual-entry affordance", () => {
     harness.releaseWidgets($);
     $(document.body).off("input.twoincManualEntry");
     $(document.body).off("keydown.twoincManualEntry");
+    $(document.body).off("select2:open.twoincManualEntry");
+    $(document.body).off("keydown.twoincManualEntryButton");
     document.body.innerHTML = "";
   });
 
@@ -71,8 +73,18 @@ describe("company-search manual-entry affordance", () => {
    * @returns {Object} the jQuery-wrapped select
    */
   function openWithAffordance() {
-    const $select = harness.openCompanyWidget($, helper);
+    // Bound BEFORE the open, the way enableCompanySearch does it: the button
+    // is now placed by a delegated `select2:open` handler (TWO-25326 §2), so
+    // binding after the widget is already open would miss the event that
+    // places it.
     helper.bindManualEntryAffordance();
+    const $select = harness.openCompanyWidget($, helper);
+
+    // That open handler defers the sync a tick. Flushed by hand here so the
+    // rest of the suite does not have to run fake timers to see the button;
+    // the deferral itself is covered by its own test below, which does NOT
+    // use this helper.
+    helper.syncManualEntryButton();
     return $select;
   }
 
@@ -128,20 +140,45 @@ describe("company-search manual-entry affordance", () => {
     expect(searchInput().length).toBe(1);
   });
 
-  describe("visibility follows the search threshold and nothing else", () => {
-    test("absent below the threshold", () => {
+  describe("visibility follows capture state, not the search threshold (TWO-25326 §2)", () => {
+    test("present as soon as the dropdown opens, before the buyer has typed anything", () => {
       openWithAffordance();
 
-      // Reach the threshold FIRST, so the mechanism is demonstrably live in
-      // this test before the absence is asserted. Without this the assertion
-      // below is a precondition dressed as a check: the button was never
-      // there, so "it is not there" holds no matter what the code does.
+      // The whole point of the requirement: Doug rejected a route into manual
+      // entry that makes the buyer type a query they already know will fail.
+      // A buyer who knows their company is not in the registry must be able to
+      // open the field and leave immediately.
+      expect(searchInput().val()).toBe("");
+      expect(btn().length).toBe(1);
+    });
+
+    test("it is `select2:open` that places it, not only an input event", () => {
+      // Deliberately not using openWithAffordance(), which flushes the
+      // deferred sync by hand. Nothing here fires an `input` event, so if the
+      // open handler were removed the button would never appear — which is
+      // exactly the failure the old threshold-gated version had.
+      jest.useFakeTimers();
+      helper.bindManualEntryAffordance();
+      harness.openCompanyWidget($, helper);
+
+      expect(btn().length).toBe(0);
+      jest.advanceTimersByTime(1);
+      expect(btn().length).toBe(1);
+      jest.useRealTimers();
+    });
+
+    test("stays put below the search threshold", () => {
+      // This is the behaviour reversal. It used to be removed here.
+      openWithAffordance();
+
       type("a".repeat(helper.companySearchMinLength));
       expect(btn().length).toBe(1);
 
       type("a".repeat(helper.companySearchMinLength - 1));
+      expect(btn().length).toBe(1);
 
-      expect(btn().length).toBe(0);
+      type("");
+      expect(btn().length).toBe(1);
     });
 
     test("present at the threshold, before any request has been made", () => {
@@ -151,8 +188,8 @@ describe("company-search manual-entry affordance", () => {
       type("a".repeat(helper.companySearchMinLength));
 
       expect(btn().length).toBe(1);
-      // The point of the timing rule: no round trip has happened, and the
-      // button is already there. A `hasSearched` gate would fail this.
+      // No round trip has happened and the button is there. A `hasSearched`
+      // gate would fail this.
       expect(ajax.calls.length).toBe(0);
       ajax.restore();
     });
@@ -165,27 +202,28 @@ describe("company-search manual-entry affordance", () => {
       expect(btn().length).toBe(1);
     });
 
-    test("removed again when the buyer deletes back below the threshold", () => {
+    test("gone once a company IS captured", () => {
       openWithAffordance();
-
-      type("a".repeat(helper.companySearchMinLength));
       expect(btn().length).toBe(1);
 
-      type("a".repeat(helper.companySearchMinLength - 1));
+      $("#billing_company_display").append(
+        '<option value="ACME Widgets Ltd" selected>ACME Widgets Ltd</option>'
+      );
+      helper.syncManualEntryButton();
+
       expect(btn().length).toBe(0);
     });
 
-    test("the threshold is read from the shared constant, not hard-coded", () => {
-      // Injecting a DIFFERENT number is the only version of this assertion
-      // worth having: a test that types three characters passes just as well
-      // against a leftover literal 3.
-      helper.companySearchMinLength = 5;
+    test("the empty option's non-breaking space does not read as a capture", () => {
+      // selectWoo's placeholder option carries   as its label and, on this
+      // field, as its value — so a naive truthiness check on the select's
+      // value reports a company captured on an untouched field and hides the
+      // button on exactly the state the requirement is written about.
       openWithAffordance();
 
-      type("abcd");
-      expect(btn().length).toBe(0);
+      $("#billing_company_display").append('<option value=" " selected> </option>');
+      helper.syncManualEntryButton();
 
-      type("abcde");
       expect(btn().length).toBe(1);
     });
   });
@@ -330,14 +368,20 @@ describe("company-search manual-entry affordance", () => {
       expect(document.activeElement).not.toBe(btn().get(0));
     });
 
-    test("below the threshold (button absent) Tab is not intercepted", () => {
+    test("Tab is not intercepted when there is no button to reach", () => {
       // Same reasoning as the Shift+Tab test above re: not asserting
       // `isDefaultPrevented()` — that reflects selectWoo's own document-level
       // Tab-as-Enter handling, not this feature. The contract under test is
       // the `!btn` early return: nothing gets created or focused when the
-      // button doesn't exist yet.
+      // button is not there.
+      //
+      // The button now exists from the moment the dropdown opens (TWO-25326
+      // §2), so a below-threshold term no longer produces this state and the
+      // absence has to be arranged directly. It is still reachable in
+      // production — a brand overlay that removes the affordance, or a
+      // captured company, both leave the dropdown open with no button in it.
       openWithAffordance();
-      type("a".repeat(helper.companySearchMinLength - 1));
+      btn().remove();
       expect(btn().length).toBe(0);
 
       searchInput().get(0).focus();
@@ -418,18 +462,18 @@ describe("company-search manual-entry affordance", () => {
       jest.useRealTimers();
     });
 
-    test("a second Tab press FROM the button does not silently select the highlighted row", () => {
-      // Found under adversarial review, reproduced against the real widget
-      // before this fix was written. selectWoo's `isOpen()` — the gate its
-      // own document-level Tab-as-Enter handler checks — is purely a CSS
-      // class on the container, entirely independent of where DOM focus
-      // actually is. Landing on the button via the shortcut does not close
-      // the dropdown, so a buyer pressing Tab AGAIN from the button — trying
-      // to move on to the next real page field, the ordinary next step —
-      // used to have that keydown bubble straight to selectWoo's still-live
-      // document handler, which silently fired `results:select` on whatever
-      // row was highlighted (a company the buyer never chose) and yanked
-      // focus back into the search field.
+    test("a second Tab press FROM the button closes the dropdown, moves on, and selects nothing", () => {
+      // TWO-25326 §1 and §4, both confirmed broken live on 2026-08-02 and
+      // both fixed by the same handler.
+      //
+      // What this used to do: `stopPropagation` and nothing else. That kept
+      // selectWoo's document-level Tab-as-Enter handler from silently
+      // selecting the highlighted row — which is real and is still asserted
+      // below — but left the dropdown open indefinitely (selectWoo only
+      // closes on Escape, a pick, or an outside mousedown) and let native Tab
+      // run, which walks off the end of the document because the dropdown is
+      // attached to the end of <body>. Live, that landed focus on <body>.
+      jest.useFakeTimers();
       const $select = openWithAffordance();
       const picker = $select.data("select2");
 
@@ -447,11 +491,48 @@ describe("company-search manual-entry affordance", () => {
       const selected = [];
       $select.on("select2:select", (ev) => selected.push(ev.params.data));
 
+      // Resolved here, from the same function the handler uses, while the
+      // dropdown is still up — which is also when the handler resolves it.
+      const expectedNext = helper.nextTabbableAfterCompanyField();
+      expect(expectedNext).not.toBeNull();
+      expect(document.activeElement).not.toBe(expectedNext);
+
       const e2 = tabAt(btn());
 
-      expect(e2.isDefaultPrevented()).toBe(false);
+      // Native Tab is now suppressed on purpose: it cannot reach the next
+      // form control from inside a body-attached dropdown, so the traversal
+      // is done by hand instead.
+      expect(e2.isDefaultPrevented()).toBe(true);
+      expect(picker.isOpen()).toBe(false);
+      expect(document.activeElement).toBe(expectedNext);
+
+      // Still no silent selection — the original contract, unchanged.
       expect(selected).toEqual([]);
       expect($("#billing_company").val()).toBe("");
+
+      // And it survives selectWoo's own post-close `$selection.focus()`,
+      // which it schedules ~1ms out, unconditionally. This is the reason the
+      // previous revision refused to close the dropdown at all.
+      jest.advanceTimersByTime(30);
+      expect(document.activeElement).toBe(expectedNext);
+      jest.useRealTimers();
+    });
+
+    test("Shift+Tab from the button is left to the browser, and leaves the dropdown open", () => {
+      // Reverse Tab from the button should go back to the query field, which
+      // sits immediately before it inside the same dropdown. Closing on
+      // Shift+Tab would tear down the thing the buyer is navigating back
+      // into.
+      const $select = openWithAffordance();
+      const picker = $select.data("select2");
+
+      type("abc");
+      btn().get(0).focus();
+
+      const e = tabAt(btn(), { shiftKey: true });
+
+      expect(e.isDefaultPrevented()).toBe(false);
+      expect(picker.isOpen()).toBe(true);
     });
 
     /**
@@ -933,8 +1014,13 @@ describe("company-search manual-entry affordance", () => {
       openWithAffordance();
       expect($("#billing_company_display").val()).toBe("ACME Widgets Ltd");
 
-      type("abc");
-      activate();
+      // Straight to the switch rather than through the button. With a company
+      // captured the manual-entry button is, correctly, no longer offered
+      // (TWO-25326 §2), so it is not the route into this state — but the
+      // state is still reachable, from sole-trader mode and from the
+      // user-meta restore, and what it must do to the display select is
+      // unchanged.
+      ctx.dom.enterManualCompanyEntry();
       jest.advanceTimersByTime(1);
 
       expect($("#billing_company_display").val()).toBe("");
@@ -1538,6 +1624,59 @@ describe("company-search manual-entry affordance", () => {
       $(fieldSelector).removeClass("hidden");
       ctx.dom.syncCompanyFieldWrappers();
       expect($(fieldSelector).parent().hasClass("hidden")).toBe(false);
+    });
+  });
+
+  describe("choosing the Tab target out of the dropdown (TWO-25326 §4)", () => {
+    test("it is the next tabbable control after the company field, in FORM order", () => {
+      openWithAffordance();
+
+      const next = helper.nextTabbableAfterCompanyField();
+
+      // Not the query field and not the button, even though both follow the
+      // anchor in DOCUMENT order — the dropdown is attached to the end of
+      // <body>, which is the whole reason native Tab could not do this.
+      expect(next).toBe($("#billing_company").get(0));
+    });
+
+    test("controls hidden by the `hidden` class are skipped, along with their contents", () => {
+      // How this checkout hides a field: the class goes on the `.form-row`
+      // wrapper, not the input. Landing focus on an invisible input is the
+      // failure this guards, and in search mode BOTH company inputs are
+      // hidden that way behind the picker.
+      openWithAffordance();
+      $("#billing_company_field, #company_id_field").addClass("hidden");
+
+      expect(helper.nextTabbableAfterCompanyField()).toBeNull();
+
+      $("#company_id_field").removeClass("hidden");
+      expect(helper.nextTabbableAfterCompanyField()).toBe($("#company_id").get(0));
+    });
+
+    test("`tabindex=-1` and hidden inputs are not tab stops", () => {
+      openWithAffordance();
+      $("#billing_company").attr("tabindex", "-1");
+      $("#company_id_field").before(
+        '<input type="hidden" id="a_hidden_input" name="a_hidden_input" value="x" />'
+      );
+
+      expect(helper.nextTabbableAfterCompanyField()).toBe($("#company_id").get(0));
+    });
+
+    test("nothing after the company field at all answers null rather than guessing", () => {
+      openWithAffordance();
+      $("#billing_company_field, #company_id_field").remove();
+
+      expect(helper.nextTabbableAfterCompanyField()).toBeNull();
+    });
+
+    test("in manual-entry mode it anchors on the real input, not the absent picker", () => {
+      // The combobox does not exist in manual entry, so an anchor lookup that
+      // only knew about it would return null and Tab would go nowhere.
+      openWithAffordance();
+      $("#billing_company_display_field").remove();
+
+      expect(helper.nextTabbableAfterCompanyField()).toBe($("#company_id").get(0));
     });
   });
 });

--- a/tests/js/company-search-transport.test.js
+++ b/tests/js/company-search-transport.test.js
@@ -480,4 +480,174 @@ describe("company search ajax transport", () => {
       expect(() => ctx.helper.showCompanySearchUnavailable()).not.toThrow();
     });
   });
+
+  describe("spinner wiring — driven through the widget, not the transport directly (TWO-25326 §1)", () => {
+    /*
+     * Every assertion in "spinner lifecycle" above calls
+     * `genSelectWooParams().ajax.transport` by hand. That proves the transport
+     * toggles the spinner; it proves nothing about whether the transport is
+     * ever reached, or whether anything else on the page is required for the
+     * spinner to appear. Live verification on 2026-08-02 found no spinner at
+     * all during a real search on staging while results came back normally —
+     * i.e. exactly the gap a hand-called transport cannot see.
+     *
+     * These drive the real widget instead: type into the query field the
+     * dropdown actually renders, let selectWoo's own `query` → data adapter
+     * → transport chain run, and assert on what the buyer would see.
+     */
+
+    /**
+     * Attach and open the widget with the plugin's own event bindings in
+     * place — `fixSelectWooPositionCompanyName` is where the spinner's
+     * lifecycle handlers live, and `enableCompanySearch` and
+     * `clearSelectedCompany` are the two production callers of it.
+     *
+     * @returns {Object} the jQuery-wrapped select
+     */
+    function openWired() {
+      const $select = harness.openCompanyWidget(ctx.$, ctx.helper);
+      ctx.helper.fixSelectWooPositionCompanyName();
+      return $select;
+    }
+
+    /**
+     * Type into the dropdown's own query field with the events selectWoo
+     * listens on, so its `query` really fires.
+     *
+     * @param {string} term
+     * @returns {void}
+     */
+    function typeQuery(term) {
+      const $search = ctx.$(ctx.helper.companySearchInputSelector);
+      $search.val(term).trigger("input");
+    }
+
+    test("typing a searchable term shows the spinner, and the response clears it", () => {
+      jest.useFakeTimers();
+      openWired();
+
+      typeQuery("kaffe");
+      expect(spinnerVisible()).toBe(true);
+
+      // Still up across the debounce and while the request is in flight.
+      jest.advanceTimersByTime(400);
+      expect(ajax.calls.length).toBe(1);
+      expect(spinnerVisible()).toBe(true);
+
+      ajax.last().succeed({ items: [] });
+
+      expect(spinnerVisible()).toBe(false);
+      jest.useRealTimers();
+    });
+
+    test("the spinner is up during the debounce, before any request goes out", () => {
+      // The buyer is waiting for 300ms before the request is even dispatched.
+      // Hanging the spinner off the transport alone left that window blank,
+      // which on a fast connection is most of the visible wait.
+      jest.useFakeTimers();
+      openWired();
+
+      typeQuery("kaffe");
+
+      expect(ajax.calls.length).toBe(0);
+      expect(spinnerVisible()).toBe(true);
+      jest.useRealTimers();
+    });
+
+    test("a below-threshold term does not leave a spinner running", () => {
+      // The ordering trap this guards: handlers run in registration order and
+      // the widget registered its own `query` handler first, so for a term
+      // under the minimum the minimumInputLength decorator has ALREADY
+      // answered with `results:message` — the hide — by the time the show
+      // would run. Without the length check in the show handler the spinner
+      // would sit there forever over a "Please enter 3 or more characters"
+      // hint with nothing in flight.
+      jest.useFakeTimers();
+      openWired();
+
+      typeQuery("ka");
+      jest.advanceTimersByTime(400);
+
+      expect(ajax.calls.length).toBe(0);
+      expect(spinnerVisible()).toBe(false);
+      jest.useRealTimers();
+    });
+
+    test("a message result — no matches, or search unavailable — clears it too", () => {
+      jest.useFakeTimers();
+      const $select = openWired();
+      const picker = $select.data("select2");
+
+      typeQuery("kaffe");
+      expect(spinnerVisible()).toBe(true);
+
+      picker.trigger("results:message", { message: "noResults" });
+
+      expect(spinnerVisible()).toBe(false);
+      jest.useRealTimers();
+    });
+
+    test("the spinner lands inside the query field's own wrapper, at its end", () => {
+      // Position is the requirement: "within and at the right hand end of the
+      // query field". The stylesheet does the placing, so what this asserts is
+      // the anchor the stylesheet needs — the spinner is the last child of the
+      // wrapper the query input lives in, and that wrapper is flagged so the
+      // rule reserving the right-hand gutter applies.
+      jest.useFakeTimers();
+      openWired();
+
+      typeQuery("kaffe");
+
+      const $spinner = ctx.$(".twoinc-search-spinner");
+      expect($spinner.length).toBe(1);
+
+      const $wrapper = $spinner.parent();
+      expect($wrapper.hasClass("select2-search--dropdown")).toBe(true);
+      expect($wrapper.hasClass("twoinc-searching")).toBe(true);
+      expect($wrapper.find(ctx.helper.companySearchInputSelector).length).toBe(1);
+      expect($wrapper.children().last().is($spinner)).toBe(true);
+      jest.useRealTimers();
+    });
+
+    test("the field wrapper is still found once selectWoo has stripped aria-owns", () => {
+      // `companySearchInputSelector` keys on `aria-owns`, which selectWoo sets
+      // on open and REMOVES on close — so the primary lookup is a widget-state
+      // check wearing an element lookup's clothes, and a caller that runs a
+      // tick off gets a silent no-op instead of a spinner. The fallback is
+      // anchored on the results list's static id instead.
+      const $select = harness.openCompanyWidget(ctx.$, ctx.helper);
+      const $search = ctx.$(ctx.helper.companySearchInputSelector);
+      expect($search.length).toBe(1);
+
+      $search.removeAttr("aria-owns");
+      expect(ctx.$(ctx.helper.companySearchInputSelector).length).toBe(0);
+
+      const $found = ctx.helper.getCompanySearchFieldContainer();
+
+      expect($found.length).toBe(1);
+      expect($found.hasClass("select2-search--dropdown")).toBe(true);
+      expect($select.data("select2")).toBeDefined();
+    });
+
+    test("the fallback cannot pick up a different field's dropdown", () => {
+      // Scoped on this field's own results-list id, not on the generic
+      // `.select2-search--dropdown` class, which the country picker's open
+      // dropdown carries just as well.
+      harness.openCompanyWidget(ctx.$, ctx.helper);
+      ctx.$(ctx.helper.companySearchInputSelector).removeAttr("aria-owns");
+
+      const $found = ctx.helper.getCompanySearchFieldContainer();
+      expect($found.length).toBe(1);
+      expect(
+        $found.closest(".select2-dropdown").find("#select2-billing_company_display-results").length
+      ).toBe(1);
+    });
+
+    test("no widget at all is inert, not a throw", () => {
+      document.body.innerHTML = "";
+
+      expect(() => ctx.helper.toggleCompanySearchSpinner(true)).not.toThrow();
+      expect(ctx.helper.getCompanySearchFieldContainer().length).toBe(0);
+    });
+  });
 });

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -68,6 +68,18 @@ describe("read-only captured-company summary", () => {
     $("form[name='checkout']").append(
       '<input type="radio" name="payment_method" value="' + GATEWAY_ID + '" checked />'
     );
+
+    // The payment tile, minimally. The captured company now renders as a text
+    // label INSIDE the tile (TWO-25326 §7), from server-rendered markup that
+    // renderCompanyTileLabel() only fills — it never creates it — so without
+    // this every tile assertion below would be checking an element that does
+    // not exist. Deliberately outside the billing field wrapper, which is what
+    // the address-area assertions are scoped to.
+    $(document.body).append(
+      '<li class="wc_payment_method"><div class="payment_box">' +
+        '<div class="twoinc-company-tile-label hidden"></div>' +
+        "</div></li>"
+    );
   }
 
   /** @returns {Object} the summary element, or an empty set */
@@ -75,9 +87,31 @@ describe("read-only captured-company summary", () => {
     return $("#" + dom.companySummaryId);
   }
 
-  /** @returns {string} the rendered company name */
+  /** @returns {Object} the payment tile's captured-company label */
+  function tileLabel() {
+    return $("." + dom.companyTileLabelClass);
+  }
+
+  /** @returns {string} the tile label's text, `<name> (<number>)` */
+  function tileText() {
+    return tileLabel().hasClass("hidden") ? "" : tileLabel().text();
+  }
+
+  /**
+   * The rendered company NAME.
+   *
+   * Reads the payment tile, not the address area. The name used to render in
+   * a `.twoinc-company-summary-name` span under the company field; TWO-25326
+   * §7 removed it from there — it was a second copy of what the company-name
+   * control immediately above already shows — and put it in the tile instead.
+   * The assertions that pre-date the move are still asking the right
+   * question, so they still call this; they just get their answer from where
+   * the name actually is now.
+   *
+   * @returns {string}
+   */
   function renderedName() {
-    return summary().find(".twoinc-company-summary-name").text();
+    return tileText().replace(/\s*\([^()]*\)\s*$/, "");
   }
 
   /** @returns {string} the rendered organisation number */
@@ -121,12 +155,25 @@ describe("read-only captured-company summary", () => {
   }
 
   describe("company search", () => {
-    test("renders the picked company's name and number", () => {
+    test("renders the picked company's number under the field and its name in the tile", () => {
       pickCompany("ACME Widgets Ltd", "12345678");
 
       expect(isShown()).toBe(true);
-      expect(renderedName()).toBe("ACME Widgets Ltd");
       expect(renderedNumber()).toBe("12345678");
+      expect(renderedName()).toBe("ACME Widgets Ltd");
+      expect(tileText()).toBe("ACME Widgets Ltd (12345678)");
+    });
+
+    test("the name does NOT render anywhere in the address area (TWO-25326 §7)", () => {
+      // Doug's finding, live 2026-08-02: the address area showed the company
+      // name twice — once in the company-name control the buyer picked it in,
+      // and again in this block underneath. §7 allows the company-name field
+      // and the number label below it, and nothing else.
+      pickCompany("ACME Widgets Ltd", "12345678");
+
+      expect(summary().find(".twoinc-company-summary-name").length).toBe(0);
+      expect(summary().text()).not.toContain("ACME Widgets Ltd");
+      expect(summary().text()).toBe("12345678");
     });
 
     test("survives a re-render with no sessionStorage snapshot behind it", () => {
@@ -145,6 +192,7 @@ describe("read-only captured-company summary", () => {
       expect(isShown()).toBe(true);
       expect(renderedName()).toBe("ACME Widgets Ltd");
       expect(renderedNumber()).toBe("12345678");
+      expect(tileText()).toBe("ACME Widgets Ltd (12345678)");
     });
 
     test("the picked values are still the posted ones", () => {
@@ -235,9 +283,14 @@ describe("read-only captured-company summary", () => {
       // The organisation number is optional on a registry hit; the name is not.
       pickCompany("ACME Widgets Ltd", "");
 
-      expect(isShown()).toBe(true);
-      expect(renderedName()).toBe("ACME Widgets Ltd");
+      // No number means no number label at all — not an empty one taking up a
+      // row under the field (TWO-25326 §5).
+      expect(isShown()).toBe(false);
       expect(renderedNumber()).toBe("");
+
+      // The tile drops the parenthesised number rather than rendering
+      // `ACME Widgets Ltd ()`, which would read as a rendering fault.
+      expect(tileText()).toBe("ACME Widgets Ltd");
     });
   });
 
@@ -255,10 +308,8 @@ describe("read-only captured-company summary", () => {
       harness.injectStylesheet();
       pickCompany("A Very Long International Holdings Group Company Ltd", "12345678");
 
-      const nameStyle = window.getComputedStyle(summary().find(".twoinc-company-summary-name")[0]);
       const idStyle = window.getComputedStyle(summary().find(".twoinc-company-summary-id")[0]);
 
-      expect(nameStyle.display).toBe("block");
       expect(idStyle.display).toBe("block");
       expect(idStyle.textAlign).toBe("end");
     });
@@ -298,12 +349,17 @@ describe("read-only captured-company summary", () => {
       // with the name for space, but does nothing on its own for a single
       // unbroken token — routine in DE/NL/NO registry names — which would
       // otherwise overflow the row horizontally instead of wrapping.
-      const nameBody = /\.twoinc-company-summary-name\s*\{([^}]*)\}/.exec(stylesheetSource());
       const idBody = /\.twoinc-company-summary-id\s*\{([^}]*)\}/.exec(stylesheetSource());
-      expect(nameBody).not.toBeNull();
       expect(idBody).not.toBeNull();
-      expect(nameBody[1]).toMatch(/overflow-wrap:\s*anywhere/);
       expect(idBody[1]).toMatch(/overflow-wrap:\s*anywhere/);
+
+      // The name rule is gone with the name span (TWO-25326 §7); the same
+      // protection now has to be on the tile label, which is narrower than
+      // the address column and so needs it more.
+      expect(stylesheetSource()).not.toMatch(/\.twoinc-company-summary-name\s*\{/);
+      const tileBody = /\.twoinc-company-tile-label\s*\{([^}]*)\}/.exec(stylesheetSource());
+      expect(tileBody).not.toBeNull();
+      expect(tileBody[1]).toMatch(/overflow-wrap:\s*anywhere/);
       // The old nowrap protected the (inline, same-line) id from wrapping
       // onto an ugly second line — but now that it has its own row, nowrap
       // would instead let an exceptionally long identifier run past the
@@ -374,10 +430,13 @@ describe("read-only captured-company summary", () => {
       dom.enterManualCompanyEntry();
       typeCompanyName("Sole Proprietor Bakery");
 
-      expect(isShown()).toBe(true);
       expect(renderedName()).toBe("Sole Proprietor Bakery");
+      expect(tileText()).toBe("Sole Proprietor Bakery");
       // enterManualCompanyEntry clears #company_id: the buyer has said the
       // registry company is not theirs, so its number must not survive.
+      // §5 goes further — manual entry shows no number label at all, so the
+      // block is hidden outright rather than rendered empty.
+      expect(isShown()).toBe(false);
       expect(renderedNumber()).toBe("");
       expect($("#company_id").val()).toBe("");
     });
@@ -441,6 +500,7 @@ describe("read-only captured-company summary", () => {
       expect(isShown()).toBe(true);
       expect(renderedName()).toBe("Jo Bloggs Trading");
       expect(renderedNumber()).toBe("99887766");
+      expect(tileText()).toBe("Jo Bloggs Trading (99887766)");
       expect($("#billing_company").val()).toBe("Jo Bloggs Trading");
       expect($("#company_id").val()).toBe("99887766");
     });
@@ -451,9 +511,12 @@ describe("read-only captured-company summary", () => {
       pickCompany("ACME Widgets Ltd", "12345678");
 
       expect(summary().find("input, select, textarea, [contenteditable]").length).toBe(0);
-      // Both values live in elements a user cannot put a caret in.
-      expect(summary().find(".twoinc-company-summary-name").prop("tagName")).toBe("SPAN");
+      // The value lives in an element a user cannot put a caret in.
       expect(summary().find(".twoinc-company-summary-id").prop("tagName")).toBe("SPAN");
+
+      // Same for the tile label, which is now the other half of the display.
+      expect(tileLabel().find("input, select, textarea, [contenteditable]").length).toBe(0);
+      expect(tileLabel().prop("tagName")).toBe("DIV");
     });
 
     test("there is no control in it that removes the captured company", () => {

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -176,6 +176,7 @@ final class BrandConfigSpec
             'testClientVersionSuffixesShortShaWhenStamped',
             'testClientVersionIsQueryEncodedAsPlus',
             'testPaymentBoxOrdersTaglineChipsThenSoleTrader',
+            'testPaymentBoxRendersCompanyLabelBetweenChipsAndIntentMessage',
             'testSelectedTermInputPrecedesChipsContainer',
             'testBrandWithoutTaglineEmitsNoTaglineBlock',
             'testTaglineSentenceIsPlatformCopyWithBrandFaqLink',
@@ -5258,6 +5259,41 @@ final class BrandConfigSpec
         TinyAssert::true($tagline < $chips, 'tagline must precede the chips');
         TinyAssert::true($chips < $sole_trader, 'chips must precede the sole-trader toggle');
         TinyAssert::true($sole_trader < $about, 'about block must trail the box');
+    }
+
+    /**
+     * The captured company renders in the payment tile, as a text label
+     * between the term chips and the intent message (TWO-25326 section 7).
+     *
+     * Position is asserted, not just presence: the requirement names the
+     * chips and the intent message as its two anchors, and the whole box is
+     * one concatenated sprintf, so an edit that moves the label is a silent
+     * regression exactly like the ordering test above guards against.
+     *
+     * Empty on render by design. The captured company is chosen client-side
+     * after this markup is generated, so the container ships empty and
+     * hidden and renderCompanyTileLabel() in twoinc.js fills it.
+     */
+    private static function testPaymentBoxRendersCompanyLabelBetweenChipsAndIntentMessage(): void
+    {
+        self::useTaglineBrand();
+        $html = self::gateway()->build_payment_description();
+
+        $chips = strpos($html, 'twoinc-term-chips');
+        $label = strpos($html, 'twoinc-company-tile-label');
+        $intent = strpos($html, 'twoinc-pay-box');
+
+        TinyAssert::true($chips !== false, 'chips container missing');
+        TinyAssert::true($label !== false, 'company tile label missing');
+        TinyAssert::true($intent !== false, 'intent/notice pay box missing');
+
+        TinyAssert::true($chips < $label, 'chips must precede the company label');
+        TinyAssert::true($label < $intent, 'company label must precede the intent message');
+
+        TinyAssert::true(
+            strpos($html, '<div class="twoinc-company-tile-label hidden"></div>') !== false,
+            'company tile label must ship empty and hidden'
+        );
     }
 
     /**


### PR DESCRIPTION
## ⚠️ DRAFT — NOT LIVE-BROWSER-VERIFIED

**None of the five fixes below have been verified in a real browser.** The Chrome bridge became unavailable partway through this pass (the Windows-side subprocess it drives now exits immediately with an org monthly spend limit error), so the verification half of the TWO-25326 process could not be run against the fixes.

What that means concretely:

- The **defects** are all real and were confirmed by real browser interaction on the staging checkout before the bridge died. Those observations are recorded on TWO-25326.
- The **fixes** are backed only by Jest and the PHP unit suite. Per the ticket's own rule, that is explicitly not a substitute: "no assuming a Playwright/Jest unit test covers what only real interactive keyboard/mouse events can prove."
- Do not merge this on green CI alone. It needs a live pass of the full TWO-25326 checklist first.

There is a second constraint worth knowing: `woocom-dev.staging.two.inc` serves byte-identical `origin/staging` (diffed 2026-08-02), and there is no dev twin tracking an arbitrary branch — so live-verifying these fixes requires them to be on `staging` first. Verify-then-merge is not achievable on this shop as currently wired.

## What this fixes

Five defects from the TWO-25326 checklist, all found by real-browser verification against the staging checkout on 2026-08-02. Three were already recorded on the ticket; two (§1 spinner, §2 gating) were found during this run and added to it.

### 1. §1 / §4 — Tab out of the dropdown did nothing useful

Tab from the "My company is not on the list" button left focus on `<body>` and left the dropdown open with `select2-container--open` still set. Two causes, and fixing either alone cannot work:

- selectWoo only closes on Escape, a pick, or an outside mousedown — never on keyboard focus-away. The previous revision of this handler documented this as a deliberately-unfixed gap.
- The dropdown is attached to the end of `<body>`, so the button is the last tabbable element in the document and native Tab falls off the end of the page.

The handler now resolves the next tabbable control in **form** order (not document order), closes the dropdown, focuses it, and re-asserts that focus 20ms later. The re-assert is the part that earns its keep: closing fires selectWoo's own `container.on('close')`, which schedules `$selection.focus()` ~1ms out unconditionally — which is precisely the reason the previous revision declined to close at all.

Shift+Tab is deliberately untouched: reverse Tab should go back to the query field, which sits immediately before the button inside the same dropdown, and native traversal already does that.

### 2. §2 — the manual-entry route required typing a doomed query first

The button was gated purely on the three-character search threshold, so on a freshly opened dropdown it was absent from the DOM entirely. §2 rules this out explicitly: a buyer who already knows their company is not in the registry must have a route into manual entry without typing a query they know will fail.

Visibility is now "search UI open and nothing captured yet". A delegated `select2:open` handler places it, because an `input`-only binding can never fire for a buyer who types nothing — which is the whole case the requirement is about. The one thing that still removes it is a company actually being captured, which §2 also calls out.

Note this leaves the button in the dropdown's subtree while the dropdown is closed. That is not a stray tab stop: selectWoo's AttachBody decorator detaches the whole dropdown container on close.

### 3. §7 — the company name rendered twice in the address area

`#twoinc_company_summary` held two spans: the name (a second copy of what the company-name control directly above already shows) and the number.

**Correction to how this was originally framed:** the fix is not to delete the block. Its number span is the only thing on this platform satisfying §5 — the number as a right-aligned plain-text label immediately below the name field, never an input. Deleting the block outright would trade a §7 violation for a §5 one. So the name span is gone and the block is narrowed to number-only.

Its visibility now keys on the number alone rather than "name or number", which also satisfies §5's "manual-entry mode shows no company-number field or label at all" — manual entry clears the number, so the block now hides outright instead of rendering an empty row under the field.

The id and class are deliberately unchanged. Brand overlays style this element by class (there is one in this repo's own stylesheet), and renaming it would silently drop their styling on a change whose entire purpose is cosmetic.

### 4. §7 — the payment tile carried no company label

A server-rendered container now sits between the term chips and the intent message, filled client-side as `<name> (<number>)`.

One platform-specific note on the requirement's wording: "between the chips and the intent message (if rendered) **or else the optional fields**". On WooCommerce the fallback half has no referent — the optional fields (invoice email, project, department) are billing-column form fields, not tile content. The container is therefore positioned immediately before the intent loader/notice, which is also where the fallback would have put it when the notice is switched off.

Falls back to the bare name when there is no number (manual entry); `Name ()` would read as a rendering fault.

### 5. §1 — no spinner during a real search — **root cause NOT established**

Flagging this one honestly rather than claiming a fix.

Live, no spinner appeared in the query field during a real search: polled every 50ms across the whole request, and separately with a MutationObserver armed before the first keystroke — zero hits, while 33 results came back normally. The element itself is fine — invoking `toggleCompanySearchSpinner(true)` by hand injects it correctly positioned, and the GIF is HTTP 200.

I could not reproduce it. Driving the identical path through the **real** selectWoo widget under Jest shows the spinner correctly, and I confirmed against the vendored bundle that its `AjaxAdapter` does honour a custom `transport`. Diagnosing further needs the browser.

So rather than blind-fix a cause I have not found, this makes the spinner not depend on the path that demonstrably does not always land:

- It is now additionally driven off the widget's own `query` → `results:all` / `results:message` lifecycle, not off the ajax transport alone. The transport hooks stay — they are the accurate signal and the supersession guard is built around them.
- That also covers the 300ms debounce, which the transport hook could never see. To the buyer the search is "in progress" for that whole time, and on a fast connection it is most of the visible wait.
- The field lookup no longer depends on `aria-owns`, which selectWoo sets on open and removes on close — a widget-state check wearing an element lookup's clothes. The fallback is anchored on the results list's static id, so it cannot pick up the country picker's dropdown.

There is an ordering trap in the lifecycle approach that is handled explicitly: handlers run in registration order and the widget registered its own `query` handler first, so for a below-minimum term the `minimumInputLength` decorator has already answered with `results:message` — the hide — by the time the show would run. Without the length guard, every keystroke under three characters would leave a spinner running forever over a "Please enter 3 or more characters" hint with nothing in flight. There is a test for exactly that.

## Test coverage

The vacuity gap that let #5 ship: **every** existing spinner assertion called `genSelectWooParams().ajax.transport` by hand. That proves the transport toggles the spinner and proves nothing about whether the widget ever reaches it. The new assertions type into the query field the dropdown actually renders and let selectWoo's own chain run.

Verified load-bearing by mutation — removing the new lifecycle binding fails four of the new tests, including the one that would have caught the live symptom.

Also added: a describe covering Tab-target resolution (`hidden`-class wrappers, `tabindex="-1"`, hidden inputs, manual-entry mode), capture-state gating for the manual-entry button, `select2:open` placement with no input event anywhere near it, address-area/tile split assertions for all three capture modes, and a PHP assertion pinning the tile label's position between the chips and the intent message.

- `npm run test:js` — 226 passed, 7 suites
- `php tests/unit/run.php` — all passed
- `npx prettier --check` — clean

Docs: `tests/js/README.md` updated for the two rules this reverses. Note it still carries pre-existing staleness elsewhere in the manual-entry section — it describes the pseudo-option `<li role="option">` version that the button rework already replaced. Left alone as out of scope; worth a follow-up.

## Also worth a decision

The leak gate is clean for this diff — it introduces nothing.

It did flag pre-existing matches: a partner-brand ticket prefix already appears in eight files on `staging`, and in one remote branch name. That predates this branch and is already in this public repo's history, so it is surfaced here for a decision rather than quietly scrubbed off the tip — scrubbing would not remove it from history anyway. Details are on TWO-25326 rather than in this description.

## Still unverified

Everything in §1-§7 for WooCommerce, against these changes, in a real browser. Specifically not yet checked at all: §6 (payment-method gating, and that the exact selected name/number are what actually get sent) — that was never reached before the bridge went down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHqsP6xutJexRoEDybQoV4
