### PR TITLE
fix(checkout): react to a real country change, and only to a real one (TWO-24867)

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -936,6 +936,9 @@ let twoincSelectWooHelper = {
    * supersession check — so those three can never disagree about what "the
    * current country" is.
    *
+   * `twoincSoleTrader.currentCountry()` delegates to this one, so the
+   * per-country availability cache cannot be keyed on a different answer.
+   *
    * NOT the only reader in the file: `getCompanyData()` and
    * `isCountrySupported()` still read `.val()` raw and uncased, so the
    * `country_prefix` this file's handler writes upper-cased is replaced with
@@ -2895,8 +2898,12 @@ let twoincSoleTrader = {
     return (window.twoinc && window.twoinc.sole_trader) || {};
   },
 
+  // Delegated rather than a second copy of the same two lines (TWO-24867):
+  // sole-trader availability is decided per country and cached per country,
+  // so it disagreeing with the country the search and the change guard use
+  // would be a cache keyed on one answer and read with another.
   currentCountry: function () {
-    return (jQuery("#billing_country").val() || "").toUpperCase();
+    return twoincSelectWooHelper.currentCountry();
   },
 
   enteredEmail: function () {
@@ -3561,18 +3568,8 @@ class Twoinc {
       twoincDomHelper.togglePaySubtitleDesc();
     });
 
-    // Handle the country inputs change event.
-    //
-    // Seeded first (TWO-25326 / TWO-24867), through the same single writer
-    // the handler uses. The handler only acts when the value differs from the
-    // last one recorded, and with no seed the FIRST country the page ever
-    // sees is adopted rather than acted on — correct for the re-render event
-    // WooCommerce fires at init (core's address-i18n.js triggers
-    // `country_to_state_changing` carrying the country the form already had),
-    // but wrong for a buyer who changes country before any re-render happens:
-    // their switch would be the first known country and would be swallowed.
-    // Seeding here is what tells those two apart.
-    twoincSelectWooHelper.countryDidChange(twoincSelectWooHelper.currentCountry());
+    // Handle the country inputs change event. The tracker behind it is seeded
+    // at the END of this function, not here — see the comment there.
     $body.on("change", "#billing_country", self.onCountryInputChange);
 
     // Re-evaluate the sole-trader autofill prefetch whenever the email
@@ -3604,6 +3601,29 @@ class Twoinc {
 
     twoincDomHelper.loadUserMetaInputs();
     if (loadSavedInputs) twoincDomHelper.loadStorageInputs();
+
+    // Seed the country tracker HERE — after the two restore passes above, not
+    // next to the binding that reads it (TWO-24867 / TWO-25326).
+    //
+    // `loadStorageInputs()` writes #billing_country with `selectElem.value =`
+    // and fires no `change`. Seeded before it, the tracker held the country
+    // the page was rendered with while the field held the restored one, and
+    // the first re-render afterwards read the difference as a real country
+    // change — destroying the company and address that same restore had just
+    // put back. The bootstrap's own call is `initialize(true)`, so that is the
+    // production path, not an edge case.
+    //
+    // Seeding at all is what tells the two first-event cases apart: with no
+    // seed the FIRST country the page ever sees is adopted rather than acted
+    // on — right for the re-render WooCommerce fires at init (core's
+    // address-i18n.js triggers `country_to_state_changing` carrying the
+    // country the form already had), wrong for a buyer who changes country
+    // before any re-render happens.
+    //
+    // Through `countryDidChange` rather than by assignment, so this file has
+    // exactly one writer for the tracker.
+    twoincSelectWooHelper.countryDidChange(twoincSelectWooHelper.currentCountry());
+
     setTimeout(function () {
       twoincDomHelper.saveCheckoutInputs();
       Twoinc.getInstance().customerCompany = twoincDomHelper.getCompanyData();
@@ -3840,12 +3860,15 @@ class Twoinc {
     });
     addressResponse.done(function (response) {
       if (seq !== self.addressLookupSeq) return;
-      // An empty reading means the field is mid-replacement, not that the
-      // country moved — discarding a good registry address on it would be a
-      // silent failure with no retry and no message. Only a country that is
-      // known AND different is grounds to drop this.
+      // An empty reading on EITHER side means the field was mid-replacement,
+      // not that the country moved — discarding a good registry address on it
+      // would be a silent failure with no retry and no message. Both sides
+      // matter: a lookup issued during a replacement snapshots "", and
+      // comparing that against a known country would drop every response.
+      // Only two countries that are both known AND different are grounds to
+      // drop this.
       const landedCountry = twoincSelectWooHelper.currentCountry();
-      if (landedCountry && landedCountry !== requestCountry) return;
+      if (requestCountry && landedCountry && landedCountry !== requestCountry) return;
       // Use new address lookup by default
       if (response.addresses) {
         self.setAddress(response.addresses[0]);
@@ -3923,9 +3946,19 @@ class Twoinc {
    * Handle the woocommerce updated checkout event
    */
   onUpdatedCheckout() {
-    // First: a re-render can have moved the billing country without firing a
-    // `change`, and everything below reads state that depends on it.
-    Twoinc.getInstance().syncBillingCountry();
+    // RECORD the billing country, and nothing else (TWO-24867). A re-render
+    // can move the field with no `change` event — a `checkout_error`
+    // re-render, a multi-step theme, a session address restored server-side —
+    // and without this the tracker would hold the pre-re-render country for
+    // the rest of the page, so a later genuine switch BACK to that value
+    // would read as no change and be swallowed.
+    //
+    // Deliberately NOT `syncBillingCountry()`. These re-renders restore the
+    // country and the company together, so clearing the capture here would
+    // destroy what the same re-render just put back — the TWO-25326 failure
+    // on a new trigger. Throwing away a captured company needs the buyer's
+    // gesture, and the `change` event is the only signal of one there is.
+    twoincSelectWooHelper.countryDidChange(twoincSelectWooHelper.currentCountry());
 
     Twoinc.getInstance().updateElements();
 
@@ -3984,31 +4017,25 @@ class Twoinc {
    * @param event
    */
 
-  onCountryInputChange(event) {
+  onCountryInputChange() {
     Twoinc.getInstance().syncBillingCountry();
   }
 
   /**
    * Bring everything that depends on the billing country back into step with
-   * the field (TWO-24867).
+   * the field (TWO-24867). Reached only from the `change` handler on
+   * #billing_country — that event is the closest thing this checkout has to a
+   * buyer gesture on the country.
    *
-   * Called from two places, and it has to be both:
-   *
-   *   - the `change` handler on #billing_country, which is the buyer's own
-   *     country change plus every re-render event WooCommerce emits alongside
-   *     it;
-   *   - `onUpdatedCheckout`, because a `change` is not guaranteed. WooCommerce
-   *     can replace the billing fields with a server-rendered country that
-   *     differs from the one on screen (a `checkout_error` re-render, a
-   *     multi-step theme, a session address restored server-side) and fire no
-   *     `change` at all. Without this second entry point the tracker below
-   *     would keep the pre-re-render country for the rest of the page, and a
-   *     later genuine switch BACK to that value would read as no change and
-   *     be swallowed — the exact opposite failure to the one this fix is
-   *     about, and a much quieter one.
-   *
-   * Both routes go through `countryDidChange`, so the tracker has a single
-   * writer and cannot drift from the field whichever way the country moved.
+   * Everything destructive lives behind that gesture on purpose. WooCommerce
+   * can also move the country with no `change` at all — a `checkout_error`
+   * re-render, a multi-step theme, a session address restored server-side —
+   * and it is tempting to run this from `updated_checkout` so the tracker
+   * cannot drift. It must NOT: those re-renders restore the country and the
+   * company TOGETHER, so clearing on them destroys data the same re-render
+   * just put back, which is the TWO-25326 failure again on a new trigger.
+   * `onUpdatedCheckout` therefore only RECORDS the country (see there); the
+   * tracker still cannot drift, and nothing is thrown away without a gesture.
    */
   syncBillingCountry() {
     const country = twoincSelectWooHelper.currentCountry();

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -931,9 +931,18 @@ let twoincSelectWooHelper = {
    * The billing country the checkout form currently holds, upper-cased, or
    * "" when the field is absent or unset (TWO-24867).
    *
-   * Single reader for every country-sensitive code path here, so the search
-   * request, the change guard and the address-lookup supersession check can
-   * never disagree about what "the current country" is.
+   * The reader for the three country-sensitive paths added or changed by
+   * TWO-24867 — the search request, the change guard and the address-lookup
+   * supersession check — so those three can never disagree about what "the
+   * current country" is.
+   *
+   * NOT the only reader in the file: `getCompanyData()` and
+   * `isCountrySupported()` still read `.val()` raw and uncased, so the
+   * `country_prefix` this file's handler writes upper-cased is replaced with
+   * the raw value by `clearSelectedCompany`'s deferred re-read. Harmless as
+   * things stand — WooCommerce's country values are already upper-case ISO
+   * codes — and left alone rather than swept into this fix, but do not read
+   * the paragraph above as a claim that the whole file is unified.
    */
   currentCountry: function () {
     return (jQuery("#billing_country").val() || "").toUpperCase();
@@ -942,9 +951,10 @@ let twoincSelectWooHelper = {
   /**
    * The last billing country this page has acted on (TWO-24867 / TWO-25326).
    *
-   * `null` until seeded by `initialize()`. Seeding matters: an unseeded
-   * tracker treats the first event it sees as a change, which is exactly the
-   * spurious re-render event this guard exists to swallow.
+   * `null` until the first known country is seen — by `initialize()`'s seed,
+   * by the country handler, or by `onUpdatedCheckout`'s re-sync, whichever
+   * gets there first. All three go through `countryDidChange`, so none of
+   * them can leave this out of step with the field.
    */
   lastObservedCountry: null,
 
@@ -972,15 +982,29 @@ let twoincSelectWooHelper = {
    * Records the new value as a side effect, so the caller must invoke this
    * exactly once per event and act on its answer.
    *
+   * Two flavours of "unknown" are deliberately NOT a change, and neither is
+   * incidental:
+   *
+   *   - An empty reading. WooCommerce replaces #billing_country wholesale on
+   *     some re-renders, so a poll landing mid-replacement reads "". Treated
+   *     as a change that would clear the captured company for nothing. It is
+   *     also not RECORDED, so a genuine switch that completes after the gap
+   *     is still compared against the last real country and still acts.
+   *   - The first known country, whatever this was called from. There is no
+   *     previous country to have moved away from, so there is nothing to
+   *     invalidate: on a checkout restored from a saved address the company
+   *     and the country arrive together.
+   *
    * @param {string} country upper-cased ISO code currently in the field
    * @returns {boolean}
    */
   countryDidChange: function (country) {
-    if (country === twoincSelectWooHelper.lastObservedCountry) {
+    if (!country) {
       return false;
     }
+    const previous = twoincSelectWooHelper.lastObservedCountry;
     twoincSelectWooHelper.lastObservedCountry = country;
-    return true;
+    return !!previous && country !== previous;
   },
 
   /**
@@ -3539,13 +3563,16 @@ class Twoinc {
 
     // Handle the country inputs change event.
     //
-    // Seeded first (TWO-25326): the handler only acts when the value differs
-    // from the last one recorded, and the very first event this binding sees
-    // is usually WooCommerce's own — core's address-i18n.js triggers
-    // `country_to_state_changing` on checkout init, carrying the country the
-    // form already had. Without the seed that event reads as a change and
-    // clears a company restored from the customer's saved address.
-    twoincSelectWooHelper.lastObservedCountry = twoincSelectWooHelper.currentCountry();
+    // Seeded first (TWO-25326 / TWO-24867), through the same single writer
+    // the handler uses. The handler only acts when the value differs from the
+    // last one recorded, and with no seed the FIRST country the page ever
+    // sees is adopted rather than acted on — correct for the re-render event
+    // WooCommerce fires at init (core's address-i18n.js triggers
+    // `country_to_state_changing` carrying the country the form already had),
+    // but wrong for a buyer who changes country before any re-render happens:
+    // their switch would be the first known country and would be swallowed.
+    // Seeding here is what tells those two apart.
+    twoincSelectWooHelper.countryDidChange(twoincSelectWooHelper.currentCountry());
     $body.on("change", "#billing_country", self.onCountryInputChange);
 
     // Re-evaluate the sole-trader autofill prefetch whenever the email
@@ -3813,7 +3840,12 @@ class Twoinc {
     });
     addressResponse.done(function (response) {
       if (seq !== self.addressLookupSeq) return;
-      if (twoincSelectWooHelper.currentCountry() !== requestCountry) return;
+      // An empty reading means the field is mid-replacement, not that the
+      // country moved — discarding a good registry address on it would be a
+      // silent failure with no retry and no message. Only a country that is
+      // known AND different is grounds to drop this.
+      const landedCountry = twoincSelectWooHelper.currentCountry();
+      if (landedCountry && landedCountry !== requestCountry) return;
       // Use new address lookup by default
       if (response.addresses) {
         self.setAddress(response.addresses[0]);
@@ -3891,6 +3923,10 @@ class Twoinc {
    * Handle the woocommerce updated checkout event
    */
   onUpdatedCheckout() {
+    // First: a re-render can have moved the billing country without firing a
+    // `change`, and everything below reads state that depends on it.
+    Twoinc.getInstance().syncBillingCountry();
+
     Twoinc.getInstance().updateElements();
 
     jQuery('input[name="payment_method"]').on("change", function () {
@@ -3949,6 +3985,32 @@ class Twoinc {
    */
 
   onCountryInputChange(event) {
+    Twoinc.getInstance().syncBillingCountry();
+  }
+
+  /**
+   * Bring everything that depends on the billing country back into step with
+   * the field (TWO-24867).
+   *
+   * Called from two places, and it has to be both:
+   *
+   *   - the `change` handler on #billing_country, which is the buyer's own
+   *     country change plus every re-render event WooCommerce emits alongside
+   *     it;
+   *   - `onUpdatedCheckout`, because a `change` is not guaranteed. WooCommerce
+   *     can replace the billing fields with a server-rendered country that
+   *     differs from the one on screen (a `checkout_error` re-render, a
+   *     multi-step theme, a session address restored server-side) and fire no
+   *     `change` at all. Without this second entry point the tracker below
+   *     would keep the pre-re-render country for the rest of the page, and a
+   *     later genuine switch BACK to that value would read as no change and
+   *     be swallowed — the exact opposite failure to the one this fix is
+   *     about, and a much quieter one.
+   *
+   * Both routes go through `countryDidChange`, so the tracker has a single
+   * writer and cannot drift from the field whichever way the country moved.
+   */
+  syncBillingCountry() {
     const country = twoincSelectWooHelper.currentCountry();
     const changed = twoincSelectWooHelper.countryDidChange(country);
 
@@ -3987,6 +4049,17 @@ class Twoinc {
     // enough — the guard has to sit on the handler.
     twoincSelectWooHelper.companySearchSeq += 1;
     self.addressLookupSeq += 1;
+    // Belt and braces, and DELIBERATELY not covered by a test — there is no
+    // reachable case that fails without it today, so a test asserting the
+    // spinner is gone afterwards would pass either way and be worse than
+    // none. The reasoning for keeping the line anyway: the transport hands
+    // the spinner off to whichever request is newest, so bumping the counter
+    // above orphans the one an in-flight search is showing (its `always()`
+    // now sees a stale sequence and returns before hiding it). What actually
+    // clears it is `clearSelectedCompany()` below re-attaching the widget and
+    // taking the dropdown — and the spinner node inside it — with it. That is
+    // an incidental consequence of an unrelated call, not a guarantee.
+    twoincSelectWooHelper.toggleCompanySearchSpinner(false);
 
     twoincDomHelper.clearSelectedCompany();
 

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -3958,7 +3958,21 @@ class Twoinc {
     // destroy what the same re-render just put back — the TWO-25326 failure
     // on a new trigger. Throwing away a captured company needs the buyer's
     // gesture, and the `change` event is the only signal of one there is.
-    twoincSelectWooHelper.countryDidChange(twoincSelectWooHelper.currentCountry());
+    if (twoincSelectWooHelper.countryDidChange(twoincSelectWooHelper.currentCountry())) {
+      // Invalidating in-flight work IS safe here, though, and record-only
+      // would otherwise leave a hole: on this path nothing bumps either
+      // counter, so a company-search response or a registry address for the
+      // OUTGOING country could still land — and the address guard's own
+      // country comparison does not cover it either, since an empty reading
+      // on either side (the field mid-replacement, which is exactly what this
+      // path is about) waves the response through by design.
+      //
+      // Purely destructive-to-pending, never to captured state: it discards
+      // answers to questions asked under a country that is no longer
+      // selected, which is not something the buyer can lose.
+      twoincSelectWooHelper.companySearchSeq += 1;
+      Twoinc.getInstance().addressLookupSeq += 1;
+    }
 
     Twoinc.getInstance().updateElements();
 

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -928,11 +928,65 @@ let twoincSelectWooHelper = {
   },
 
   /**
+   * The billing country the checkout form currently holds, upper-cased, or
+   * "" when the field is absent or unset (TWO-24867).
+   *
+   * Single reader for every country-sensitive code path here, so the search
+   * request, the change guard and the address-lookup supersession check can
+   * never disagree about what "the current country" is.
+   */
+  currentCountry: function () {
+    return (jQuery("#billing_country").val() || "").toUpperCase();
+  },
+
+  /**
+   * The last billing country this page has acted on (TWO-24867 / TWO-25326).
+   *
+   * `null` until seeded by `initialize()`. Seeding matters: an unseeded
+   * tracker treats the first event it sees as a change, which is exactly the
+   * spurious re-render event this guard exists to swallow.
+   */
+  lastObservedCountry: null,
+
+  /**
+   * Whether a `change` event on #billing_country represents a REAL country
+   * change, as opposed to WooCommerce re-emitting one during its own
+   * re-render (TWO-25326).
+   *
+   * The handler this gates destroys the captured company — #billing_company,
+   * #company_id, the picker's selection and the registry address behind it.
+   * WooCommerce fires `change` on #billing_country for reasons that are not
+   * the buyer changing country: `updated_checkout` re-renders the billing
+   * fields and core's address-i18n.js re-triggers the field on
+   * `country_to_state_changing` at init, not only on a user gesture. Bound
+   * delegated on document.body, this handler saw all of them, so a buyer who
+   * had picked a company watched it vanish on an unrelated re-render with no
+   * action of their own — observed live on TWO-25326.
+   *
+   * Compared by value rather than by `event.originalEvent` being present:
+   * WooCommerce's re-render path re-triggers through jQuery on some themes
+   * and dispatches a native event on others, so an event-source test would
+   * hold on the fixture and fail on the shop. The value comparison is true
+   * to what the handler actually needs to know.
+   *
+   * Records the new value as a side effect, so the caller must invoke this
+   * exactly once per event and act on its answer.
+   *
+   * @param {string} country upper-cased ISO code currently in the field
+   * @returns {boolean}
+   */
+  countryDidChange: function (country) {
+    if (country === twoincSelectWooHelper.lastObservedCountry) {
+      return false;
+    }
+    twoincSelectWooHelper.lastObservedCountry = country;
+    return true;
+  },
+
+  /**
    * Generate parameters for selectwoo
    */
   genSelectWooParams: function () {
-    let country = jQuery("#billing_country").val();
-
     let twoincSearchLimit = 50;
     return {
       minimumInputLength: twoincSelectWooHelper.companySearchMinLength,
@@ -1032,8 +1086,17 @@ let twoincSelectWooHelper = {
           return request;
         },
         url: function (params) {
+          // Read live, per request — NOT captured when the widget was built
+          // (TWO-24867). The widget outlives a country change on any path
+          // that does not rebuild it: WooCommerce replaces #billing_country
+          // wholesale on some `updated_checkout` re-renders, address-i18n.js
+          // rewrites the field without a user gesture, and a programmatic
+          // `.val()` fires no `change` at all. A captured value made the
+          // search query the PREVIOUS country's register while the form said
+          // otherwise — the buyer saw "no companies found" for a company that
+          // exists, which reads as a broken registry rather than stale state.
           const searchParams = new URLSearchParams({
-            country: country,
+            country: twoincSelectWooHelper.currentCountry(),
             limit: twoincSearchLimit,
             offset: (params.page || 0) * twoincSearchLimit,
             q: decodeURIComponent(params.term)
@@ -3294,6 +3357,11 @@ class Twoinc {
     // (TWO-25288); read by `enterManualCompanyEntry` to decide whether
     // disowning the company should clear the address behind it.
     this.registryAddressApplied = false;
+    // Monotonic supersession counter for the registry address lookup
+    // (TWO-24867). Bumped by every lookup and by every real country change,
+    // so only the newest lookup — and only one issued under the country still
+    // selected — is allowed to write the address fields.
+    this.addressLookupSeq = 0;
     this.orderIntentCheck = {
       interval: null,
       pendingCheck: false,
@@ -3469,7 +3537,15 @@ class Twoinc {
       twoincDomHelper.togglePaySubtitleDesc();
     });
 
-    // Handle the country inputs change event
+    // Handle the country inputs change event.
+    //
+    // Seeded first (TWO-25326): the handler only acts when the value differs
+    // from the last one recorded, and the very first event this binding sees
+    // is usually WooCommerce's own — core's address-i18n.js triggers
+    // `country_to_state_changing` on checkout init, carrying the country the
+    // form already had. Without the seed that event reads as a change and
+    // clears a company restored from the customer's saved address.
+    twoincSelectWooHelper.lastObservedCountry = twoincSelectWooHelper.currentCountry();
     $body.on("change", "#billing_country", self.onCountryInputChange);
 
     // Re-evaluate the sole-trader autofill prefetch whenever the email
@@ -3722,11 +3798,22 @@ class Twoinc {
 
   addressLookup(selectedCompany) {
     const self = this;
+    // Supersession, not cancellation (TWO-24867). Two independent things can
+    // make this response wrong by the time it arrives: a newer lookup (the
+    // buyer picked a different company) and a country change (the buyer
+    // corrected a mis-clicked country). The sequence number catches the
+    // first, the country snapshot the second — a country switched away from
+    // and back again between request and response leaves the sequence stale
+    // but the country matching, and vice versa, so both are needed.
+    const seq = (self.addressLookupSeq += 1);
+    const requestCountry = twoincSelectWooHelper.currentCountry();
     const addressResponse = jQuery.ajax({
       dataType: "json",
       url: twoincUtilHelper.constructTwoincUrl(`/companies/v2/company/${selectedCompany.lookup_id}`)
     });
     addressResponse.done(function (response) {
+      if (seq !== self.addressLookupSeq) return;
+      if (twoincSelectWooHelper.currentCountry() !== requestCountry) return;
       // Use new address lookup by default
       if (response.addresses) {
         self.setAddress(response.addresses[0]);
@@ -3862,18 +3949,47 @@ class Twoinc {
    */
 
   onCountryInputChange(event) {
-    const $input = jQuery(this);
+    const country = twoincSelectWooHelper.currentCountry();
 
-    Twoinc.getInstance().customerCompany.country_prefix = $input.val();
+    // Only a REAL change gets to throw away the captured company
+    // (TWO-25326 — see countryDidChange for the events this swallows).
+    if (!twoincSelectWooHelper.countryDidChange(country)) {
+      return;
+    }
+
+    const self = Twoinc.getInstance();
+
+    // Invalidate everything already in flight under the OUTGOING country
+    // (TWO-24867). Neither of these responses can be allowed to land:
+    //
+    //  - a company search would repopulate the picker with the previous
+    //    country's register, next to a field this handler is about to clear;
+    //  - an address lookup would write the previous country's registry
+    //    address over the cleared address fields, and set
+    //    registryAddressApplied on it.
+    //
+    // Both are supersession counters rather than aborts on purpose: the
+    // network request may already have completed, so cancelling it is not
+    // enough — the guard has to sit on the handler.
+    twoincSelectWooHelper.companySearchSeq += 1;
+    self.addressLookupSeq += 1;
 
     twoincDomHelper.toggleBusinessFields();
 
     twoincDomHelper.clearSelectedCompany();
 
+    // AFTER clearSelectedCompany, deliberately: that function resets
+    // `customerCompany` to {} wholesale, so setting the country prefix before
+    // it (as this used to) discarded it immediately and left getApproval()
+    // below — and getDueInDays(), which early-returns without one — running
+    // on an undefined country for the three seconds until the deferred
+    // re-read inside clearSelectedCompany put it back (TWO-24867).
+    self.customerCompany.country_prefix = country;
+
     // Sole trader availability is per-country; re-evaluate the toggle.
     twoincSoleTrader.refresh();
 
-    Twoinc.getInstance().getApproval();
+    self.getApproval();
   }
 }
 

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -3950,10 +3950,24 @@ class Twoinc {
 
   onCountryInputChange(event) {
     const country = twoincSelectWooHelper.currentCountry();
+    const changed = twoincSelectWooHelper.countryDidChange(country);
 
-    // Only a REAL change gets to throw away the captured company
-    // (TWO-25326 — see countryDidChange for the events this swallows).
-    if (!twoincSelectWooHelper.countryDidChange(country)) {
+    // Unconditional, and BEFORE the guard below. This pass is idempotent —
+    // it re-derives which company fields should be visible and required from
+    // the current state and writes nothing the buyer typed — and the events
+    // the guard now swallows are exactly the ones that just re-rendered the
+    // billing fields underneath it (core's address-i18n.js re-sorts them on
+    // `country_to_state_changing`). Gating it behind the guard along with
+    // everything else would have turned this fix into a field-visibility
+    // regression on every such re-render (TWO-24867).
+    twoincDomHelper.toggleBusinessFields();
+
+    // Everything past here is destructive, so only a REAL country change gets
+    // to run it (TWO-25326 — see countryDidChange for the events this
+    // swallows). The rest of what this handler used to do on those events is
+    // already re-run by `onUpdatedCheckout`: sole-trader availability and the
+    // approval check both go through it.
+    if (!changed) {
       return;
     }
 
@@ -3973,8 +3987,6 @@ class Twoinc {
     // enough — the guard has to sit on the handler.
     twoincSelectWooHelper.companySearchSeq += 1;
     self.addressLookupSeq += 1;
-
-    twoincDomHelper.toggleBusinessFields();
 
     twoincDomHelper.clearSelectedCompany();
 

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -262,14 +262,19 @@ about the company-search helper, so the bootstrap is left to no-op.
   and leaves the new `country_prefix` on `customerCompany` — set _after_ `clearSelectedCompany()`,
   which resets that object wholesale and only re-reads it from the DOM three seconds later.
 - **the tracker cannot drift from the field**, which is the failure mode the guard buys and
-  therefore the one this suite spends most of its assertions on. Five separate ways it could:
+  therefore the one this suite spends most of its assertions on. Seven separate ways it could:
   `initialize()` seeds it, and the seed is what makes a genuine FIRST change act rather than
-  be adopted; the first country the page ever sees (billing fields rendering after
-  `initialize()` has run) is adopted, not acted on; an empty reading — WooCommerce replacing
-  `#billing_country` wholesale mid-re-render — is neither acted on _nor recorded_, so the
-  switch that completes afterwards still acts; `updated_checkout` re-syncs a country that
-  moved with no `change` event at all; and that re-sync terminates rather than looping,
-  because a real change there reaches `setAddress()`, which triggers `update_checkout`.
+  be adopted; the seed is taken _after_ `loadStorageInputs()`, which writes the country with
+  `selectElem.value` and fires no `change` — seeded before it, the first re-render read the
+  restore as a real country change and destroyed the company that restore had just put back
+  (`initialize(true)` is the bootstrap's own call, so that was the production path); the first
+  country the page ever sees (billing fields rendering after `initialize()` has run) is
+  adopted, not acted on; an empty reading — WooCommerce replacing `#billing_country` wholesale
+  mid-re-render — is neither acted on _nor recorded_, so the switch that completes afterwards
+  still acts; `updated_checkout` **records** a country that moved with no `change` event;
+  it records **without** clearing the capture, because those re-renders restore the country and
+  the company together and clearing would destroy what they just restored; and the recording
+  path cannot loop, even though a change reaching `setAddress()` triggers `update_checkout`.
 - **the whole suite drives the real wiring**: a real `initialize(false)`, then
   `trigger("change")` on the field, so unwiring the delegated binding or moving the seed out
   of `initialize()`'s reach fails it. `afterEach` unbinds `document.body` — jsdom's document
@@ -283,9 +288,10 @@ about the company-search helper, so the bootstrap is left to no-op.
   the country snapshot taken when the request was issued. Both are needed and both are pinned
   separately — a country written programmatically fires no `change`, so nothing bumps the
   sequence, and a country switched away and back leaves the sequence stale but the country
-  matching. A third case, the country reading back empty mid-replacement, is deliberately
-  NOT a mismatch — dropping a good registry address there would be a silent failure with no
-  retry. The happy path is pinned too, so the guard cannot be tightened into a no-op.
+  matching. An empty reading on _either_ side is deliberately NOT a mismatch — dropping a good
+  registry address there would be a silent failure with no retry, and a lookup issued during a
+  replacement snapshots `""`, which compared against a known country would discard every
+  response. The happy path is pinned too, so the guard cannot be tightened into a no-op.
 
 One line in this change is deliberately uncovered and says so in its own comment: the
 spinner hand-off in the country handler. Nothing reachable fails without it — what clears

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -142,8 +142,9 @@ about the company-search helper, so the bootstrap is left to no-op.
 - request url: the configured host and `/companies/v2/company` path, the country from the
   checkout form, `limit`/`offset` bounding and paging by that same bound, the term decoded
   exactly once, and `client`/`client_v` alongside the search params rather than replacing them.
-- the country is captured when `genSelectWooParams()` runs, not per keystroke — which is
-  why a country change has to re-run `selectWoo()` with fresh params.
+- the country is read per request rather than captured when `genSelectWooParams()` runs
+  (inverted by TWO-24867 — the widget outlives a country change on every path that does
+  not go through `clearSelectedCompany()`).
 - widget params: the 3-character minimum, the 300ms debounce shared with the other plugin
   checkouts, `escapeMarkup` passing the endpoint's highlight markup through while
   `templateSelection` uses plain text, and the non-error messages borrowing WooCommerce
@@ -247,6 +248,31 @@ about the company-search helper, so the bootstrap is left to no-op.
   on the select.
 - the user-meta restore path, which passes both values explicitly because `loadUserMetaInputs`
   writes `#company_id` _after_ it renders.
+
+`country-switch.test.js` — what a billing-country change does, and what a fake one must not
+(TWO-24867, with TWO-25326):
+
+- **a `change` event that is not a country change is inert.** WooCommerce re-renders the
+  billing fields on `updated_checkout`, and core's `address-i18n.js` re-triggers the country
+  field on `country_to_state_changing` at init — both reach the delegated handler as a bare
+  `change` with the value unchanged, and each one used to destroy the captured company. The
+  guard compares against the last country acted on, so the captured company survives one
+  such event and a run of them, and nothing in flight is invalidated.
+- **`initialize()` seeds that comparison** from the country already in the form, because the
+  first event the binding sees is usually WooCommerce's own. Asserted through a real
+  `trigger("change")` on the delegated binding, so unwiring either half fails it.
+- **a real change still clears everything**, records the new country for the next comparison,
+  and leaves the new `country_prefix` on `customerCompany` — set _after_ `clearSelectedCompany()`,
+  which resets that object wholesale and only re-reads it from the DOM three seconds later.
+- **the search country is read per request**, so a widget that outlived a country change
+  queries the country the form currently holds rather than the one it was built under.
+- **an in-flight company search for the outgoing country cannot repopulate the list** — the
+  supersession counter is bumped by the country change, not only by a newer search.
+- **the registry address lookup is guarded twice**: by sequence (a newer lookup wins) and by
+  the country snapshot taken when the request was issued. Both are needed and both are pinned
+  separately — a country written programmatically fires no `change`, so nothing bumps the
+  sequence, and a country switched away and back leaves the sequence stale but the country
+  matching. The happy path is pinned too, so the guard cannot be tightened into a no-op.
 
 ### Two defects these tests found, now fixed
 

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -258,12 +258,23 @@ about the company-search helper, so the bootstrap is left to no-op.
   `change` with the value unchanged, and each one used to destroy the captured company. The
   guard compares against the last country acted on, so the captured company survives one
   such event and a run of them, and nothing in flight is invalidated.
-- **`initialize()` seeds that comparison** from the country already in the form, because the
-  first event the binding sees is usually WooCommerce's own. Asserted through a real
-  `trigger("change")` on the delegated binding, so unwiring either half fails it.
 - **a real change still clears everything**, records the new country for the next comparison,
   and leaves the new `country_prefix` on `customerCompany` — set _after_ `clearSelectedCompany()`,
   which resets that object wholesale and only re-reads it from the DOM three seconds later.
+- **the tracker cannot drift from the field**, which is the failure mode the guard buys and
+  therefore the one this suite spends most of its assertions on. Five separate ways it could:
+  `initialize()` seeds it, and the seed is what makes a genuine FIRST change act rather than
+  be adopted; the first country the page ever sees (billing fields rendering after
+  `initialize()` has run) is adopted, not acted on; an empty reading — WooCommerce replacing
+  `#billing_country` wholesale mid-re-render — is neither acted on _nor recorded_, so the
+  switch that completes afterwards still acts; `updated_checkout` re-syncs a country that
+  moved with no `change` event at all; and that re-sync terminates rather than looping,
+  because a real change there reaches `setAddress()`, which triggers `update_checkout`.
+- **the whole suite drives the real wiring**: a real `initialize(false)`, then
+  `trigger("change")` on the field, so unwiring the delegated binding or moving the seed out
+  of `initialize()`'s reach fails it. `afterEach` unbinds `document.body` — jsdom's document
+  outlives the test, so without it each test leaves a live handler closed over its own
+  evaluation of the source and the next test's event runs all of them.
 - **the search country is read per request**, so a widget that outlived a country change
   queries the country the form currently holds rather than the one it was built under.
 - **an in-flight company search for the outgoing country cannot repopulate the list** — the
@@ -272,7 +283,15 @@ about the company-search helper, so the bootstrap is left to no-op.
   the country snapshot taken when the request was issued. Both are needed and both are pinned
   separately — a country written programmatically fires no `change`, so nothing bumps the
   sequence, and a country switched away and back leaves the sequence stale but the country
-  matching. The happy path is pinned too, so the guard cannot be tightened into a no-op.
+  matching. A third case, the country reading back empty mid-replacement, is deliberately
+  NOT a mismatch — dropping a good registry address there would be a silent failure with no
+  retry. The happy path is pinned too, so the guard cannot be tightened into a no-op.
+
+One line in this change is deliberately uncovered and says so in its own comment: the
+spinner hand-off in the country handler. Nothing reachable fails without it — what clears
+the spinner today is `clearSelectedCompany()` re-attaching the widget and taking the
+dropdown with it — so a test asserting the spinner is gone afterwards would pass either way,
+which is worse than no test.
 
 ### Two defects these tests found, now fixed
 

--- a/tests/js/company-search-results.test.js
+++ b/tests/js/company-search-results.test.js
@@ -204,16 +204,21 @@ describe("company search results", () => {
       expect(urlFor({ term: "Example & Co" }).searchParams.get("q")).toBe("Example & Co");
     });
 
-    test("the country is read at widget-creation time, not per keystroke", () => {
-      // genSelectWooParams() closes over the country. That is why
-      // clearSelectedCompany() re-runs selectWoo() with fresh params on
-      // a country change instead of relying on url() to re-read the
-      // field — pinned here so the closure is not "simplified" away
-      // without noticing what depends on it.
+    test("the country is read per request, not captured when the widget is built", () => {
+      // Inverted by TWO-24867. genSelectWooParams() used to close over the
+      // country, on the reasoning that clearSelectedCompany() re-runs
+      // selectWoo() with fresh params on a country change. That coupling
+      // only held while EVERY country change reached that handler, and it
+      // no longer does: the handler now ignores the re-render `change`
+      // events WooCommerce emits with the value unchanged (TWO-25326), and
+      // a country written programmatically fires no `change` at all. Both
+      // leave the widget alive with a stale closure, searching the previous
+      // country's register. Reading the field per request removes the
+      // dependency instead of documenting it.
       const url = ctx.helper.genSelectWooParams().ajax.url;
       ctx.$("#billing_country").append('<option value="SE">Sweden</option>').val("SE");
 
-      expect(new URL(url({ term: "exampleco" })).searchParams.get("country")).toBe("GB");
+      expect(new URL(url({ term: "exampleco" })).searchParams.get("country")).toBe("SE");
     });
 
     test("identifies the plugin and its version to the API", () => {

--- a/tests/js/country-switch.test.js
+++ b/tests/js/country-switch.test.js
@@ -381,6 +381,52 @@ describe("billing country switch", () => {
       expect(ctx.helper.lastObservedCountry).toBe("GB");
     });
 
+    test("updated_checkout invalidates in-flight work for the outgoing country", () => {
+      // Record-only would otherwise leave a hole: nothing on this path bumps
+      // either counter, so a registry address for the country just left could
+      // still land. The lookup's own country comparison does not cover it —
+      // an empty reading on either side waves the response through by design,
+      // and the field being mid-replacement is exactly what this path is
+      // about. Invalidating pending answers is safe in a way clearing the
+      // capture is not: it discards replies to questions asked under a
+      // country that is no longer selected, which the buyer cannot lose.
+      ctx
+        .$("form[name='checkout']")
+        .append(
+          "<input type='text' id='billing_address_1' value='' />" +
+            "<input type='text' id='billing_city' value='' />" +
+            "<input type='text' id='billing_postcode' value='' />" +
+            "<input type='text' id='billing_address_2' value='' />"
+        );
+      initializeCheckout();
+      const searchSeqBefore = ctx.helper.companySearchSeq;
+      ctx.Twoinc.getInstance().addressLookup({ lookup_id: "gb-lookup-id" });
+      const inFlight = ajax.last();
+
+      // No `change` event — the whole point of this path.
+      ctx.$("#billing_country").val("ES");
+      ctx.$(document.body).trigger("updated_checkout");
+      inFlight.succeed({
+        addresses: [{ street_address: "1 Example Street", city: "London", postal_code: "EC1A 1BB" }]
+      });
+
+      expect(ctx.helper.companySearchSeq).toBeGreaterThan(searchSeqBefore);
+      expect(ctx.$("#billing_address_1").val()).toBe("");
+      expect(ctx.Twoinc.getInstance().registryAddressApplied).toBe(false);
+    });
+
+    test("updated_checkout does NOT invalidate when the country is unchanged", () => {
+      // The counter bump is behind the same change test as the recording, so
+      // the constant stream of `updated_checkout` events on an ordinary
+      // checkout does not cancel the buyer's own in-flight search.
+      initializeCheckout();
+      const searchSeqBefore = ctx.helper.companySearchSeq;
+
+      ctx.$(document.body).trigger("updated_checkout");
+
+      expect(ctx.helper.companySearchSeq).toBe(searchSeqBefore);
+    });
+
     test("the updated_checkout re-sync terminates instead of looping", () => {
       // The loop this must not become: `updated_checkout` -> a country change
       // -> clearSelectedCompany() -> setAddress() -> `update_checkout` ->

--- a/tests/js/country-switch.test.js
+++ b/tests/js/country-switch.test.js
@@ -66,6 +66,9 @@ describe("billing country switch", () => {
     // cleared by a predecessor's zombie guard — rather than as the leak it is.
     ctx.$(document.body).off();
     document.body.innerHTML = "";
+    // jsdom's sessionStorage outlives the test too, and one test seeds a
+    // saved-input snapshot into it.
+    window.sessionStorage.clear();
     jest.clearAllTimers();
     jest.useRealTimers();
   });
@@ -268,20 +271,91 @@ describe("billing country switch", () => {
       expect(capturedCompany()).toEqual({ name: "Example Co", id: "123456789" });
     });
 
-    test("updated_checkout re-syncs a country that moved with no change event", () => {
+    test("updated_checkout RECORDS a country that moved with no change event", () => {
       // WooCommerce can replace the billing fields with a server-rendered
       // country and fire no `change`: a checkout_error re-render, a
       // multi-step theme, a session address restored server-side. Left
-      // unhandled the tracker keeps the pre-re-render country for the rest of
-      // the page, and a later genuine switch BACK to it reads as no change.
+      // unrecorded the tracker keeps the pre-re-render country for the rest
+      // of the page, and a later genuine switch BACK to it reads as no
+      // change and is swallowed.
+      initializeCheckout();
+
+      ctx.$("#billing_country").val("ES");
+      ctx.$(document.body).trigger("updated_checkout");
+
+      expect(ctx.helper.lastObservedCountry).toBe("ES");
+
+      // And the tracker is genuinely usable afterwards: a switch back to GB
+      // is a real change and is acted on.
+      captureCompany("Ejemplo SL", "B12345678");
+      ctx.$("#billing_country").val("GB");
+      fireCountryChange();
+
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
+    });
+
+    test("updated_checkout records WITHOUT clearing the captured company", () => {
+      // The other half, and the reason this entry point records rather than
+      // running the whole handler. Those re-renders restore the country and
+      // the company TOGETHER, so clearing here destroys what the same
+      // re-render just put back — TWO-25326 again on a new trigger. Nothing
+      // is thrown away without the buyer's gesture, and a `change` event is
+      // the only signal of one this checkout has.
       initializeCheckout();
       captureCompany("Example Co", "123456789");
 
       ctx.$("#billing_country").val("ES");
       ctx.$(document.body).trigger("updated_checkout");
 
+      expect(capturedCompany()).toEqual({ name: "Example Co", id: "123456789" });
+    });
+
+    test("the seed is taken AFTER the saved-input restore, not before", () => {
+      // `loadStorageInputs()` writes #billing_country with `selectElem.value`
+      // and fires no `change`. Seeded before it ran, the tracker held the
+      // country the page was RENDERED with while the field held the RESTORED
+      // one, and the first re-render afterwards read the difference as a real
+      // country change — destroying the company and address that same restore
+      // had just put back. `initialize(true)` is the bootstrap's own call, so
+      // this is the production path.
+      // The shape saveCheckoutInputs() actually writes.
+      window.sessionStorage.setItem(
+        "checkoutInputs",
+        JSON.stringify([
+          {
+            htmlTag: "SELECT",
+            id: "billing_country",
+            name: "billing_country",
+            val: "ES",
+            optionHtml: '<option value="ES">Spain</option>'
+          },
+          {
+            htmlTag: "INPUT",
+            id: "billing_company",
+            name: "billing_company",
+            type: "text",
+            val: "Ejemplo SL"
+          },
+          {
+            htmlTag: "INPUT",
+            id: "company_id",
+            name: "company_id",
+            type: "text",
+            val: "B12345678"
+          }
+        ])
+      );
+
+      ctx.Twoinc.getInstance().initialize(true);
+
+      expect(ctx.$("#billing_country").val()).toBe("ES");
       expect(ctx.helper.lastObservedCountry).toBe("ES");
-      expect(capturedCompany()).toEqual({ name: "", id: "" });
+
+      // The re-render that follows the restore must not read it as a change.
+      ctx.$(document.body).trigger("updated_checkout");
+      fireCountryChange();
+
+      expect(capturedCompany()).toEqual({ name: "Ejemplo SL", id: "B12345678" });
     });
 
     test("the FIRST country ever seen is adopted, not acted on", () => {
@@ -308,14 +382,16 @@ describe("billing country switch", () => {
     });
 
     test("the updated_checkout re-sync terminates instead of looping", () => {
-      // The loop this could have been: `updated_checkout` -> a real country
-      // change -> clearSelectedCompany() -> setAddress() -> `update_checkout`
-      // -> WooCommerce refreshes -> `updated_checkout` again. What stops it is
-      // that the country was RECORDED on the way through, so the second pass
-      // sees no change and returns. Worth pinning rather than reasoning about:
-      // the termination condition lives in a different function from the
-      // recursion, and address lookup (which is what reaches setAddress) is
-      // off by default, so the loop would only appear on shops that enable it.
+      // The loop this must not become: `updated_checkout` -> a country change
+      // -> clearSelectedCompany() -> setAddress() -> `update_checkout` ->
+      // WooCommerce refreshes -> `updated_checkout` again. Two things stop it
+      // — this entry point only RECORDS, so it never reaches
+      // clearSelectedCompany at all; and even if it did, the country was
+      // recorded on the way through, so the second pass sees no change.
+      // Pinned rather than reasoned about because both guards live in
+      // different functions from the recursion, and the setAddress leg is
+      // behind `enable_address_lookup`, so a regression here would only
+      // appear on shops that turn address lookup on.
       ctx.twoinc.enable_address_lookup = "yes";
       ctx
         .$("form[name='checkout']")

--- a/tests/js/country-switch.test.js
+++ b/tests/js/country-switch.test.js
@@ -307,6 +307,43 @@ describe("billing country switch", () => {
       expect(ctx.helper.lastObservedCountry).toBe("GB");
     });
 
+    test("the updated_checkout re-sync terminates instead of looping", () => {
+      // The loop this could have been: `updated_checkout` -> a real country
+      // change -> clearSelectedCompany() -> setAddress() -> `update_checkout`
+      // -> WooCommerce refreshes -> `updated_checkout` again. What stops it is
+      // that the country was RECORDED on the way through, so the second pass
+      // sees no change and returns. Worth pinning rather than reasoning about:
+      // the termination condition lives in a different function from the
+      // recursion, and address lookup (which is what reaches setAddress) is
+      // off by default, so the loop would only appear on shops that enable it.
+      ctx.twoinc.enable_address_lookup = "yes";
+      ctx
+        .$("form[name='checkout']")
+        .append(
+          [
+            "<input type='text' id='billing_address_1' value='' />",
+            "<input type='text' id='billing_address_2' value='' />",
+            "<input type='text' id='billing_city' value='' />",
+            "<input type='text' id='billing_postcode' value='' />"
+          ].join("\n")
+        );
+      initializeCheckout();
+      // Stand in for WooCommerce core's checkout.js, which is what turns a
+      // requested `update_checkout` into a completed `updated_checkout`.
+      let passes = 0;
+      ctx.$(document.body).on("update_checkout", function () {
+        passes += 1;
+        if (passes > 20) throw new Error("update_checkout did not settle");
+        ctx.$(document.body).trigger("updated_checkout");
+      });
+
+      ctx.$("#billing_country").val("ES");
+      ctx.$(document.body).trigger("updated_checkout");
+
+      expect(passes).toBeLessThan(5);
+      expect(ctx.helper.lastObservedCountry).toBe("ES");
+    });
+
     test("an empty reading is neither acted on nor recorded", () => {
       // WooCommerce replaces #billing_country wholesale on some re-renders,
       // so an event landing mid-replacement reads "". Clearing on that would

--- a/tests/js/country-switch.test.js
+++ b/tests/js/country-switch.test.js
@@ -106,6 +106,24 @@ describe("billing country switch", () => {
       expect(ctx.helper.companySearchSeq).toBe(seqBefore);
     });
 
+    test("still re-runs the field-visibility pass", () => {
+      // The half of the handler that is NOT destructive stays unconditional.
+      // These events are exactly the ones that just re-rendered the billing
+      // fields underneath the plugin, so skipping the visibility pass along
+      // with the clear would turn this guard into a field-visibility
+      // regression. Simulated by knocking a field's state out and checking
+      // the handler puts it back.
+      ctx.helper.lastObservedCountry = "GB";
+      // The field this configuration resolves to visible (the gateway is not
+      // the selected payment method here, and company search is not enabled
+      // for other methods, so the plain company field is the one shown).
+      ctx.$("#billing_company_field").addClass("hidden");
+
+      fireCountryChange();
+
+      expect(ctx.$("#billing_company_field").hasClass("hidden")).toBe(false);
+    });
+
     test("repeated re-renders stay inert, not just the first", () => {
       ctx.helper.lastObservedCountry = "GB";
       captureCompany("Example Co", "123456789");

--- a/tests/js/country-switch.test.js
+++ b/tests/js/country-switch.test.js
@@ -29,6 +29,10 @@ describe("billing country switch", () => {
   let ajax;
 
   beforeEach(() => {
+    // initialize() installs a 3s setInterval and an 800ms setTimeout that
+    // would outlive the test on real timers and run against a torn-down DOM.
+    // Nothing here needs either to fire.
+    jest.useFakeTimers();
     // `supported_buyer_countries` is read by isCountrySupported(), which
     // toggleBusinessFields() calls — the first thing the country handler does.
     ctx = harness.loadTwoinc({ supported_buyer_countries: ["GB", "ES"] });
@@ -36,14 +40,51 @@ describe("billing country switch", () => {
     // The harness fixture carries a single country option, which is all the
     // search tests need. Switching country needs somewhere to switch TO.
     ctx.$("#billing_country").append('<option value="ES">Spain</option>');
+    // The checkout-page gate initialize() returns on, and the gateway radio
+    // the payment-method checks look for.
+    ctx.$("form[name='checkout']").after('<div id="order_review"></div>');
+    ctx
+      .$("form[name='checkout']")
+      .append(
+        "<input type='radio' id='payment_method_woocommerce-gateway-tillit'" +
+          " name='payment_method' value='woocommerce-gateway-tillit' />"
+      );
     ajax = harness.stubAjax(ctx.$);
   });
 
   afterEach(() => {
     ajax.restore();
     harness.releaseWidgets(ctx.$);
+    // Load-bearing, not tidying. `initialize()` binds its handlers DELEGATED
+    // on document.body, and jsdom's document outlives the test — wiping
+    // `innerHTML` removes the elements but not the bindings. Every test that
+    // calls initializeCheckout() would otherwise leave a live handler closed
+    // over its own evaluation of the source (the harness re-evaluates per
+    // test, so each has its own `lastObservedCountry` and its own singleton),
+    // and the next test's `change` event would run all of them against the
+    // current DOM. That presents as an order-dependent flake — a company
+    // cleared by a predecessor's zombie guard — rather than as the leak it is.
+    ctx.$(document.body).off();
     document.body.innerHTML = "";
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
+
+  /**
+   * Run the real page wiring: the delegated `change` binding on
+   * #billing_country, the `updated_checkout` binding, and the seed of the
+   * country tracker.
+   *
+   * Every test that fires a country event goes through this rather than
+   * calling the handler by hand. Calling it directly would leave the binding
+   * itself untested, so unwiring it — or moving the seed to somewhere
+   * initialize() does not reach — would keep the suite green.
+   *
+   * @returns {void}
+   */
+  function initializeCheckout() {
+    ctx.Twoinc.getInstance().initialize(false);
+  }
 
   /**
    * Put a captured company in every field that holds one, the way a pick from
@@ -64,16 +105,13 @@ describe("billing country switch", () => {
   }
 
   /**
-   * Fire the country handler the way the delegated binding in `initialize()`
-   * does — `this` is the country field, which is what the handler reads.
+   * Fire a real `change` on the country field, which reaches the plugin only
+   * through the delegated binding `initialize()` installs on document.body.
    *
    * @returns {void}
    */
   function fireCountryChange() {
-    ctx.Twoinc.prototype.onCountryInputChange.call(
-      ctx.$("#billing_country")[0],
-      ctx.$.Event("change")
-    );
+    ctx.$("#billing_country").trigger("change");
   }
 
   /** @returns {{name: string, id: string}} the currently captured company */
@@ -86,7 +124,7 @@ describe("billing country switch", () => {
 
   describe("a change event that is not a country change (TWO-25326)", () => {
     test("leaves the captured company alone", () => {
-      ctx.helper.lastObservedCountry = "GB";
+      initializeCheckout();
       captureCompany("Example Co", "123456789");
 
       // WooCommerce re-renders the billing fields on `updated_checkout` and
@@ -98,7 +136,7 @@ describe("billing country switch", () => {
     });
 
     test("does not invalidate an in-flight company search", () => {
-      ctx.helper.lastObservedCountry = "GB";
+      initializeCheckout();
       const seqBefore = ctx.helper.companySearchSeq;
 
       fireCountryChange();
@@ -113,7 +151,7 @@ describe("billing country switch", () => {
       // with the clear would turn this guard into a field-visibility
       // regression. Simulated by knocking a field's state out and checking
       // the handler puts it back.
-      ctx.helper.lastObservedCountry = "GB";
+      initializeCheckout();
       // The field this configuration resolves to visible (the gateway is not
       // the selected payment method here, and company search is not enabled
       // for other methods, so the plain company field is the one shown).
@@ -125,7 +163,7 @@ describe("billing country switch", () => {
     });
 
     test("repeated re-renders stay inert, not just the first", () => {
-      ctx.helper.lastObservedCountry = "GB";
+      initializeCheckout();
       captureCompany("Example Co", "123456789");
 
       fireCountryChange();
@@ -138,7 +176,7 @@ describe("billing country switch", () => {
 
   describe("a real country change", () => {
     test("clears the captured company", () => {
-      ctx.helper.lastObservedCountry = "GB";
+      initializeCheckout();
       captureCompany("Example Co", "123456789");
 
       ctx.$("#billing_country").val("ES");
@@ -148,7 +186,7 @@ describe("billing country switch", () => {
     });
 
     test("records the new country so the next re-render is inert again", () => {
-      ctx.helper.lastObservedCountry = "GB";
+      initializeCheckout();
 
       ctx.$("#billing_country").val("ES");
       fireCountryChange();
@@ -163,7 +201,7 @@ describe("billing country switch", () => {
       // re-reads it from the DOM three seconds later, so an assignment made
       // BEFORE it is silently dropped — which left getApproval() and
       // getDueInDays() running with no country for that whole window.
-      ctx.helper.lastObservedCountry = "GB";
+      initializeCheckout();
       captureCompany("Example Co", "123456789");
 
       ctx.$("#billing_country").val("ES");
@@ -173,7 +211,7 @@ describe("billing country switch", () => {
     });
 
     test("invalidates an in-flight company search", () => {
-      ctx.helper.lastObservedCountry = "GB";
+      initializeCheckout();
       const seqBefore = ctx.helper.companySearchSeq;
 
       ctx.$("#billing_country").val("ES");
@@ -183,7 +221,7 @@ describe("billing country switch", () => {
     });
 
     test("a search response for the previous country cannot repopulate the list", () => {
-      ctx.helper.lastObservedCountry = "GB";
+      initializeCheckout();
       const $select = harness.openCompanyWidget(ctx.$, ctx.helper);
       const transport = ctx.helper.genSelectWooParams().ajax.transport;
       const success = harness.successRecorder();
@@ -195,45 +233,99 @@ describe("billing country switch", () => {
       inFlight.succeed({ items: [{ name: "Example Co", highlight: "Example Co" }] });
 
       expect(success.calls).toHaveLength(0);
-      expect($select.length).toBe(1);
+      expect(harness.resultsText(ctx.$)).not.toContain("Example Co");
+      $select.select2("close");
     });
   });
 
-  describe("initialize() seeds the tracker (TWO-25326)", () => {
-    beforeEach(() => {
-      // initialize() installs a 3s setInterval and an 800ms setTimeout that
-      // would outlive the test on real timers and run against a torn-down
-      // DOM. Nothing here needs them to fire.
-      jest.useFakeTimers();
-      // The checkout-page gate initialize() returns on, and the gateway radio
-      // the bootstrap looks for.
-      ctx.$("form[name='checkout']").after('<div id="order_review"></div>');
-      ctx
-        .$("form[name='checkout']")
-        .append(
-          "<input type='radio' id='payment_method_woocommerce-gateway-tillit'" +
-            " name='payment_method' value='woocommerce-gateway-tillit' />"
-        );
+  describe("the tracker cannot drift from the field", () => {
+    test("the seed makes a FIRST event that IS a real change act", () => {
+      // The mirror of the seeding test below, and the reason the seed is
+      // load-bearing rather than an optimisation: with no seed the first
+      // country the page ever sees is adopted rather than acted on, which is
+      // right for WooCommerce's init re-render and wrong for a buyer who
+      // changes country before any re-render has happened.
+      initializeCheckout();
+      captureCompany("Example Co", "123456789");
+
+      ctx.$("#billing_country").val("ES");
+      fireCountryChange();
+
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
     });
 
-    afterEach(() => {
-      jest.clearAllTimers();
-      jest.useRealTimers();
-    });
-
-    test("records the country already in the form, so the first re-render is inert", () => {
+    test("initialize() records the country already in the form", () => {
       // Core's address-i18n.js triggers `country_to_state_changing` on
       // checkout init, which reaches this binding as a `change` carrying the
-      // country the form ALREADY had. An unseeded tracker (null) treats that
-      // as a change and clears a company restored from the saved address.
-      ctx.Twoinc.getInstance().initialize(false);
+      // country the form ALREADY had.
+      initializeCheckout();
 
       expect(ctx.helper.lastObservedCountry).toBe("GB");
 
       captureCompany("Example Co", "123456789");
-      ctx.$("#billing_country").trigger("change");
+      fireCountryChange();
 
       expect(capturedCompany()).toEqual({ name: "Example Co", id: "123456789" });
+    });
+
+    test("updated_checkout re-syncs a country that moved with no change event", () => {
+      // WooCommerce can replace the billing fields with a server-rendered
+      // country and fire no `change`: a checkout_error re-render, a
+      // multi-step theme, a session address restored server-side. Left
+      // unhandled the tracker keeps the pre-re-render country for the rest of
+      // the page, and a later genuine switch BACK to it reads as no change.
+      initializeCheckout();
+      captureCompany("Example Co", "123456789");
+
+      ctx.$("#billing_country").val("ES");
+      ctx.$(document.body).trigger("updated_checkout");
+
+      expect(ctx.helper.lastObservedCountry).toBe("ES");
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
+    });
+
+    test("the FIRST country ever seen is adopted, not acted on", () => {
+      // The billing fields can render after initialize() does: the gate it
+      // returns on is #order_review, and a multi-step or late-rendering theme
+      // puts the address block in afterwards. The seed then reads nothing, so
+      // the first country the page ever sees arrives on the re-render event —
+      // together with the company restored from the saved address, not
+      // instead of it. There is no previous country to have moved away from,
+      // so there is nothing to invalidate.
+      const $country = ctx.$("#billing_country");
+      const markup = $country.prop("outerHTML");
+      $country.remove();
+
+      initializeCheckout();
+      expect(ctx.helper.lastObservedCountry).toBe(null);
+
+      ctx.$("#billing_country_field").append(markup);
+      captureCompany("Example Co", "123456789");
+      fireCountryChange();
+
+      expect(capturedCompany()).toEqual({ name: "Example Co", id: "123456789" });
+      expect(ctx.helper.lastObservedCountry).toBe("GB");
+    });
+
+    test("an empty reading is neither acted on nor recorded", () => {
+      // WooCommerce replaces #billing_country wholesale on some re-renders,
+      // so an event landing mid-replacement reads "". Clearing on that would
+      // destroy a captured company for nothing; RECORDING it would be worse —
+      // the genuine switch that completes afterwards would then be compared
+      // against "" and swallowed.
+      initializeCheckout();
+      captureCompany("Example Co", "123456789");
+      const $country = ctx.$("#billing_country");
+      const restore = $country.html();
+
+      $country.empty();
+      fireCountryChange();
+      expect(capturedCompany()).toEqual({ name: "Example Co", id: "123456789" });
+      expect(ctx.helper.lastObservedCountry).toBe("GB");
+
+      $country.html(restore).val("ES");
+      fireCountryChange();
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
     });
   });
 
@@ -283,7 +375,7 @@ describe("billing country switch", () => {
     };
 
     test("a response that lands after a country change is discarded", () => {
-      ctx.helper.lastObservedCountry = "GB";
+      initializeCheckout();
       const inFlight = lookup("gb-lookup-id");
 
       ctx.$("#billing_country").val("ES");
@@ -316,6 +408,25 @@ describe("billing country switch", () => {
       const inFlight = lookup("gb-lookup-id");
 
       ctx.$("#billing_country").val("ES");
+      inFlight.succeed(GB_ADDRESS);
+
+      expect(ctx.$("#billing_address_1").val()).toBe("");
+      expect(ctx.Twoinc.getInstance().registryAddressApplied).toBe(false);
+    });
+
+    test("a response is discarded after a switch AWAY and BACK", () => {
+      // The one case only the country handler's sequence bump covers. By the
+      // time the response lands the country reads GB again, so the snapshot
+      // comparison matches and waves it through — but the buyer has been to
+      // Spain and back, the company that lookup belonged to was cleared on
+      // the way out, and its address must not arrive behind them.
+      initializeCheckout();
+      const inFlight = lookup("gb-lookup-id");
+
+      ctx.$("#billing_country").val("ES");
+      fireCountryChange();
+      ctx.$("#billing_country").val("GB");
+      fireCountryChange();
       inFlight.succeed(GB_ADDRESS);
 
       expect(ctx.$("#billing_address_1").val()).toBe("");

--- a/tests/js/country-switch.test.js
+++ b/tests/js/country-switch.test.js
@@ -1,0 +1,315 @@
+/**
+ * TWO-24867 (with TWO-25326). What happens when the billing country changes
+ * mid-checkout — and what must NOT happen when WooCommerce merely says it did.
+ *
+ * Three distinct defects are pinned here, all of them "the country-sensitive
+ * code and the country field disagree":
+ *
+ *   1. The handler fired on WooCommerce's own re-render `change` events, not
+ *      only on a buyer's country change, and each one destroyed the captured
+ *      company (observed live, TWO-25326).
+ *   2. The company search took its country from a closure captured when the
+ *      selectWoo widget was built, so a widget that outlived a country change
+ *      searched the previous country's register.
+ *   3. The registry address lookup had no supersession guard, so a response
+ *      for a company picked under the OLD country wrote its address over the
+ *      fields after the switch — and flagged it as registry data.
+ *
+ * The same three behaviours were fixed on the PrestaShop checkout first; this
+ * is the WooCommerce equivalent, in this plugin's own delegated-handler and
+ * selectWoo shape. See the ticket for the cross-platform parity notes.
+ */
+
+"use strict";
+
+const harness = require("./wc-harness");
+
+describe("billing country switch", () => {
+  let ctx;
+  let ajax;
+
+  beforeEach(() => {
+    // `supported_buyer_countries` is read by isCountrySupported(), which
+    // toggleBusinessFields() calls — the first thing the country handler does.
+    ctx = harness.loadTwoinc({ supported_buyer_countries: ["GB", "ES"] });
+    harness.buildCheckoutForm({ country: "GB" });
+    // The harness fixture carries a single country option, which is all the
+    // search tests need. Switching country needs somewhere to switch TO.
+    ctx.$("#billing_country").append('<option value="ES">Spain</option>');
+    ajax = harness.stubAjax(ctx.$);
+  });
+
+  afterEach(() => {
+    ajax.restore();
+    harness.releaseWidgets(ctx.$);
+    document.body.innerHTML = "";
+  });
+
+  /**
+   * Put a captured company in every field that holds one, the way a pick from
+   * the search results does.
+   *
+   * @param {string} name
+   * @param {string} id
+   * @returns {void}
+   */
+  function captureCompany(name, id) {
+    ctx.$("#billing_company").val(name);
+    ctx.$("#company_id").val(id);
+    ctx.Twoinc.getInstance().customerCompany = {
+      company_name: name,
+      organization_number: id,
+      country_prefix: "GB"
+    };
+  }
+
+  /**
+   * Fire the country handler the way the delegated binding in `initialize()`
+   * does — `this` is the country field, which is what the handler reads.
+   *
+   * @returns {void}
+   */
+  function fireCountryChange() {
+    ctx.Twoinc.prototype.onCountryInputChange.call(
+      ctx.$("#billing_country")[0],
+      ctx.$.Event("change")
+    );
+  }
+
+  /** @returns {{name: string, id: string}} the currently captured company */
+  function capturedCompany() {
+    return {
+      name: ctx.$("#billing_company").val(),
+      id: ctx.$("#company_id").val()
+    };
+  }
+
+  describe("a change event that is not a country change (TWO-25326)", () => {
+    test("leaves the captured company alone", () => {
+      ctx.helper.lastObservedCountry = "GB";
+      captureCompany("Example Co", "123456789");
+
+      // WooCommerce re-renders the billing fields on `updated_checkout` and
+      // core's address-i18n.js re-triggers the country field at init; both
+      // arrive here as a bare `change` with the value unchanged.
+      fireCountryChange();
+
+      expect(capturedCompany()).toEqual({ name: "Example Co", id: "123456789" });
+    });
+
+    test("does not invalidate an in-flight company search", () => {
+      ctx.helper.lastObservedCountry = "GB";
+      const seqBefore = ctx.helper.companySearchSeq;
+
+      fireCountryChange();
+
+      expect(ctx.helper.companySearchSeq).toBe(seqBefore);
+    });
+
+    test("repeated re-renders stay inert, not just the first", () => {
+      ctx.helper.lastObservedCountry = "GB";
+      captureCompany("Example Co", "123456789");
+
+      fireCountryChange();
+      fireCountryChange();
+      fireCountryChange();
+
+      expect(capturedCompany()).toEqual({ name: "Example Co", id: "123456789" });
+    });
+  });
+
+  describe("a real country change", () => {
+    test("clears the captured company", () => {
+      ctx.helper.lastObservedCountry = "GB";
+      captureCompany("Example Co", "123456789");
+
+      ctx.$("#billing_country").val("ES");
+      fireCountryChange();
+
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
+    });
+
+    test("records the new country so the next re-render is inert again", () => {
+      ctx.helper.lastObservedCountry = "GB";
+
+      ctx.$("#billing_country").val("ES");
+      fireCountryChange();
+      captureCompany("Ejemplo SL", "B12345678");
+      fireCountryChange();
+
+      expect(capturedCompany()).toEqual({ name: "Ejemplo SL", id: "B12345678" });
+    });
+
+    test("leaves the new country on customerCompany, not the cleared {}", () => {
+      // clearSelectedCompany() resets customerCompany wholesale and only
+      // re-reads it from the DOM three seconds later, so an assignment made
+      // BEFORE it is silently dropped — which left getApproval() and
+      // getDueInDays() running with no country for that whole window.
+      ctx.helper.lastObservedCountry = "GB";
+      captureCompany("Example Co", "123456789");
+
+      ctx.$("#billing_country").val("ES");
+      fireCountryChange();
+
+      expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("ES");
+    });
+
+    test("invalidates an in-flight company search", () => {
+      ctx.helper.lastObservedCountry = "GB";
+      const seqBefore = ctx.helper.companySearchSeq;
+
+      ctx.$("#billing_country").val("ES");
+      fireCountryChange();
+
+      expect(ctx.helper.companySearchSeq).toBeGreaterThan(seqBefore);
+    });
+
+    test("a search response for the previous country cannot repopulate the list", () => {
+      ctx.helper.lastObservedCountry = "GB";
+      const $select = harness.openCompanyWidget(ctx.$, ctx.helper);
+      const transport = ctx.helper.genSelectWooParams().ajax.transport;
+      const success = harness.successRecorder();
+      transport({ term: "example", page: 0 }, success.fn);
+      const inFlight = ajax.last();
+
+      ctx.$("#billing_country").val("ES");
+      fireCountryChange();
+      inFlight.succeed({ items: [{ name: "Example Co", highlight: "Example Co" }] });
+
+      expect(success.calls).toHaveLength(0);
+      expect($select.length).toBe(1);
+    });
+  });
+
+  describe("initialize() seeds the tracker (TWO-25326)", () => {
+    beforeEach(() => {
+      // initialize() installs a 3s setInterval and an 800ms setTimeout that
+      // would outlive the test on real timers and run against a torn-down
+      // DOM. Nothing here needs them to fire.
+      jest.useFakeTimers();
+      // The checkout-page gate initialize() returns on, and the gateway radio
+      // the bootstrap looks for.
+      ctx.$("form[name='checkout']").after('<div id="order_review"></div>');
+      ctx
+        .$("form[name='checkout']")
+        .append(
+          "<input type='radio' id='payment_method_woocommerce-gateway-tillit'" +
+            " name='payment_method' value='woocommerce-gateway-tillit' />"
+        );
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    });
+
+    test("records the country already in the form, so the first re-render is inert", () => {
+      // Core's address-i18n.js triggers `country_to_state_changing` on
+      // checkout init, which reaches this binding as a `change` carrying the
+      // country the form ALREADY had. An unseeded tracker (null) treats that
+      // as a change and clears a company restored from the saved address.
+      ctx.Twoinc.getInstance().initialize(false);
+
+      expect(ctx.helper.lastObservedCountry).toBe("GB");
+
+      captureCompany("Example Co", "123456789");
+      ctx.$("#billing_country").trigger("change");
+
+      expect(capturedCompany()).toEqual({ name: "Example Co", id: "123456789" });
+    });
+  });
+
+  describe("the search country is read live, not captured (TWO-24867)", () => {
+    test("a widget built under GB searches ES after the field changes", () => {
+      // The widget is deliberately NOT rebuilt between the two searches: it
+      // survives a country change on every path that does not go through
+      // clearSelectedCompany, which is where the captured-closure bug bit.
+      const params = ctx.helper.genSelectWooParams();
+      harness.openCompanyWidget(ctx.$, ctx.helper);
+
+      const before = params.ajax.url({ term: "example", page: 0 });
+      ctx.$("#billing_country").val("ES");
+      const after = params.ajax.url({ term: "example", page: 0 });
+
+      expect(before).toContain("country=GB");
+      expect(after).toContain("country=ES");
+    });
+  });
+
+  describe("registry address lookup supersession (TWO-24867)", () => {
+    beforeEach(() => {
+      // setAddress() writes the four core billing address inputs, which the
+      // company-search fixture has no reason to carry.
+      ctx
+        .$("form[name='checkout']")
+        .append(
+          [
+            "<input type='text' id='billing_address_1' name='billing_address_1' value='' />",
+            "<input type='text' id='billing_address_2' name='billing_address_2' value='' />",
+            "<input type='text' id='billing_city' name='billing_city' value='' />",
+            "<input type='text' id='billing_postcode' name='billing_postcode' value='' />"
+          ].join("\n")
+        );
+    });
+
+    /**
+     * @returns {Object} the stubbed request for the lookup just issued
+     */
+    function lookup(lookupId) {
+      ctx.Twoinc.getInstance().addressLookup({ lookup_id: lookupId });
+      return ajax.last();
+    }
+
+    const GB_ADDRESS = {
+      addresses: [{ street_address: "1 Example Street", city: "London", postal_code: "EC1A 1BB" }]
+    };
+
+    test("a response that lands after a country change is discarded", () => {
+      ctx.helper.lastObservedCountry = "GB";
+      const inFlight = lookup("gb-lookup-id");
+
+      ctx.$("#billing_country").val("ES");
+      fireCountryChange();
+      inFlight.succeed(GB_ADDRESS);
+
+      expect(ctx.$("#billing_address_1").val()).toBe("");
+      expect(ctx.Twoinc.getInstance().registryAddressApplied).toBe(false);
+    });
+
+    test("a response superseded by a newer lookup is discarded", () => {
+      const first = lookup("first-lookup-id");
+      const second = lookup("second-lookup-id");
+
+      second.succeed({
+        addresses: [{ street_address: "2 Second Street", city: "Leeds", postal_code: "LS1 1AA" }]
+      });
+      first.succeed(GB_ADDRESS);
+
+      expect(ctx.$("#billing_address_1").val()).toBe("2 Second Street");
+    });
+
+    test("a response is discarded when the country moved on WITHOUT an event", () => {
+      // Not the same case as the test above, and not covered by the sequence
+      // number: nothing bumped it here. WooCommerce's own address-i18n.js and
+      // several themes write #billing_country with `.val()`, which fires no
+      // `change`, so the handler never runs and never invalidates anything.
+      // The country snapshot taken at request time is the only guard that
+      // stops the GB registry address landing on an ES checkout.
+      const inFlight = lookup("gb-lookup-id");
+
+      ctx.$("#billing_country").val("ES");
+      inFlight.succeed(GB_ADDRESS);
+
+      expect(ctx.$("#billing_address_1").val()).toBe("");
+      expect(ctx.Twoinc.getInstance().registryAddressApplied).toBe(false);
+    });
+
+    test("the current lookup still writes the address", () => {
+      // The guard must not be so tight that the happy path stops working.
+      lookup("gb-lookup-id").succeed(GB_ADDRESS);
+
+      expect(ctx.$("#billing_address_1").val()).toBe("1 Example Street");
+      expect(ctx.Twoinc.getInstance().registryAddressApplied).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## TWO-24867 — country switch breaks company search & autofill (PrestaShop → WooCommerce)

Ports the PrestaShop country-switch fix to WooCommerce, and fixes the
spurious-clear defect found live while working TWO-25326 — which turns out to
be the same bug class pointing the other way.

Everything here is one sentence: **the country-sensitive code and the billing
country field could disagree**, in four different ways.

### 1. The handler fired when the country had not changed (TWO-25326)

`onCountryInputChange` is bound delegated on `document.body` and acted on every
`change` event `#billing_country` emitted. WooCommerce emits plenty that are not
a buyer changing country — `updated_checkout` re-renders the billing fields, and
core's `address-i18n.js` re-triggers the field on `country_to_state_changing` at
checkout init. Each one ran `clearSelectedCompany()` and destroyed the captured
company (`#billing_company`, `#company_id`, the picker's selection, the registry
address behind it) with the buyer having done nothing.

Now guarded on the value actually differing from the last country the page acted
on. Compared by value rather than by testing `event.originalEvent`: WooCommerce's
re-render path re-triggers through jQuery on some themes and dispatches a native
event on others, so an event-source test would hold on the fixture and fail on
the shop.

**Only the destructive half is behind the guard.** `toggleBusinessFields()` stays
unconditional — the swallowed events are precisely the ones that just re-rendered
the billing fields underneath it, so gating the visibility pass too would have
turned this fix into a field-visibility regression.

### 2. The tracker could drift from the field

The guard is only as good as what it compares against, so `countryDidChange` is
the single writer and every path goes through it.

**The seed was taken too early — this was the blocker.** `initialize()` seeded
next to the binding that reads it, then went on to call `loadStorageInputs()`,
which writes `#billing_country` with `selectElem.value =` and fires no `change`.
So the tracker held the country the page was *rendered* with while the field held
the *restored* one, and the first re-render afterwards read the difference as a
real country change — destroying the company and address that same restore had
just put back. `initialize(true)` is the bootstrap's own call, so this was the
production path for any buyer returning to a checkout mid-session. Seeded at the
end of `initialize()` now, after both restore passes.

**`updated_checkout` RECORDS the country, and deliberately does no more.** A
`change` is not guaranteed: WooCommerce can replace the billing fields with a
server-rendered country and fire nothing — a `checkout_error` re-render, a
multi-step theme, a session address restored server-side. Without recording,
the tracker kept the pre-re-render country for the rest of the page and a later
genuine switch *back* to it read as no change and was swallowed.

It must not do more than record. Those same re-renders restore the country and
the company **together**, so clearing the capture there destroys what the
re-render just put back — the same failure this PR exists to remove, on a new
trigger. Throwing away a captured company needs the buyer's gesture, and a
`change` event is the only signal of one this checkout has.

Two readings are deliberately not a change: an **empty** one (the field
mid-replacement) — not acted on and *not recorded*, so a switch completing after
the gap is still compared against the last real country — and the **first known**
country, where there is nothing to have moved away from.

### 3. The search queried the country the widget was built under

`genSelectWooParams()` closed over the country. That held only while *every*
country change went through `clearSelectedCompany()`, which rebuilds the widget —
and it no longer does: the guard above deliberately skips the re-render events,
and a country written programmatically (`.val()`) fires no `change` at all. Both
leave the widget alive with a stale closure, so the buyer got "no companies
found" for a company that exists. Read per request now.

This inverts a test that pinned the old behaviour deliberately
(`company-search-results.test.js`); updated with the reasoning rather than deleted.

### 4. The registry address lookup had no supersession guard

A response for a company picked under the outgoing country wrote its address over
the fields after the switch, and set `registryAddressApplied` on it. Guarded
twice, because neither subsumes the other:

- a sequence number — bumped by a newer lookup **and** by a real country change
  (the only thing covering a switch away and back, where the country matches
  again by the time the response lands);
- the country snapshot taken when the request was issued — the only thing
  covering a country moved programmatically, where nothing bumps the sequence.

An empty reading on **either** side is not a mismatch: discarding a good registry
address would be a silent failure with no retry and no message, and a lookup
issued while WooCommerce was mid-replacement snapshots `""`, which compared
against a known country would discard every response for it.

`twoincSoleTrader.currentCountry()` also delegates to the shared reader now
rather than keeping its own copy of the same two lines — its per-country
availability cache would otherwise be keyed on one answer and read with another.

### Plus

`customerCompany.country_prefix` is written **after** `clearSelectedCompany()`
rather than before it. That function resets the object wholesale and only re-reads
it from the DOM three seconds later, so the assignment was dropped and
`getApproval()` — plus `getDueInDays()`, which early-returns without one — ran
with no country for that window.

### Acceptance criteria

- *Switching country re-runs company search and re-populates autofill with no
  stale state* — (3) and (4).
- *No 500 from stale formatter state* — the PrestaShop 500 came from an address
  formatter override that repo carries; **WooCommerce has no equivalent**. The one
  piece of server-side per-country state here,
  `WC_Twoinc_Sole_Trader::$types_cache`, is already keyed by ISO country and
  session-scoped — checked as part of this work. Nothing to port; recorded so the
  gap is not re-investigated.
- *Behaviour consistent across platforms* — Magento remains outstanding on the ticket.

### Tests

`tests/js/country-switch.test.js`, 19 new tests. Suite: **257 passed**.

The whole suite drives the **real** wiring — a real `initialize(false)`, then
`trigger("change")` on the field — so unwiring the delegated binding, or moving
the seed out of `initialize()`'s reach, fails it. That restructure exposed a leak
worth naming: those bindings are delegated on `document.body`, which survives
`innerHTML = ""`, so each test was leaving a live handler closed over its own
evaluation of the source and the next test's event ran all of them. Unbound in
`afterEach`; it had been producing an order-dependent pass.

Mutation-checked — each fix reverted individually, the named test confirmed red,
then restored green:

| mutation | caught by |
|---|---|
| guard removed (handler always acts) | 6 tests |
| `toggleBusinessFields` moved behind the guard | "still re-runs the field-visibility pass" |
| `initialize()` seed removed | 9 tests |
| empty-reading early return removed | "an empty reading is neither acted on nor recorded" |
| first-known-adopt removed | "the FIRST country ever seen is adopted, not acted on" |
| `countryDidChange` stops recording | 8 tests |
| seed moved back before the restore passes | "the seed is taken AFTER the saved-input restore, not before" |
| `onUpdatedCheckout` recording removed | 2 tests |
| `onUpdatedCheckout` recording made destructive | "updated_checkout records WITHOUT clearing the captured company" |
| closure capture restored | live-country test + the inverted results test |
| search-seq bump removed | 2 tests |
| `addressLookupSeq` bump removed | "a response is discarded after a switch AWAY and BACK" |
| lookup sequence guard removed | "a response superseded by a newer lookup is discarded" |
| lookup country guard removed | "a response is discarded when the country moved on WITHOUT an event" |
| `country_prefix` set before the clear | "leaves the new country on customerCompany" |

**One line is deliberately uncovered** and says so in its own comment: the spinner
hand-off in the country handler. Nothing reachable fails without it — what clears
the spinner today is `clearSelectedCompany()` re-attaching the widget and taking
the dropdown with it — so a test would pass either way, which is worse than none.

PHP unit suite green. `tests/js/README.md` updated for the new suite and for the
inverted claim.

<sub>PR description by Claude.</sub>
