### PR TITLE
fix(company-search): land Tab focus on the next control, not back on company-name (TWO-25326 §4)

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -562,15 +562,33 @@ let twoincSelectWooHelper = {
 
         // Resolved BEFORE the close, while the company-name control this is
         // measured from is still the one on screen.
-        const next = helper.nextTabbableAfterCompanyField();
+        const candidates = helper.tabbablesAfterCompanyField();
 
         e.preventDefault();
         helper.closeCompanySearchDropdown();
 
-        if (!next) return;
-        next.focus();
+        // Walk the candidates until one actually takes focus, rather than
+        // focusing one and hoping. This is the fix for what Doug found live on
+        // the first attempt (PR #427): the dropdown closed correctly but focus
+        // stayed on company-name, because the single resolved target could not
+        // take focus, `.focus()` said nothing about it, and selectWoo's own
+        // post-close refocus was left to win by default.
+        //
+        // Falling all the way through means nothing after the company field
+        // can be focused at all. `<body>` is then the honest answer — Tab
+        // again resumes from the top of the document — and it is strictly
+        // better than being dumped back on company-name, which is
+        // indistinguishable from Tab having done nothing.
+        if (!helper.focusFirstThatTakes(candidates)) helper.releaseFocusFromCompanyField();
+
+        // selectWoo schedules `$selection.focus()` 1ms after close,
+        // unconditionally (vendored bundle, `container.on('close')`). 20ms
+        // clears that comfortably. Re-checked rather than re-applied blindly:
+        // only take focus back if the steal actually happened, so a buyer who
+        // clicked somewhere else inside the window is never fought.
         setTimeout(function () {
-          if (document.activeElement !== next) next.focus();
+          if (!helper.focusIsBackOnCompanyField()) return;
+          if (!helper.focusFirstThatTakes(candidates)) helper.releaseFocusFromCompanyField();
         }, 20);
       });
     // NOTE: #search_company_btn's equivalent Enter/Space fix (round 4,
