### PR TITLE
fix(company-search): tie the tile company label to the intent message's visibility (TWO-25326 §7)

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -617,6 +617,24 @@
 .twoinc-company-tile-label.hidden {
   display: none;
 }
+/*
+ * The no-content case (TWO-25326 §7, revised 2026-08-03).
+ *
+ * The label's visibility now mirrors the intent-approved notice's, and NOT
+ * "has a company been captured" — so the label can be unhidden while holding
+ * no text, on an intent-approved checkout whose company is unknown. That is a
+ * real state rather than a defensive hypothetical: the notice itself carries a
+ * separate no-company variant of its sentence for exactly it.
+ *
+ * Without this rule such a label would be an invisible 24px gap (the 12px
+ * margins above and below) wedged between the chips and the notice. Handled
+ * here rather than by and-ing the text back into the JS condition, so the one
+ * gate in twoinc.js stays literally "shown when the notice is shown" and this
+ * stays what it is — a rendering detail about an element with nothing in it.
+ */
+.twoinc-company-tile-label:empty {
+  display: none;
+}
 .twoinc-mode-selector {
   display: flex;
   flex-wrap: wrap;

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1580,6 +1580,47 @@ let twoincDomHelper = {
         jQuery(".twoinc-pay-box" + errSelector).removeClass("hidden");
       }
     }
