### PR TITLE
fix(company-search): a captured company must not lock the buyer out of manual entry or the keyboard (TWO-25326 §2/§4)

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -284,20 +284,29 @@ let twoincSelectWooHelper = {
   syncManualEntryButton: function () {
     const helper = twoincSelectWooHelper;
 
-    const $display = jQuery("#billing_company_display");
-    const picker = $display.data("select2");
+    const picker = jQuery("#billing_company_display").data("select2");
     if (!picker || !picker.$results || !picker.$results.length) return;
 
     const $list = picker.$results;
     const $existing = jQuery("#" + helper.manualEntryRowId);
 
-    // The empty option's label is a non-breaking space, so an unselected
-    // picker reads back as " " rather than "" — the same trap
-    // renderCompanySummary documents. blankToEmpty collapses both.
-    if (twoincUtilHelper.blankToEmpty($display.val())) {
-      $existing.remove();
-      return;
-    }
+    // No capture gate. There was one — the button was removed as soon as
+    // `#billing_company_display` held a value — and it was wrong, found live
+    // by Doug 2026-08-02: pick a company, reopen the dropdown to change it,
+    // and there was no route into manual entry at all any more. Worse than
+    // the threshold gate it replaced, because typing no longer brought it
+    // back either.
+    //
+    // §2's "hidden once a company IS selected" cannot mean that. This button
+    // only ever exists inside the dropdown, so it is only ever on screen
+    // while the dropdown is open — and the dropdown being open IS the buyer
+    // searching again. "Hidden once selected" is satisfied by the dropdown
+    // being shut; it does not extend to locking a buyer out of manual entry
+    // because of a pick they are in the middle of correcting.
+    //
+    // That gate also silently disabled the Tab shortcut, since the handler
+    // below keys on the button existing — which is how one regression
+    // presented as two (§2 invisible, §4 keyboard trap).
 
     // Already there, immediately after the current results list: nothing to
     // do. Load-bearing rather than an optimisation for the same reason it was
@@ -434,19 +443,43 @@ let twoincSelectWooHelper = {
       .on("keydown.twoincManualEntry", helper.companySearchInputSelector, function (e) {
         if (e.which !== 9 || e.shiftKey) return;
 
+        // No button to shortcut to — a brand overlay that drops the
+        // affordance, or any future gating — must NOT fall through to the
+        // browser's own Tab. Measured live 2026-08-02, in exactly that state:
+        // selectWoo's document-level handler swallows the keystroke whole
+        // (`preventDefault` + refocus the search field), so focus never left
+        // the query field and the dropdown never closed. That is a keyboard
+        // trap, which §4 forbids outright, and it is what the removed capture
+        // gate above was producing. Close and move on instead, the same way
+        // Tab from the button does.
         const btn = jQuery("#" + helper.manualEntryRowId).get(0);
-        if (!btn) return;
+        if (!btn) {
+          const onwards = helper.tabbablesAfterCompanyField();
+          e.preventDefault();
+          e.stopPropagation();
+          helper.closeCompanySearchDropdown();
+          if (!helper.focusFirstThatTakes(onwards)) helper.releaseFocusFromCompanyField();
+          setTimeout(function () {
+            if (!helper.focusIsBackOnCompanyField()) return;
+            if (!helper.focusFirstThatTakes(onwards)) helper.releaseFocusFromCompanyField();
+          }, 20);
+          return;
+        }
 
-        // Accepted risk, not handled: if the button happens to be hidden or
-        // mid-transition at this exact moment, `.focus()` on a real browser
-        // silently no-ops per the HTML spec (unlike jsdom, which does not
-        // reliably enforce this, so no test here can catch it either way).
-        // The buyer is left with focus stuck on the search field — no worse
-        // than before this feature existed, just not the "Tab reaches the
-        // button" this comment otherwise promises.
+        // `.focus()` on a button that is hidden or mid-transition silently
+        // no-ops per the HTML spec, so confirm it landed rather than assume —
+        // same lesson as the Tab-out handler below, which shipped broken for
+        // exactly this reason. If the button will not take focus, fall
+        // through to closing and moving on rather than stranding the buyer.
         e.preventDefault();
         e.stopPropagation();
         btn.focus();
+        if (document.activeElement !== btn) {
+          const onwards = helper.tabbablesAfterCompanyField();
+          helper.closeCompanySearchDropdown();
+          if (!helper.focusFirstThatTakes(onwards)) helper.releaseFocusFromCompanyField();
+          return;
+        }
 
         setTimeout(function () {
           const stillThere = jQuery("#" + helper.manualEntryRowId).get(0);

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -140,7 +140,20 @@ describe("company-search manual-entry affordance", () => {
     expect(searchInput().length).toBe(1);
   });
 
-  describe("visibility follows capture state, not the search threshold (TWO-25326 §2)", () => {
+  describe("visibility: present whenever the dropdown is open (TWO-25326 §2)", () => {
+    /**
+     * Dispatch a real Tab keydown at the query field. Same `which: 9`
+     * reasoning as the copies in the Tab describes below.
+     *
+     * @param {Object} $el
+     * @returns {Object} the jQuery.Event dispatched
+     */
+    function tabAtSearch($el) {
+      const e = jQuery.Event("keydown", { key: "Tab", which: 9 });
+      $el.trigger(e);
+      return e;
+    }
+
     test("present as soon as the dropdown opens, before the buyer has typed anything", () => {
       openWithAffordance();
 
@@ -202,7 +215,15 @@ describe("company-search manual-entry affordance", () => {
       expect(btn().length).toBe(1);
     });
 
-    test("gone once a company IS captured", () => {
+    test("still there after a company has been captured and the dropdown reopened", () => {
+      // The regression Doug found live on 2026-08-02. A capture gate used to
+      // remove the button as soon as the display select held a value, so a
+      // buyer who picked the wrong company and reopened the dropdown to
+      // correct it had no route into manual entry at all — and typing no
+      // longer brought it back, which the threshold gate before it at least
+      // did. §2's "hidden once a company IS selected" is satisfied by the
+      // dropdown being shut; it does not mean locking the buyer out of manual
+      // entry mid-correction.
       openWithAffordance();
       expect(btn().length).toBe(1);
 
@@ -211,20 +232,26 @@ describe("company-search manual-entry affordance", () => {
       );
       helper.syncManualEntryButton();
 
-      expect(btn().length).toBe(0);
+      expect(btn().length).toBe(1);
     });
 
-    test("the empty option's non-breaking space does not read as a capture", () => {
-      // selectWoo's placeholder option carries   as its label and, on this
-      // field, as its value — so a naive truthiness check on the select's
-      // value reports a company captured on an untouched field and hides the
-      // button on exactly the state the requirement is written about.
+    test("a captured company does not disable the Tab shortcut either", () => {
+      // The same gate took the keyboard with it: the search-field Tab handler
+      // keys on the button existing, so removing the button turned Tab into a
+      // no-op that selectWoo's own document handler then swallowed whole —
+      // one regression presenting as two (§2 invisible, §4 keyboard trap).
       openWithAffordance();
-
-      $("#billing_company_display").append('<option value=" " selected> </option>');
+      $("#billing_company_display").append(
+        '<option value="ACME Widgets Ltd" selected>ACME Widgets Ltd</option>'
+      );
       helper.syncManualEntryButton();
+      type("abc");
 
-      expect(btn().length).toBe(1);
+      searchInput().get(0).focus();
+      const e = tabAtSearch(searchInput());
+
+      expect(e.isDefaultPrevented()).toBe(true);
+      expect(document.activeElement).toBe(btn().get(0));
     });
   });
 
@@ -368,26 +395,52 @@ describe("company-search manual-entry affordance", () => {
       expect(document.activeElement).not.toBe(btn().get(0));
     });
 
-    test("Tab is not intercepted when there is no button to reach", () => {
-      // Same reasoning as the Shift+Tab test above re: not asserting
-      // `isDefaultPrevented()` — that reflects selectWoo's own document-level
-      // Tab-as-Enter handling, not this feature. The contract under test is
-      // the `!btn` early return: nothing gets created or focused when the
-      // button is not there.
-      //
-      // The button now exists from the moment the dropdown opens (TWO-25326
-      // §2), so a below-threshold term no longer produces this state and the
-      // absence has to be arranged directly. It is still reachable in
-      // production — a brand overlay that removes the affordance, or a
-      // captured company, both leave the dropdown open with no button in it.
+    test("Tab with no button to reach still closes the dropdown and moves on", () => {
+      // Measured live 2026-08-02 in exactly this state: with no button, this
+      // handler used to `return` and let the keystroke through — straight into
+      // selectWoo's document-level handler, which swallows it whole
+      // (preventDefault + refocus the search field). Focus never left the
+      // query field and the dropdown never closed. That is the keyboard trap
+      // §4 forbids, and "no button" is reachable in production through a brand
+      // overlay that drops the affordance.
+      jest.useFakeTimers();
       openWithAffordance();
+      type("abc");
       btn().remove();
       expect(btn().length).toBe(0);
+
+      const onwards = helper.tabbablesAfterCompanyField()[0];
+      expect(onwards).toBeDefined();
+
+      searchInput().get(0).focus();
+      const e = tabAt(searchInput());
+
+      expect(e.isDefaultPrevented()).toBe(true);
+      expect($("#billing_company_display").data("select2").isOpen()).toBe(false);
+      expect(document.activeElement).toBe(onwards);
+
+      jest.advanceTimersByTime(30);
+      expect(document.activeElement).toBe(onwards);
+      jest.useRealTimers();
+    });
+
+    test("a button that refuses focus is not a dead end either", () => {
+      // `.focus()` on a hidden or mid-transition element silently no-ops per
+      // the HTML spec. The shortcut used to call it and assume — the same
+      // mistake that shipped in the Tab-out handler and had to be fixed there.
+      jest.useFakeTimers();
+      openWithAffordance();
+      type("abc");
+      btn().get(0).focus = function () {};
+
+      const onwards = helper.tabbablesAfterCompanyField()[0];
 
       searchInput().get(0).focus();
       tabAt(searchInput());
 
-      expect(btn().length).toBe(0);
+      expect($("#billing_company_display").data("select2").isOpen()).toBe(false);
+      expect(document.activeElement).toBe(onwards);
+      jest.useRealTimers();
     });
 
     test("no-trap regression check: closing the dropdown removes this handler's own hook, not just the button", () => {


### PR DESCRIPTION
Fixes two of the three defects Doug found live on 2026-08-02. **Both are verified in a real browser** — see the evidence section. The third is diagnosed and turns out not to be what it looked like; details at the bottom.

## The two defects were one regression

The capture gate added in PR #427 removed the "My company is not on the list" button as soon as `#billing_company_display` held a value. That produced both reports:

**§2 — "invisible entirely, worse than before".** Pick a company, reopen the dropdown to correct it, and there is no route into manual entry at all. Worse than the search-threshold gate it replaced, because typing no longer brought it back either. Confirmed in the browser: with a company selected, `#company_not_in_btn` does not exist in the DOM.

**§1/§4 — "Tab still doesn't work".** The search-field Tab handler keys on that button existing. With no button it did `return` and let the keystroke through to selectWoo's own document-level handler, which swallows it whole — `preventDefault` plus refocus the search field. Measured in that exact state: one real Tab press, focus stayed on `input.select2-search__field`, dropdown still in the DOM, `isOpen()` still true. A keyboard trap, which §4 forbids outright.

So PR #428's traversal was not the problem — it was never reached. Verified separately: with the button present, Tab has been landing on `#billing_address_1` correctly all along.

## Changes

**The capture gate is gone.** §2's "hidden once a company IS selected" cannot mean what it did. This button only exists inside the dropdown, so it is only ever on screen while the dropdown is open — and the dropdown being open *is* the buyer searching again. The clause is satisfied by the dropdown being shut; it does not extend to locking someone out mid-correction.

**Tab out of the query field no longer depends on the button.** If there is no button to shortcut to — a brand overlay dropping the affordance, or any future gating — it closes the dropdown and advances to the next real tab stop rather than falling through to a handler that traps focus.

**The shortcut confirms the button actually took focus.** `.focus()` on a hidden or mid-transition element silently no-ops per the HTML spec. That assumption is what shipped broken in the Tab-out handler and had to be fixed in #428; the same assumption was still sitting in this handler. If the button will not take focus, this path closes and advances too.

## Browser evidence

Live staging checkout, this build's code injected into the page, real mouse clicks and real Tab keypresses (not synthetic events):

| Step | Result |
|---|---|
| Company selected, dropdown reopened | `#company_not_in_btn` **exists**, `display: block`, `visibility: visible`, rect 602×41, offsetParent is the dropdown panel — where before the patch, in this exact state, it did not exist at all |
| Tab from the query field | focus → `BUTTON#company_not_in_btn`, dropdown still open |
| Tab again | focus → `INPUT#billing_address_1`, `select2-dropdown` gone from the DOM, `isOpen()` **false** |
| Same, from a dropdown opened without typing anything | identical: button, then `#billing_address_1`, `isOpen()` false |

## Tests

`npm run test:js` — 234 passed, 7 suites. `prettier@3.1.0` clean (pinned to the pre-commit version).

New coverage: the button survives a capture and a dropdown reopen; a captured company does not disable the Tab shortcut; Tab with no button still closes and advances; a button that refuses focus is not a dead end. The last one needs an element whose `focus()` is a no-op, modelled explicitly — jsdom does not enforce the spec's non-rendered rule.

## The third defect is not a label bug — do not "fix" it the way it was described

Reported as: the tile's name/number label appears on selection, then disappears once the intent check begins.

It did not reproduce on an idle intent check (polled every 500ms for 60s — label populated on selection and stayed populated straight through the intent box appearing, same DOM node throughout), nor on a forced `update_checkout`, nor on a term-chip click.

It **does** reproduce on a payment-method round trip — switch to another method and back. But the label is not being wiped. The captured company is:

```
{"probe":"P1","txt":"","n":1,
 "sum":"<div id=\"twoinc_company_summary\" class=\"twoinc-company-summary hidden\"><span class=\"twoinc-company-summary-id\"></span></div>",
 "bc":"","cid":""}
```

`data-probe` survived, so the element was never replaced — it was correctly re-rendered as empty, because `#billing_company` and `#company_id` are **both empty**. The address-area summary is blank for the same reason. Calling `renderCompanySummary()` by hand does not repopulate it, correctly, because there is nothing captured to render.

This diff and the two before it never write those two fields (checked: no such write appears anywhere in the added lines). The plausible mechanism is `clearSelectedCompany()` firing from `onCountryInputChange` on a spurious `change` during WooCommerce's checkout re-render — which is TWO-24867, "country-switch breaks company search and autofill (PS, WC)", already linked from TWO-25326.

Two reasons this matters more than a cosmetic label:

1. It is a data-integrity bug, not a display one. The buyer sees a company in the combobox while the fields the order actually posts are empty — §6 territory.
2. **Making the label persist here would be the wrong fix.** It would display a company the order is not carrying, which is precisely the failure the existing `readCapturedCompany` comments were written to prevent. The label is doing its job by going blank; it is the first thing in the tile that ever made this visible.

Left for a decision rather than patched over. Nothing in this PR changes that behaviour either way.

## Other

Leak gate clean for this diff. One incidental, not chased and not introduced here: on a fresh load the first real click on the company control sometimes does not open the dropdown and a second is needed — seen intermittently across several browser runs, and it may be a bridge click-dispatch artefact rather than a page bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHqsP6xutJexRoEDybQoV4