@@ -614,29 +632,25 @@ let twoincSelectWooHelper = {
   /**
    * Is this element hidden, for the purpose of choosing a Tab target?
    *
-   * Deliberately NOT jQuery's `:visible`. That is the more accurate answer in
-   * a browser and the wrong tool here for one reason: it is a LAYOUT query
-   * (`offsetWidth || offsetHeight || getClientRects().length`), and jsdom
-   * implements no layout at all, so under Jest it reports every element in
-   * the document as hidden. A caller filtered on `:visible` would find no tab
-   * target ever, and the test proving the fix works would pass against a
-   * function that always returns null.
+   * A cheap pre-filter, NOT the guarantee. It reads the ways this checkout
+   * actually hides a field — the `hidden` class on the field or an ancestor
+   * (the plugin's and WooCommerce's own convention, and how both company
+   * inputs are hidden behind the picker in search mode), the `hidden`
+   * attribute, and an inline `display: none` — all of which are readable
+   * without layout.
    *
-   * The three checks below are the ways this checkout actually hides a field,
-   * and all of them are readable without layout:
+   * Deliberately NOT jQuery's `:visible`, which is a layout query
+   * (`offsetWidth || offsetHeight || getClientRects().length`). jsdom
+   * implements no layout, so under Jest `:visible` reports every element in
+   * the document as hidden and a filter built on it would find no tab target
+   * ever — the test proving the fix works would pass against a function that
+   * always returns nothing.
    *
-   *   - the `hidden` CLASS on the field or any ancestor — the plugin's and
-   *     WooCommerce's own convention, and how every company field on this
-   *     form is toggled (`#billing_company_field.hidden`, the tile's boxes,
-   *     `toggleBusinessFields`);
-   *   - the `hidden` ATTRIBUTE, for anything a theme hides declaratively;
-   *   - an inline `display: none`, for anything hidden by a script.
-   *
-   * The residual gap is a field hidden by a stylesheet rule that is neither
-   * of those — a theme with its own `.foo { display: none }`. Landing focus
-   * on such a field would be wrong, but it fails safe: the buyer sees focus
-   * apparently vanish and Tabs again, which is where they were before this
-   * function existed. Worth revisiting if a theme is ever found doing it.
+   * What this cannot see is a field hidden by a stylesheet rule that is none
+   * of the above. That is why the caller no longer trusts this: it walks the
+   * candidates in order and CHECKS that focus actually landed, because
+   * `.focus()` on a non-rendered element silently no-ops per the HTML spec.
+   * See `focusFirstThatTakes`.
    *
    * @param {HTMLElement} el
    * @returns {boolean}
@@ -648,7 +662,8 @@ let twoincSelectWooHelper = {
   },
 
   /**
-   * The next real tab-stop after the company-name control (TWO-25326 §4).
+   * Every real tab-stop after the company-name control, in tab order
+   * (TWO-25326 §4).
    *
    * Needed because the dropdown is not where the buyer thinks it is: selectWoo
    * attaches it to the END of `<body>`, so native Tab out of anything inside
@@ -657,44 +672,158 @@ let twoincSelectWooHelper = {
    * to be recomputed from the control's position in the FORM, not from the
    * focused element's position in the document.
    *
-   * Anchored on the select2 combobox in search mode and on `#billing_company`
-   * otherwise, so the same function answers correctly in both capture modes.
+   * Returns a LIST, not just the first hit, and that is the fix for the defect
+   * Doug found on the merged first attempt (PR #427, live-tested 2026-08-02):
+   * Tab closed the dropdown but left focus sitting on company-name. The old
+   * version resolved exactly one element and the caller focused it and assumed
+   * it worked. Any reason that one element could not take focus — chiefly a
+   * theme hiding it by a stylesheet rule this cannot detect, where `.focus()`
+   * silently no-ops — degraded to "nothing focused", which handed the race to
+   * selectWoo's own unconditional post-close `$selection.focus()`. Losing that
+   * race puts focus back on company-name, which is precisely the symptom. With
+   * a list the caller can keep walking until one actually takes.
    *
-   * Everything inside an open select2 is excluded from the candidate list.
-   * Without that the answer would be the query field or this very button —
-   * both of which follow the anchor in document order, both of which are
-   * about to be detached by the close, and neither of which is "the next
-   * control in the tab order" in any sense the buyer would recognise.
+   * Anchored on the select2 combobox in search mode, falling through to the
+   * field wrapper and then the plain input, so the same function answers in
+   * both capture modes and survives the combobox not being where it is
+   * expected. A missing anchor now yields an empty list rather than a null the
+   * caller has to remember to handle.
+   *
+   * Everything inside an open select2 is excluded. Without that the answer
+   * would be the query field or the manual-entry button — both of which follow
+   * the anchor in document order, both of which are about to be detached by
+   * the close, and neither of which is "the next control in the tab order" in
+   * any sense the buyer would recognise.
    *
    * Uses `compareDocumentPosition` rather than an index into the candidate
    * list on purpose: selectWoo flips the combobox's own `tabindex` while the
-   * dropdown is open, so the anchor is not reliably a member of the list it
-   * is being located within, and an index lookup would return -1 exactly when
+   * dropdown is open, so the anchor is not reliably a member of the list it is
+   * being located within, and an index lookup would return -1 exactly when
    * this is called.
    *
-   * @returns {HTMLElement|null} the element to focus, or null if there is
-   *   nothing after the company field (last control on the page)
+   * @returns {Array<HTMLElement>} in document order, possibly empty
    */
-  nextTabbableAfterCompanyField: function () {
-    let $anchor = jQuery("#billing_company_display_field").find(".select2-selection").first();
-    if (!$anchor.length) $anchor = jQuery("#billing_company").first();
-    if (!$anchor.length) return null;
+  tabbablesAfterCompanyField: function () {
+    const anchor = twoincSelectWooHelper.companyFieldTabAnchor();
+    if (!anchor) return [];
 
-    const anchor = $anchor.get(0);
-    let next = null;
+    const found = [];
 
-    // jQuery returns a multi-element selector's matches in document order, so
-    // the FIRST candidate that follows the anchor is the one Tab would reach.
+    // jQuery returns a grouped selector's matches in document order, so
+    // appending in iteration order gives the list in tab order.
     jQuery(twoincSelectWooHelper.tabbableSelector).each(function () {
-      if (next) return;
       if (this.tabIndex < 0) return;
       if (jQuery(this).closest(".select2-container--open, .select2-dropdown").length) return;
       if (twoincSelectWooHelper.isHiddenForTabbing(this)) return;
       if (!((anchor.compareDocumentPosition(this) & 4) /* DOCUMENT_POSITION_FOLLOWING */)) return;
-      next = this;
+      found.push(this);
     });
 
-    return next;
+    return found;
+  },
+
+  /**
+   * The element the Tab traversal is measured from (TWO-25326 §4).
+   *
+   * Three candidates rather than the two the first attempt used, in order of
+   * how precisely they locate the control the buyer is actually tabbing out
+   * of: the rendered combobox, then its `.form-row` wrapper, then the plain
+   * input that manual entry uses. The wrapper is the new middle rung — it is
+   * present whether or not select2 has rendered, and whether or not the
+   * plugin's own field reordering has moved the container, so the anchor no
+   * longer disappears just because the combobox is not where it was looked
+   * for.
+   *
+   * @returns {HTMLElement|null}
+   */
+  companyFieldTabAnchor: function () {
+    const selectors = [
+      "#billing_company_display_field .select2-selection",
+      "#billing_company_display_field",
+      "#billing_company"
+    ];
+
+    for (let i = 0; i < selectors.length; i++) {
+      const el = jQuery(selectors[i]).get(0);
+      if (el) return el;
+    }
+
+    return null;
+  },
+
+  /**
+   * Focus the first candidate that will actually accept focus (TWO-25326 §4).
+   *
+   * `.focus()` is not a request that can be relied on to succeed: per the HTML
+   * spec it silently does nothing on an element that is not being rendered,
+   * and returns nothing to say so. A caller that focuses one element and moves
+   * on cannot tell "focused" from "no-op", which is the whole reason the first
+   * attempt at this fix shipped broken.
+   *
+   * So: try, then read `document.activeElement` back, and keep walking on
+   * failure. The verification is what makes the visibility pre-filter in
+   * `isHiddenForTabbing` an optimisation rather than a correctness
+   * requirement — a field hidden in a way this plugin cannot detect costs one
+   * wasted `.focus()` call and nothing else.
+   *
+   * @param {Array<HTMLElement>} candidates in tab order
+   * @returns {HTMLElement|null} the element that took focus, or null
+   */
+  focusFirstThatTakes: function (candidates) {
+    for (let i = 0; i < candidates.length; i++) {
+      candidates[i].focus();
+      if (document.activeElement === candidates[i]) return candidates[i];
+    }
+
+    return null;
+  },
+
+  /**
+   * Is focus back on the company-name control? (TWO-25326 §4)
+   *
+   * Asked after the dropdown closes, to tell selectWoo's unconditional
+   * post-close `$selection.focus()` — scheduled 1ms out, in the vendored
+   * bundle's `container.on('close')` — apart from the buyer having deliberately
+   * gone somewhere themselves in the meantime. Only the former is worth
+   * fighting.
+   *
+   * Nothing focused (`<body>`) counts as yes. Either the traversal found no
+   * target and released focus deliberately, or the browser dropped it when the
+   * dropdown was torn out from under it; both are worth one more attempt at
+   * the candidates now that the dropdown is gone. What must NOT count is focus
+   * sitting on some other real control, which only the buyer can have caused.
+   *
+   * @returns {boolean}
+   */
+  focusIsBackOnCompanyField: function () {
+    const active = document.activeElement;
+    if (!active || active === document.body) return true;
+
+    return (
+      jQuery(active).closest("#billing_company_display_field").length > 0 ||
+      active === jQuery("#billing_company").get(0)
+    );
+  },
+
+  /**
+   * Give up on finding a tab target, but do not let the buyer be dumped back
+   * where they started (TWO-25326 §4).
+   *
+   * If nothing after the company field can take focus, `<body>` is the honest
+   * answer — the buyer presses Tab again and the browser resumes from the top
+   * of the document. Leaving focus on the company-name control instead is
+   * strictly worse: it is indistinguishable from Tab having done nothing at
+   * all, which is exactly what was reported live.
+   *
+   * @returns {void}
+   */
+  releaseFocusFromCompanyField: function () {
+    const active = document.activeElement;
+    if (!active || typeof active.blur !== "function") return;
+    if (!twoincSelectWooHelper.focusIsBackOnCompanyField()) return;
+    if (active === document.body) return;
+
+    active.blur();
   },
 
   /**

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -493,8 +493,8 @@ describe("company-search manual-entry affordance", () => {
 
       // Resolved here, from the same function the handler uses, while the
       // dropdown is still up — which is also when the handler resolves it.
-      const expectedNext = helper.nextTabbableAfterCompanyField();
-      expect(expectedNext).not.toBeNull();
+      const expectedNext = helper.tabbablesAfterCompanyField()[0];
+      expect(expectedNext).toBeDefined();
       expect(document.activeElement).not.toBe(expectedNext);
 
       const e2 = tabAt(btn());
@@ -1628,29 +1628,45 @@ describe("company-search manual-entry affordance", () => {
   });
 
   describe("choosing the Tab target out of the dropdown (TWO-25326 §4)", () => {
-    test("it is the next tabbable control after the company field, in FORM order", () => {
-      openWithAffordance();
+    /** @returns {HTMLElement|undefined} first candidate, for the common case */
+    function firstTarget() {
+      return helper.tabbablesAfterCompanyField()[0];
+    }
 
-      const next = helper.nextTabbableAfterCompanyField();
+    test("the first candidate is the next tabbable control after the company field, in FORM order", () => {
+      openWithAffordance();
 
       // Not the query field and not the button, even though both follow the
       // anchor in DOCUMENT order — the dropdown is attached to the end of
       // <body>, which is the whole reason native Tab could not do this.
-      expect(next).toBe($("#billing_company").get(0));
+      expect(firstTarget()).toBe($("#billing_company").get(0));
+    });
+
+    test("it returns EVERY following tab stop, in order, not just the first", () => {
+      // The list is the fix for the live defect on PR #427. One resolved
+      // element gave the caller no way to recover when that element turned
+      // out not to be focusable, and "nothing focused" hands the race to
+      // selectWoo's post-close refocus — which lands on company-name, exactly
+      // what Doug reported.
+      openWithAffordance();
+
+      expect(helper.tabbablesAfterCompanyField()).toEqual([
+        $("#billing_company").get(0),
+        $("#company_id").get(0)
+      ]);
     });
 
     test("controls hidden by the `hidden` class are skipped, along with their contents", () => {
       // How this checkout hides a field: the class goes on the `.form-row`
-      // wrapper, not the input. Landing focus on an invisible input is the
-      // failure this guards, and in search mode BOTH company inputs are
-      // hidden that way behind the picker.
+      // wrapper, not the input. In search mode BOTH company inputs are hidden
+      // that way behind the picker.
       openWithAffordance();
       $("#billing_company_field, #company_id_field").addClass("hidden");
 
-      expect(helper.nextTabbableAfterCompanyField()).toBeNull();
+      expect(helper.tabbablesAfterCompanyField()).toEqual([]);
 
       $("#company_id_field").removeClass("hidden");
-      expect(helper.nextTabbableAfterCompanyField()).toBe($("#company_id").get(0));
+      expect(firstTarget()).toBe($("#company_id").get(0));
     });
 
     test("`tabindex=-1` and hidden inputs are not tab stops", () => {
@@ -1660,23 +1676,159 @@ describe("company-search manual-entry affordance", () => {
         '<input type="hidden" id="a_hidden_input" name="a_hidden_input" value="x" />'
       );
 
-      expect(helper.nextTabbableAfterCompanyField()).toBe($("#company_id").get(0));
+      expect(firstTarget()).toBe($("#company_id").get(0));
     });
 
-    test("nothing after the company field at all answers null rather than guessing", () => {
+    test("nothing after the company field at all answers an empty list", () => {
       openWithAffordance();
       $("#billing_company_field, #company_id_field").remove();
 
-      expect(helper.nextTabbableAfterCompanyField()).toBeNull();
+      expect(helper.tabbablesAfterCompanyField()).toEqual([]);
     });
 
-    test("in manual-entry mode it anchors on the real input, not the absent picker", () => {
-      // The combobox does not exist in manual entry, so an anchor lookup that
-      // only knew about it would return null and Tab would go nowhere.
+    test("the anchor falls through the combobox, then its wrapper, then the plain input", () => {
+      // Three rungs rather than two. The wrapper is the one added after the
+      // live failure: it is present whether or not select2 has rendered and
+      // wherever the plugin's own field reordering has put the container, so
+      // the anchor no longer vanishes just because the combobox was not found
+      // where it was looked for — and a vanished anchor is an empty candidate
+      // list, which is how focus ended up stranded on company-name.
       openWithAffordance();
-      $("#billing_company_display_field").remove();
+      expect(helper.companyFieldTabAnchor()).toBe(
+        $("#billing_company_display_field .select2-selection").get(0)
+      );
 
-      expect(helper.nextTabbableAfterCompanyField()).toBe($("#company_id").get(0));
+      $("#billing_company_display_field").find(".select2-container").remove();
+      expect(helper.companyFieldTabAnchor()).toBe($("#billing_company_display_field").get(0));
+
+      $("#billing_company_display_field").remove();
+      expect(helper.companyFieldTabAnchor()).toBe($("#billing_company").get(0));
+
+      $("#billing_company_field").remove();
+      expect(helper.companyFieldTabAnchor()).toBeNull();
+    });
+  });
+
+  describe("landing the focus, not just aiming it (TWO-25326 §4)", () => {
+    /**
+     * Dispatch a real Tab keydown, the way the browser would. Same shape and
+     * same `which: 9` reasoning as the copy in the shortcut describe above.
+     *
+     * @param {Object} $el
+     * @returns {Object} the jQuery.Event dispatched
+     */
+    function tabAt($el) {
+      const e = jQuery.Event("keydown", { key: "Tab", which: 9 });
+      $el.trigger(e);
+      return e;
+    }
+
+    /**
+     * A candidate that refuses focus, the way a non-rendered element does in
+     * a real browser: `.focus()` is called, nothing happens, and nothing is
+     * returned to say so. jsdom does not enforce that rule — it focuses
+     * anything — so the behaviour has to be modelled explicitly or no test
+     * here can exercise the recovery path at all.
+     *
+     * @returns {HTMLElement} an element whose focus() is a no-op
+     */
+    function unfocusable() {
+      const el = document.createElement("input");
+      document.body.appendChild(el);
+      el.focus = function () {};
+      return el;
+    }
+
+    test("skips a candidate whose focus() silently does nothing", () => {
+      openWithAffordance();
+      const dead = unfocusable();
+      const live = $("#billing_company").get(0);
+
+      expect(helper.focusFirstThatTakes([dead, live])).toBe(live);
+      expect(document.activeElement).toBe(live);
+    });
+
+    test("answers null when no candidate will take focus", () => {
+      openWithAffordance();
+
+      expect(helper.focusFirstThatTakes([unfocusable(), unfocusable()])).toBeNull();
+    });
+
+    test("an empty candidate list is not an error", () => {
+      openWithAffordance();
+
+      expect(helper.focusFirstThatTakes([])).toBeNull();
+    });
+
+    test("a Tab that can find nothing focusable releases the field rather than sitting on it", () => {
+      // The live symptom being fixed: focus left on company-name is
+      // indistinguishable from Tab having done nothing. <body> at least lets
+      // the next Tab resume from the top of the document.
+      jest.useFakeTimers();
+      openWithAffordance();
+      type("abc");
+
+      // Nothing after the company field can be focused.
+      $("#billing_company_field, #company_id_field").addClass("hidden");
+      expect(helper.tabbablesAfterCompanyField()).toEqual([]);
+
+      btn().get(0).focus();
+      tabAt(btn());
+
+      expect(document.activeElement).toBe(document.body);
+
+      // And selectWoo's post-close refocus does not get to undo that.
+      jest.advanceTimersByTime(30);
+      expect(document.activeElement).toBe(document.body);
+      jest.useRealTimers();
+    });
+
+    test("focus stolen back to the company field inside the window is taken back again", () => {
+      // selectWoo's `container.on('close')` fires `$selection.focus()` 1ms
+      // out, unconditionally. Modelled directly here rather than relying on
+      // the widget's own timing, so the recovery is pinned even if the
+      // vendored bundle changes when it fires.
+      jest.useFakeTimers();
+      openWithAffordance();
+      type("abc");
+
+      btn().get(0).focus();
+      tabAt(btn());
+      const landed = $("#billing_company").get(0);
+      expect(document.activeElement).toBe(landed);
+
+      $("#billing_company_display_field").find(".select2-selection").get(0).focus();
+
+      jest.advanceTimersByTime(30);
+
+      expect(document.activeElement).toBe(landed);
+      jest.useRealTimers();
+    });
+
+    test("a buyer who moves on themselves is not dragged back", () => {
+      jest.useFakeTimers();
+      openWithAffordance();
+      type("abc");
+
+      btn().get(0).focus();
+      tabAt(btn());
+
+      // Let selectWoo's own 1ms post-close refocus land FIRST. Ordering is the
+      // point: the buyer can only meaningfully "move on themselves" after that
+      // steal, and modelling their click before it would be modelling a 1ms
+      // window that no human is in. (Inside that window the steal wins and
+      // this code then moves focus to its own target rather than the buyer's
+      // click — an accepted trade, and still better than leaving it on
+      // company-name.)
+      jest.advanceTimersByTime(5);
+
+      const elsewhere = $("#billing_country").get(0);
+      elsewhere.focus();
+
+      jest.advanceTimersByTime(30);
+
+      expect(document.activeElement).toBe(elsewhere);
+      jest.useRealTimers();
     });
   });
 });


### PR DESCRIPTION
## ⚠️ NOT LIVE-BROWSER-VERIFIED

The Chrome bridge is still unavailable (the Windows-side subprocess exits immediately on the org monthly spend limit — re-tested at the start of this pass, still blocked). So this fix is backed by Jest only, which the TWO-25326 process explicitly says is not a substitute. **Needs a live Tab test before it can be called done.**

## What Doug found

Live-testing the merged PR #427 with real clicks and keypresses:

- **Spinner: confirmed fixed.** Nothing more owed there.
- **Tab-close: partial.** Tab from "My company is not on the list" now closes the dropdown — that half works — but focus stays *on* company-name instead of advancing to the next tab stop after it. From the buyer's side that is still indistinguishable from Tab doing nothing.

## Why it happened

Not the race I was worried about. selectWoo's post-close `$selection.focus()` fires 1ms out (checked against the vendored bundle, `container.on('close')`) and the existing 20ms re-assert comfortably beats it. The problem was upstream.

`nextTabbableAfterCompanyField()` resolved exactly **one** element, and the handler focused it and assumed it worked:

```js
if (!next) return;
next.focus();
```

`.focus()` on an element that is not being rendered **silently no-ops** per the HTML spec, and returns nothing to say so. So any target that could not take focus left nothing focused at all — which handed the race back to selectWoo by default, and losing that race lands focus on company-name. Exactly the reported symptom. An empty result from a missed anchor lookup (`if (!next) return`) fails identically.

Two plausible triggers, and I could not distinguish them without a browser:

1. The one resolved target was a field hidden by a stylesheet rule that `isHiddenForTabbing`'s class/attribute/inline-style checks cannot see, so it was offered as a candidate and then refused focus.
2. The anchor lookup (`#billing_company_display_field .select2-selection`, falling back to `#billing_company`) found nothing, giving an empty list.

## The fix

Deliberately built so it does not depend on knowing which of the two it was — both are covered, and so is any third cause with the same shape.

- **`tabbablesAfterCompanyField()` returns every following tab stop in order**, not just the first, so the caller can keep walking.
- **`focusFirstThatTakes()` verifies.** It focuses a candidate, reads `document.activeElement` back, and moves to the next one if it did not land. This demotes the class-based visibility filter from a correctness requirement to a cheap pre-filter — a field hidden in a way the plugin cannot detect now costs one wasted `.focus()` call instead of breaking the feature.
- **Nothing focusable releases the field.** If no candidate takes focus, the company field is blurred so focus falls to `<body>`. Tab then resumes from the top of the document, which is honest. Being dumped back on company-name is worse than nothing, because it reads as a dead key.
- **A third anchor rung**: the field wrapper `#billing_company_display_field`, between the combobox and the plain input. It is present whether or not select2 has rendered and wherever the plugin's own field reordering has moved the container, so the traversal's starting point cannot vanish the way it could before.
- **The 20ms re-assert re-runs the same walk** rather than blindly refocusing one element, and only fires when focus is actually back on the company field or nowhere — so a buyer who has moved on under their own steam is never fought.

## Tests

`npm run test:js` — 233 passed, 7 suites. `npx prettier@3.1.0 --check` clean (pinned to the pre-commit version; the node_modules copy disagrees about one expression).

New coverage, in two describes. The recovery path needs an element whose `focus()` is a no-op, modelled explicitly — jsdom does not enforce the spec's non-rendered rule and will focus anything, so without modelling it no test here could exercise the fix at all.

Mutation-verified rather than assumed:

| Mutation | Tests that fail |
|---|---|
| `focusFirstThatTakes` stops verifying (i.e. the old blind focus) | 2 |
| the release-on-nothing-focusable is dropped | 1 |
| the wrapper anchor rung is dropped | 1 |

One behaviour recorded rather than fixed, in a test comment: if the buyer clicks elsewhere in the ~1ms before selectWoo's steal, the steal wins and this code then moves focus to its own target rather than to their click. Accepted — the window is 1ms, and the outcome is still better than focus sitting on company-name.

## Still unverified

The literal thing Doug tested: press Tab from "My company is not on the list" on the real staging checkout and confirm focus lands on the next form control after the company field, with the dropdown closed. Also worth re-checking that the §1 spinner he confirmed fixed is unaffected — this touches the same handler file but not the spinner path.

Leak gate clean for this diff (introduces nothing; the pre-existing matches already reported on TWO-25326 are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHqsP6xutJexRoEDybQoV4