+
+    // The tile's captured-company label tracks the intent notice's
+    // visibility (TWO-25326 §7, revised 2026-08-03), and this method is the
+    // ONLY thing in the plugin that changes that visibility — the sweep on
+    // the first line plus the three branches above are the whole set. So the
+    // re-sync belongs here, at the end, AFTER the notice's own class has
+    // settled: `renderCompanyTileLabel()` reads that class back rather than
+    // recomputing the action, which is what keeps the two from drifting.
+    //
+    // Called unconditionally, including for the actions that show nothing:
+    // hiding the notice must hide the label in the same turn, and the early
+    // `addClass` sweep means every non-intent action is a hide.
+    twoincDomHelper.renderCompanyTileLabel();
+  },
+
+  /**
+   * Whether the payment tile's intent-approved notice is on screen right now
+   * (TWO-25326 §7, revised 2026-08-03).
+   *
+   * The single source of truth for the captured-company label's visibility.
+   * Deliberately reads the notice ELEMENT's own state rather than re-deriving
+   * it from the intent action: the requirement is that the label shows
+   * exactly when the notice shows, and any second copy of the condition — however
+   * faithful when written — is a thing that can come to disagree.
+   *
+   * Both halves are load-bearing, and they cover the two independent ways the
+   * notice can be off screen:
+   *   - `.length` — the brand switched the notice off, so
+   *     get_intent_approved_notice() returned '' and the div was never
+   *     rendered at all (`intent_approved_notice_enabled: false`). An absent
+   *     notice is a hidden notice, so the label stays hidden forever on that
+   *     brand;
+   *   - `.hidden` — the notice exists but the checkout is not in the
+   *     intent-approved state (pre-intent, checking, errored, or a
+   *     re-render), which is the runtime case.
+   *
+   * @returns {boolean}
+   */
+  isIntentNoticeVisible: function () {
+    const $notice = jQuery(".twoinc-pay-box.twoinc-intent-approved");
+    return $notice.length > 0 && !$notice.hasClass("hidden");
   },
 
   /**
@@ -1884,10 +1925,38 @@ let twoincDomHelper = {
     const $label = jQuery("." + twoincDomHelper.companyTileLabelClass);
     if (!$label.length) return;
 
+    // Both arguments omitted => read the live inputs, the same fallback
+    // `renderCompanySummary` uses. This is the shape `togglePaySubtitleDesc`
+    // calls: it knows the notice's visibility changed but holds no company
+    // values of its own, and re-reading is what lets it re-sync the label
+    // without the capture sites having to notify it.
+    if (name === undefined && number === undefined) {
+      const captured = twoincDomHelper.readCapturedCompany();
+      name = twoincUtilHelper.blankToEmpty(captured.company_name);
+      number = twoincUtilHelper.blankToEmpty(captured.organization_number);
+    }
+
     const text = name && number ? name + " (" + number + ")" : name;
 
     $label.text(text);
-    $label.toggleClass("hidden", !text);
+
+    // Visibility is the intent notice's, not "is a company captured"
+    // (TWO-25326 §7, revised 2026-08-03: the label is no longer wanted
+    // shown unconditionally once a company is known). `isIntentNoticeVisible()`
+    // reads the notice element back, so this is the same gate the notice
+    // itself passed through rather than a parallel re-derivation of it.
+    //
+    // Note what is NOT and-ed in here: `text`. A captured company is no
+    // longer part of the condition, so an intent-approved checkout whose
+    // company is unknown — a real state, which is precisely why the notice
+    // ships a no-company variant of its sentence — leaves this element
+    // unhidden with nothing in it. The empty case is suppressed in CSS
+    // instead (`.twoinc-company-tile-label:empty`), because an empty label
+    // with the rule's 12px margins would otherwise push the notice down by
+    // 24px for no visible reason. Keeping that out of the JS is what makes
+    // "shown exactly when the notice is shown" literally true of this line,
+    // with the no-content case handled as the rendering detail it is.
+    $label.toggleClass("hidden", !twoincDomHelper.isIntentNoticeVisible());
   },
 
   /**

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -925,9 +925,7 @@ if (!class_exists('WC_Twoinc')) {
             // optional fields (invoice email, project, department) are billing
             // form fields, not tile content — so the only anchor that exists
             // here is the intent message, and this sits immediately before the
-            // intent loader/notice pair. That also keeps it last in the tile
-            // when the notice is switched off, which is where the fallback
-            // would have put it anyway.
+            // intent loader/notice pair.
             //
             // Empty and `hidden` on render, filled by renderCompanyTileLabel()
             // in twoinc.js. Server-side it cannot be filled at all: the
@@ -935,22 +933,38 @@ if (!class_exists('WC_Twoinc')) {
             // generated, and this same block is re-rendered by every
             // `update_checkout` regardless of whether a company was picked.
             //
+            // Suppressed with the notice (TWO-25326 §7, revised 2026-08-03).
+            // The label's visibility now mirrors the intent-approved notice's
+            // exactly, so on a brand with 'intent_approved_notice_enabled'
+            // false there is no state in which this container can ever be
+            // shown — shipping it anyway would be markup that only ever sits
+            // empty and hidden. This is the same reasoning TWO-25224 already
+            // applied to the intent loader, and it puts the label inside the
+            // one reassurance pass the notice switch governs. twoinc.js does
+            // not rely on the suppression (its gate reads the notice element,
+            // and an absent notice reads as hidden) — the two agree because
+            // they are the same rule, which is the point.
+            //
             // A <div>, not a <p>: some themes give `.payment_box p` its own
             // margins, and this must not pick up spacing the chips and notices
             // around it do not have.
+            $company_label = $notice_enabled
+                ? '<div class="twoinc-company-tile-label hidden"></div>'
+                : '';
             return sprintf(
                 '<div>
                     %s
                     <label class="twoinc-term-chips-heading hidden"></label>
                     <div class="twoinc-term-chips hidden" role="radiogroup"></div>
                     <div class="twoinc-sole-trader-toggle hidden" role="radiogroup"></div>
-                    <div class="twoinc-company-tile-label hidden"></div>
+                    %s
                     %s
                     %s
                     <div class="twoinc-pay-box twoinc-err-payment-default hidden">%s</div>
                     <div class="twoinc-pay-box twoinc-err-phone-number hidden">%s</div>
                 </div>',
                 $term_input,
+                $company_label,
                 $this->get_intent_loader_html($notice_enabled),
                 $this->get_intent_approved_notice($notice_enabled),
                 sprintf(__('Invoice purchase with %s is not available for this order.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')),

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -888,6 +888,13 @@ describe("read-only captured-company summary", () => {
       expect(intentShown()).toBe(true);
       expect(tileLabel().text()).toBe("");
 
+      // The element is deliberately NOT hidden here — that is the whole reason
+      // the CSS rule below has to exist. Asserted rather than left implied
+      // (round 1 review): without it this test would still pass against an
+      // implementation that quietly and-ed the text back into the JS gate, and
+      // the CSS assertion underneath would then be guarding nothing.
+      expect(tileLabelShown()).toBe(true);
+
       const empty = /\.twoinc-company-tile-label:empty\s*\{([^}]*)\}/.exec(stylesheetSource());
       expect(empty).not.toBeNull();
       expect(empty[1]).toMatch(/display:\s*none/);

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -75,11 +75,54 @@ describe("read-only captured-company summary", () => {
     // this every tile assertion below would be checking an element that does
     // not exist. Deliberately outside the billing field wrapper, which is what
     // the address-area assertions are scoped to.
+    //
+    // The intent-approved notice is part of that minimum now (TWO-25326 §7,
+    // revised 2026-08-03): the label's visibility mirrors this element's, so
+    // a tile without it is a tile whose label can never appear. Rendered with
+    // the server's own attributes — `hidden`, and the company template on
+    // data-company-template — because both are what the production markup
+    // ships and the gate reads the `hidden` class back.
     $(document.body).append(
       '<li class="wc_payment_method"><div class="payment_box">' +
         '<div class="twoinc-company-tile-label hidden"></div>' +
+        '<div class="twoinc-pay-box twoinc-intent-approved hidden" ' +
+        'data-company-template="Your invoice is likely to be accepted for {company}.">' +
+        "Your invoice is likely to be accepted." +
+        "</div>" +
         "</div></li>"
     );
+
+    // Intent approved is this suite's baseline state, because it is the only
+    // state in which the label is on screen at all. Tests about WHEN the label
+    // shows live in their own describe block below and drive the notice
+    // themselves; everything else here is about WHAT it renders, and would be
+    // asserting against a permanently hidden element without this.
+    approveIntent();
+  }
+
+  /**
+   * Put the tile into the intent-approved state — the notice on screen, and
+   * so the label with it.
+   *
+   * @returns {void}
+   */
+  function approveIntent() {
+    dom.togglePaySubtitleDesc("intent-approved");
+  }
+
+  /** @returns {Object} the payment tile's intent-approved notice */
+  function intentNotice() {
+    return $(".twoinc-pay-box.twoinc-intent-approved");
+  }
+
+  /** @returns {boolean} whether the intent-approved notice is on screen */
+  function intentShown() {
+    return intentNotice().length > 0 && !intentNotice().hasClass("hidden");
+  }
+
+  /** @returns {boolean} whether the tile's company label is on screen */
+  function tileLabelShown() {
+    return tileLabel().length > 0 && !tileLabel().hasClass("hidden");
   }
 
   /** @returns {Object} the summary element, or an empty set */
