### PR TITLE
chore(TWO-25326): remove partner-initial ticket prefixes from comments

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -403,8 +403,8 @@
 
 /* Payment terms chip selector (TWO-24751) */
 /*
- * Heading above the chips, shown only when more than one term is offered
- * (ABN-468). Mirrors Magento's <label class="label"> in the Luma
+ * Heading above the chips, shown only when more than one term is offered.
+ * Mirrors Magento's <label class="label"> in the Luma
  * gateway_method.html template — a plain form label, not a chip.
  */
 .twoinc-term-chips-heading {

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -3033,7 +3033,7 @@ let twoincTermChips = {
     // Heading placement mirrors Magento's Luma template: shown ABOVE the
     // chips only when the buyer has a choice to make. A single chip carries
     // its own "Payment Terms N days" label instead, so a heading there would
-    // say the same thing twice (ABN-468).
+    // say the same thing twice.
     const $heading = jQuery(".twoinc-term-chips-heading");
     if (single || terms.length === 0) {
       $heading.addClass("hidden").text("");

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -952,7 +952,7 @@ if (!class_exists('WC_Twoinc')) {
             // this server-side one is the fallback for every path where that
             // JS never runs — JS disabled, a theme that strips the container,
             // or the pay-for-order page (TWO-24812 — a withdrawn single term
-            // must abort, not silently re-price). Since ABN-468 the chips DO
+            // must abort, not silently re-price). The chips now DO
             // render for a single offered term, so this is no longer the
             // single-term case's only input; it stays as the belt to the
             // JS input's braces.
@@ -4059,9 +4059,9 @@ if (!class_exists('WC_Twoinc')) {
                     // surcharge-method-keyed copy that
                     // generate_two_surcharge_grid_html() renders BELOW the
                     // table, word-for-word from Magento's
-                    // view/adminhtml/templates/system/config/field/surcharge-grid.phtml
-                    // (ABN-476). A 'description' set by a wc_two_form_fields
-                    // filter is still rendered, also below the table.
+                    // view/adminhtml/templates/system/config/field/surcharge-grid.phtml.
+                    // A 'description' set by a wc_two_form_fields filter is
+                    // still rendered, also below the table.
                     'type'        => 'two_surcharge_grid',
                 ],
                 'surcharge_rounding_basis' => [

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -453,7 +453,7 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                     // (view/frontend/web/js/view/payment/method-renderer/
                     // gateway_method.js + template/payment/gateway_method.html),
                     // which is also what the Amasty and Fire checkouts render —
-                    // they share that one template (ABN-468).
+                    // they share that one template.
                     //
                     // >1 term  → `heading` sits ABOVE the chips.
                     // exactly 1 → no heading; `single_label` replaces the bare

--- a/class/WC_Twoinc_Payment_Terms.php
+++ b/class/WC_Twoinc_Payment_Terms.php
@@ -921,7 +921,7 @@ if (!class_exists('WC_Twoinc_Payment_Terms')) {
         /**
          * Buyer-facing chip amount: the store's own price format, so the chip
          * shows the currency SYMBOL in the store's configured position with
-         * the store's separators — "€12,50", not "12.50 EUR" (ABN-468).
+         * the store's separators — "€12,50", not "12.50 EUR".
          *
          * This is the WooCommerce equivalent of Magento's
          * priceUtils.formatPrice(amount, quote.getPriceFormat()) in

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -486,7 +486,7 @@ suite green:
   the surcharge fee recalculation trigger, saved-input replay, sole-trader fields;
 - the fetch half of `twoincTermChips` — `refresh()`'s fee POST and its done/fail branches.
   `render()` itself IS covered, by `term-chips.test.js`: the singular/plural chip labelling
-  and heading placement, and the currency-symbol fee label (ABN-468);
+  and heading placement, and the currency-symbol fee label;
 - the selection side of company search — `onCompanySelected`-equivalent handling in
   `Twoinc.initialize`'s `select2:select` binding, `clearSelectedCompany()`, the
   the address autofill. Neither the manual-entry row nor the captured-company summary is among

--- a/tests/js/term-chips.test.js
+++ b/tests/js/term-chips.test.js
@@ -1,5 +1,5 @@
 /**
- * ABN-468. The payment-terms chip renderer in assets/js/twoinc.js.
+ * The payment-terms chip renderer in assets/js/twoinc.js.
  *
  * Three behaviours are pinned here because all three are silent when they
  * regress — the chips still render, just saying the wrong thing:

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -1671,7 +1671,7 @@ final class BrandConfigSpec
     }
 
     /**
-     * ABN-468: the chip fee label goes out already formatted by the store's
+     * The chip fee label goes out already formatted by the store's
      * own price format, so the buyer sees the currency SYMBOL — Magento's
      * priceUtils.formatPrice behaviour, not the currency code the pricing
      * API echoes back. Tags stripped and entities decoded, because the chip
@@ -2366,7 +2366,7 @@ final class BrandConfigSpec
         // cap (Woo does no FX conversion), so the help text must not claim
         // a fixed maximum it will not enforce. The fixed-amount help
         // paragraph disappears entirely and the combined variant degrades
-        // to the percentage-only wording (ABN-476) — the percentage
+        // to the percentage-only wording — the percentage
         // ceiling itself is always enforced, so "Max: 100%" stays.
         $GLOBALS['__twoinc_test_store_currency'] = 'NOK';
         $html = $gateway->generate_two_surcharge_grid_html('surcharge_grid', []);
@@ -2398,7 +2398,7 @@ final class BrandConfigSpec
      * admin.css) so the help text wraps at the grid's width rather than the
      * full width of the WooCommerce settings cell. The table therefore
      * carries no width of its own — admin.css makes it 100% of the
-     * container. Mirrors Magento's #surcharge-grid-container (ABN-476).
+     * container. Mirrors Magento's #surcharge-grid-container.
      */
     private static function testSurchargeGridNotesShareTheGridsWidthContainer(): void
     {


### PR DESCRIPTION
## What

Comment-only cleanup. Eleven places in this **public** repo carried an
external ticket prefix whose letters are a partner's initials:

| File | Kind |
|---|---|
| `assets/css/twoinc.css` | CSS comment |
| `assets/js/twoinc.js` | JS comment |
| `class/WC_Twoinc.php` (x2) | PHP comments |
| `class/WC_Twoinc_Checkout.php` | PHP comment |
| `class/WC_Twoinc_Payment_Terms.php` | docblock |
| `tests/js/README.md` | prose |
| `tests/js/term-chips.test.js` | docblock |
| `tests/unit/run.php` (x3) | docblock + comment |

Each reference is dropped rather than reworded — the surrounding prose
already explains the behaviour it was pointing at, so nothing
load-bearing is lost. Two comments were re-wrapped to keep line lengths
tidy after the parenthetical came out.

## Not in scope

Old commits still contain the references. Per the task owner's
instruction, history is **not** rewritten — only the branch tip is made
clean.

## Verification

- `php tests/unit/run.php` — all tests passed
- `npm run test:js` — 7 suites, 242 tests passed
- `php -l` clean on all four touched PHP files
- Repo-wide case-insensitive grep for the partner name and the prefix
  returns zero hits at this tip (one base64 substring in
  `package-lock.json` is a false positive and untouched)
- Three-dot diff against `staging` contains the prefix only on removal
  (`-`) lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