@@ -158,6 +201,13 @@ describe("read-only captured-company summary", () => {
     test("renders the picked company's number under the field and its name in the tile", () => {
       pickCompany("ACME Widgets Ltd", "12345678");
 
+      // Picking a company invalidates the intent that was approved for the
+      // PREVIOUS one, so the pick itself takes the notice back off screen —
+      // and the label with it (TWO-25326 §7, revised 2026-08-03). That is the
+      // behaviour, not a harness quirk; re-approve to get back to the state
+      // this test is about, which is what the label renders once shown.
+      approveIntent();
+
       expect(isShown()).toBe(true);
       expect(renderedNumber()).toBe("12345678");
       expect(renderedName()).toBe("ACME Widgets Ltd");
@@ -188,6 +238,13 @@ describe("read-only captured-company summary", () => {
       sessionStorage.removeItem("checkoutInputs");
 
       dom.toggleBusinessFields();
+
+      // The re-render clears the intent state (toggleBusinessFields calls
+      // togglePaySubtitleDesc with no action), which hides the notice and the
+      // label together — correct, since nothing is approved mid-re-render.
+      // Re-approve: the question here is whether the NAME survives the
+      // re-render, and the label has to be on screen to answer it.
+      approveIntent();
 
       expect(isShown()).toBe(true);
       expect(renderedName()).toBe("ACME Widgets Ltd");
@@ -282,6 +339,10 @@ describe("read-only captured-company summary", () => {
     test("a company carrying no organisation number renders its name alone", () => {
       // The organisation number is optional on a registry hit; the name is not.
       pickCompany("ACME Widgets Ltd", "");
+
+      // The pick invalidated the previous intent; re-approve so the tile label
+      // is on screen to be read (see the first test in this block).
+      approveIntent();
 
       // No number means no number label at all — not an empty one taking up a
       // row under the field (TWO-25326 §5).
@@ -429,6 +490,11 @@ describe("read-only captured-company summary", () => {
 
       dom.enterManualCompanyEntry();
       typeCompanyName("Sole Proprietor Bakery");
+
+      // The pick above invalidated the previous intent; re-approve so the tile
+      // label is on screen to be read (see the first test in this file's
+      // company-search block).
+      approveIntent();
 
       expect(renderedName()).toBe("Sole Proprietor Bakery");
       expect(tileText()).toBe("Sole Proprietor Bakery");
@@ -682,6 +748,149 @@ describe("read-only captured-company summary", () => {
       expect(renderedName()).toBe("ACME Widgets Ltd");
       expect(renderedNumber()).toBe("12345678");
       expect($("#company_id").val()).toBe("12345678");
+    });
+  });
+
+  /**
+   * The tile label's visibility mirrors the intent-approved notice's
+   * (TWO-25326 §7, revised by Doug 2026-08-03).
+   *
+   * The rule this replaces was "shown whenever a company is captured", which
+   * shipped the night before in PR #429. The revision drops that: capture is no
+   * longer part of the condition at all — the
+   * notice's visibility is the whole of it, in both directions.
+   *
+   * The assertions below are deliberately written against the NOTICE's state
+   * rather than against the action that produced it. A test that checked
+   * `action === "intent-approved"` would pass just as happily against a
+   * parallel re-derivation of the condition, which is the exact failure mode
+   * the implementation is built to rule out — the label has to follow the
+   * element, so that is what gets compared.
+   */
+  describe("tile label visibility mirrors the intent notice (TWO-25326 §7, 2026-08-03)", () => {
+    /** Capture a company without leaving the intent notice on screen. */
+    function captureCompanyOnly() {
+      const ajax = harness.stubAjax($);
+      pickCompany("ACME Widgets Ltd", "12345678");
+      ajax.restore();
+    }
+
+    test("a captured company alone does NOT show the label", () => {
+      // The whole point of the revision. Picking a company fills the label's
+      // text and leaves it hidden, because nothing has approved an intent yet.
+      captureCompanyOnly();
+
+      expect($("#billing_company").val()).toBe("ACME Widgets Ltd");
+      expect(intentShown()).toBe(false);
+      expect(tileLabelShown()).toBe(false);
+    });
+
+    test("the label appears with the notice, and carries the captured company", () => {
+      captureCompanyOnly();
+      approveIntent();
+
+      expect(intentShown()).toBe(true);
+      expect(tileLabelShown()).toBe(true);
+      expect(tileLabel().text()).toBe("ACME Widgets Ltd (12345678)");
+    });
+
+    test("the label goes away again when the notice does", () => {
+      captureCompanyOnly();
+      approveIntent();
+      expect(tileLabelShown()).toBe(true);
+
+      // Back into the checking state: a new intent is in flight, so the
+      // approval no longer holds and neither element may claim it does.
+      dom.togglePaySubtitleDesc("checking-intent");
+
+      expect(intentShown()).toBe(false);
+      expect(tileLabelShown()).toBe(false);
+    });
+
+    test("an error state hides the label even with a company captured", () => {
+      captureCompanyOnly();
+      approveIntent();
+
+      dom.togglePaySubtitleDesc("errored", ".twoinc-err-payment-default");
+
+      expect(intentShown()).toBe(false);
+      expect(tileLabelShown()).toBe(false);
+    });
+
+    test("the two agree across every intent action, in both directions", () => {
+      // The invariant itself, swept over the full action set rather than
+      // spot-checked: hidden(label) === hidden(notice), always. A parallel
+      // condition that merely usually agrees fails somewhere in here.
+      captureCompanyOnly();
+
+      const actions = [
+        undefined,
+        "checking-intent",
+        "intent-approved",
+        "errored",
+        "intent-approved",
+        undefined,
+        "intent-approved"
+      ];
+
+      actions.forEach(function (action) {
+        dom.togglePaySubtitleDesc(action, ".twoinc-err-payment-default");
+        expect(tileLabelShown()).toBe(intentShown());
+      });
+
+      // And the sweep genuinely visited both states, so the invariant was not
+      // satisfied trivially by everything staying hidden throughout.
+      dom.togglePaySubtitleDesc("intent-approved");
+      expect(tileLabelShown()).toBe(true);
+      dom.togglePaySubtitleDesc();
+      expect(tileLabelShown()).toBe(false);
+    });
+
+    test("a brand that suppressed the notice never shows the label", () => {
+      // 'intent_approved_notice_enabled: false' => get_intent_approved_notice()
+      // returns '' and the notice div is never rendered. An absent notice is a
+      // hidden notice, so the label must stay down even on the action that
+      // would otherwise show it. WC_Twoinc.php also stops emitting the label
+      // container on such a brand; this asserts the JS gate holds on its own,
+      // so the two are not load-bearing for each other.
+      intentNotice().remove();
+      captureCompanyOnly();
+
+      dom.togglePaySubtitleDesc("intent-approved");
+
+      expect(intentNotice().length).toBe(0);
+      expect(tileLabelShown()).toBe(false);
+    });
+
+    test("the label re-syncs without the capture sites having to re-render it", () => {
+      // togglePaySubtitleDesc holds no company values of its own, so the
+      // no-argument path of renderCompanyTileLabel has to read them back off
+      // the live inputs. If it did not, toggling the notice would show an
+      // empty label on a checkout that has a company.
+      captureCompanyOnly();
+      tileLabel().text("");
+
+      dom.togglePaySubtitleDesc("intent-approved");
+
+      expect(tileLabel().text()).toBe("ACME Widgets Ltd (12345678)");
+    });
+
+    test("an intent-approved checkout with no company leaves no empty label behind", () => {
+      // The no-company state is real — the notice ships a separate sentence
+      // for it — and the JS gate deliberately does not and-in the text, so the
+      // element is unhidden while empty. CSS is what stops that being a 24px
+      // gap (the rule's own 12px margins) between the chips and the notice.
+      $("#billing_company").val("");
+      $("#company_id").val("");
+
+      dom.togglePaySubtitleDesc("intent-approved");
+
+      expect(intentShown()).toBe(true);
+      expect(tileLabel().text()).toBe("");
+
+      const empty = /\.twoinc-company-tile-label:empty\s*\{([^}]*)\}/.exec(stylesheetSource());
+      expect(empty).not.toBeNull();
+      expect(empty[1]).toMatch(/display:\s*none/);
     });
   });
 });

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -191,6 +191,7 @@ final class BrandConfigSpec
             'testIntentApprovedNoticeInvalidSwitchReportsAndDefaultsOn',
             'testIntentLoaderRendersTheOneSharedDotPulse',
             'testIntentLoaderSuppressedWithTheNoticeButErrorBoxesSurvive',
+            'testCompanyTileLabelSuppressedWithTheNotice',
             'testAssetVersionTracksFileMtimeNotPluginVersion',
             'testAssetVersionFallsBackToPluginVersionWhenFileMissing',
         ];
@@ -5716,6 +5717,48 @@ final class BrandConfigSpec
         TinyAssert::true(
             strpos($html, 'twoinc-pay-box twoinc-err-phone-number hidden') !== false,
             'the phone-number error box must survive the notice being off'
+        );
+    }
+
+    /**
+     * TWO-25326 section 7, revised 2026-08-03: the captured-company label's
+     * visibility mirrors the intent-approved notice's exactly. On a brand
+     * that switched the notice off there is therefore no state in which the
+     * label can ever be shown, so its container must not be emitted either —
+     * the same conclusion TWO-25224 reached for the loader, extended to the
+     * label now that it belongs to the same reassurance pass.
+     *
+     * Asserted as a pair with the enabled case. Presence alone would pass
+     * against markup that emits the container unconditionally, and absence
+     * alone would pass against markup that never emits it at all; only the
+     * two together pin the container to the switch.
+     */
+    private static function testCompanyTileLabelSuppressedWithTheNotice(): void
+    {
+        add_filter('twoinc_brand_file', static function ($file) {
+            return __DIR__ . '/fixtures/suppressednoticebrand.php';
+        });
+        TinyAssert::same(false, WC_Twoinc_Brand::get('intent_approved_notice_enabled'));
+
+        $html = self::gateway()->build_payment_description();
+        TinyAssert::true(
+            strpos($html, 'twoinc-company-tile-label') === false,
+            'a brand disabling the notice must emit no company tile label container'
+        );
+
+        // The error boxes still prove the tile itself rendered, so the
+        // absence above is the switch doing its job and not an empty build.
+        TinyAssert::true(
+            strpos($html, 'twoinc-pay-box twoinc-err-phone-number hidden') !== false,
+            'the tile must still have rendered for that absence to mean anything'
+        );
+
+        self::reset();
+        self::useTaglineBrand();
+        $enabled_html = self::gateway()->build_payment_description();
+        TinyAssert::true(
+            strpos($enabled_html, '<div class="twoinc-company-tile-label hidden"></div>') !== false,
+            'a brand with the notice on must still ship the label container'
         );
     }
 


### PR DESCRIPTION
## What

TWO-25326 §7, revised 2026-08-03. The payment tile's captured-company label is now shown **exactly when the intent-approved notice is shown**, and hidden exactly when it is hidden.

This supersedes the rule that shipped in woocommerce-plugin PR #429, which showed the label whenever a company had been captured, regardless of anything else.

## How

**One gate, not two.** A new `isIntentNoticeVisible()` reads the notice *element's* own state back out of the DOM; `renderCompanyTileLabel()` toggles the label on that. The label follows the notice rather than re-deriving the condition that produced it — a parallel copy of the condition would agree today and drift later, which is the specific failure this shape rules out.

Both halves of that read are load-bearing, covering the two independent ways the notice can be off screen:

- **absent** — the brand set `intent_approved_notice_enabled` false, so `get_intent_approved_notice()` returned `''` and the div was never rendered;
- **`hidden`** — the notice exists but the checkout is not in the approved state (pre-intent, checking, errored, mid-re-render).

**Reactive, not render-once.** `togglePaySubtitleDesc` is the only thing in the plugin that changes the notice's visibility, so the label re-sync sits at the end of it, after the notice's class has settled. It calls the label renderer with no arguments, which reads the captured company back off the live inputs — so the capture sites don't have to know the notice moved. Without this the label would only ever be correct on whichever render happened to follow a capture, and e.g. an error state would leave it stranded on screen.

Two supporting changes:

- **The label container is no longer emitted** when the brand has the notice switched off. With the notice suppressed there is no state in which the label can appear, so the markup would only ever sit empty and hidden. Same reasoning TWO-25224 already applied to the intent loader. The JS gate does not depend on this — it holds on its own — the two agree because they are the same rule.
- **`.twoinc-company-tile-label:empty { display: none }`.** The JS gate deliberately does *not* and-in "has text", so that "shown when the notice is shown" is literally true of that one line. An intent-approved checkout with no known company is a real state — the notice ships a separate no-company sentence precisely for it — and would otherwise leave an empty label holding its own `12px` margins open: 24px of gap between the chips and the notice, for nothing. The no-content case belongs in CSS, not in the visibility policy.

## Tests

8 new JS cases in the new `tile label visibility mirrors the intent notice` block, asserting the label's hidden state against **the notice's**, never against the intent action — a test keyed on the action would pass just as happily against the parallel re-derivation this is built to avoid. Includes the both-directions sweep over the full action set (with an explicit check that the sweep visited both states, so the invariant can't be satisfied by everything staying hidden), the brand-suppressed case, the re-sync case, and the no-company case.

1 new PHP case pins the container to the notice switch in **both** directions — presence alone would pass against unconditional markup, absence alone against markup that never emits it.

The pre-existing content assertions now drive the tile into the approved state first, since that is the only state the label is on screen in; the notice is part of the test tile's minimum markup as a result. Where a capture or a re-render legitimately invalidates the prior approval, the test re-approves explicitly with a comment saying so — that hiding is the new behaviour, not a harness quirk.

### Verification

| Check | Result |
|---|---|
| `npm run test:js` | 242 passed (was 234; +8) |
| `php tests/unit/run.php` | all passed (+1 new case) |
| `pre-commit` (prettier) | passed |
| Mutation: gate reverted to old captured-company rule | **fails 5 cases** |
| Mutation: re-sync call removed | **fails 7 cases** |
| Mutation: absent-notice half of the gate dropped | **fails 1 case** |
| Mutation: `:empty` CSS rule removed | **fails 1 case** |
| Mutation: container always emitted | **fails the PHP case** |

Every mutation was confirmed to have actually applied to the tree before its verdict was taken.

**Not verified in a real browser.** The Chrome bridge was disconnecting repeatedly during this session. Verification here is unit + mutation + CI only. The reactive path in particular (notice hides → label hides in the same turn) is asserted in jsdom against the real `togglePaySubtitleDesc`, but has not been watched happen on a live checkout.

`phpcs` and `phpstan` are not installed locally; CI covers both.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
