### PR TITLE
fix(checkout): drop a company stranded in the wrong country (TWO-25333)

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -4070,9 +4070,12 @@ class Twoinc {
       twoincSelectWooHelper.companySearchSeq += 1;
       Twoinc.getInstance().addressLookupSeq += 1;
 
-      // BEFORE updateElements() below, which is what re-runs getApproval():
-      // called after it, the intent request for the stale pair would already
-      // have gone out and its answer would still be on screen.
+      // BEFORE updateElements() below, which is what re-runs getApproval().
+      // getApproval() does not fire immediately — it arms a 1s interval — so
+      // the ordering is not what stops the stale pair being posted, and no
+      // test pins it as though it were. It is here because clearing before the
+      // approval pass is the only order in which `updateElements` sees the
+      // state that the rest of this event's work should be derived from.
       Twoinc.getInstance().clearCompanyIfCountryStale(movedCountry);
     }
 
@@ -4100,13 +4103,23 @@ class Twoinc {
     let inputName = $input.attr("name");
 
     if (inputName === "company_id") {
-      Twoinc.getInstance().customerCompany.organization_number = $input.val();
-      // Pin the capture country next to the number the buyer just typed
-      // (TWO-25333 — see the picker's select handler for why the two have to
-      // be written together). Unconditional on the value: an emptied field
-      // leaves no capture for the country to be wrong about, and re-pinning it
-      // to the country now in the form is true either way.
-      Twoinc.getInstance().customerCompany.country_prefix = twoincSelectWooHelper.currentCountry();
+      const typed = $input.val();
+      // Only when the blur actually MOVED the number (TWO-25333 — see the
+      // picker's select handler for why the number and the country have to be
+      // written together). This is a BLUR, not a change: tabbing through an
+      // untouched `#company_id` fires it too, and re-pinning there would
+      // launder a stale pair into a consistent-looking one. The number would
+      // still be the previous country's company while `country_prefix` was
+      // rewritten to the country the form has since moved to, and
+      // `clearCompanyIfCountryStale` could never fire on it again. Pinning only
+      // a number the buyer actually entered keeps the witness tied to a
+      // capture rather than to a keystroke that passed through.
+      const numberMoved = typed !== Twoinc.getInstance().customerCompany.organization_number;
+      Twoinc.getInstance().customerCompany.organization_number = typed;
+      if (numberMoved) {
+        Twoinc.getInstance().customerCompany.country_prefix =
+          twoincSelectWooHelper.currentCountry();
+      }
     } else if (inputName === "billing_company_display") {
       Twoinc.getInstance().customerCompany.company_name = $input.val();
     }
@@ -4261,6 +4274,22 @@ class Twoinc {
    *     id is not a capture (TWO-25326 §6: the payment method is usable only
    *     for a company captured WITH an id), and there is nothing about a bare
    *     name that a country change invalidates.
+   *
+   *     KNOWN RESIDUAL GAP, not closed here. `customerCompany` is populated
+   *     from the DOM on a timer, so `#company_id` can hold a real capture
+   *     while this object still holds nulls — during `initialize()`'s deferred
+   *     seed, and for the three seconds after `clearSelectedCompany`. A silent
+   *     country move inside one of those windows is missed, and the deferred
+   *     re-read then pairs the old country's company with the new country via
+   *     `getCompanyData()`, which reads `#billing_country` live and so
+   *     UN-PINS the witness — leaving a self-consistent false pair nothing can
+   *     detect afterwards. Falling back to `#company_id` here would not help:
+   *     the DOM has no per-company country to compare against, which is why
+   *     the witness has to live in JS state at all. Closing it properly means
+   *     stopping the DOM re-reads from overwriting a pinned `country_prefix`,
+   *     which is a change to `getCompanyData()`'s contract and its several
+   *     other callers — deliberately left for its own ticket rather than
+   *     widened into this one.
    *   - An unknown country on either side. `country_prefix` is null until the
    *     first capture or DOM re-read, and an empty field reading means the
    *     field was mid-replacement — the same rule the address-lookup guard
@@ -4295,11 +4324,30 @@ class Twoinc {
 
     const domNumber = jQuery("#company_id").val() || "";
     if (domNumber && domNumber !== company.organization_number) {
-      // Re-read both halves together, from the same DOM, in one go — the
-      // pairing is the whole point, so taking the company from the fields and
-      // the country from the tracker would rebuild the same mismatch this
-      // function exists to catch.
-      this.customerCompany = twoincDomHelper.getCompanyData();
+      // Built field by field rather than by `getCompanyData()`, which is what
+      // this did first and which was wrong on the half that matters. In
+      // company-search mode `getCompanyData()` takes the name from
+      // `getCompanyName()`, and that does not read the DOM at all: it reads the
+      // `checkoutInputs` sessionStorage snapshot, refreshed only by
+      // `saveCheckoutInputs()`'s own interval. So the name came from a
+      // different moment than the number and the country — up to three seconds
+      // stale, or `""` when no snapshot had been taken yet — which is the
+      // mismatched-pair defect this function exists to prevent, rebuilt by the
+      // function itself. An empty name is not cosmetic either:
+      // `isReadyApprovalCheck()` refuses on ANY empty value, so it left the
+      // payment method quietly unusable for a company the re-render had just
+      // restored, with nothing scheduled to re-read it (this branch never arms
+      // clearSelectedCompany's deferred pass).
+      //
+      // `#billing_company` is the right name source here: it is the field
+      // WooCommerce posts, the mirror a restore writes, and the one
+      // `clearSelectedCompany` and `enterManualCompanyEntry` already treat as
+      // authoritative. All three values are now read within this one tick.
+      this.customerCompany = {
+        company_name: jQuery("#billing_company").val() || "",
+        country_prefix: country,
+        organization_number: domNumber
+      };
       return false;
     }
 

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -4128,6 +4128,15 @@ class Twoinc {
         Twoinc.getInstance().customerCompany.organization_number
       );
       const numberMoved = twoincUtilHelper.blankToEmpty(typed) !== previousNumber;
+      // Stored RAW, deliberately. Normalising on the way in was written here
+      // first, to remove the asymmetry between this one writer and the readers
+      // that all normalise — and then reverted: no test could tell the
+      // difference, because the discriminator normalises the recorded value
+      // anyway and that normalisation IS tested. It would also have changed the
+      // organisation number this plugin POSTS on the order intent, which is a
+      // behaviour change nothing in this ticket asked for. The record may hold
+      // an unnormalised value; that is precisely why every comparison against
+      // it goes through `blankToEmpty` rather than trusting its shape.
       Twoinc.getInstance().customerCompany.organization_number = typed;
       if (numberMoved && twoincUtilHelper.blankToEmpty(typed)) {
         Twoinc.getInstance().customerCompany.country_prefix =
@@ -4372,8 +4381,20 @@ class Twoinc {
     // branch then pinned the new country onto a number no capture path had
     // witnessed, next to the PREVIOUS company's name — a two-moment pair made
     // self-consistent, which is the exact defect this function exists to catch.
-    // Requiring the name to have moved too is what separates a restore (which
-    // writes both mirrors) from a keystroke (which writes one).
+    //
+    // What the rule actually tests is "both mirrors changed", not "restore
+    // versus keystroke" — the two are not the same thing and the difference
+    // matters to whoever reads this next. A genuine restore of a DIFFERENT
+    // company that happens to carry the SAME name (group entities trading
+    // under one name) reads as one mirror moving and is cleared. Accepted:
+    // rare, fail-closed, and the buyer re-picks.
+    //
+    // The rule holds on WooCommerce's own re-render paths because `#company_id`
+    // is a registered billing field (`$fields['billing']['company_id']` in
+    // WC_Twoinc_Checkout), so it lives in the same billing fragment as
+    // `#billing_company` and every WC-driven re-render writes both from the
+    // same vintage. One mirror moving alone is therefore evidence of something
+    // other than a re-render.
     //
     // Anything else falls through to the clear, deliberately fail-CLOSED. In
     // particular a diverged number with an EMPTY `#billing_company` is NOT
@@ -4395,22 +4416,28 @@ class Twoinc {
     // `clearSelectedCompany` and `enterManualCompanyEntry` already treat as
     // authoritative.
     //
-    // Two things here are deliberately NOT independently covered, because no
-    // reachable case can distinguish them — recorded rather than left for the
-    // next reader to "fix" into a difference:
+    // Normalising the RECORDED values is load-bearing, not defence in depth —
+    // an earlier version of this comment claimed the name condition made it
+    // unreachable and that was wrong, so both halves now have their own test.
+    // Two reachable ways the record diverges from the DOM by representation
+    // alone, while the name has genuinely moved:
     //
-    //   - Normalising `recordedNumber` is defence in depth, not an independent
-    //     guard. A number-vs-string mismatch on its own cannot reach the
-    //     re-sync, because the name condition rejects it first; it would take a
-    //     re-render that moved the name while leaving a numerically identical
-    //     but differently typed number. Kept because all four values go through
-    //     the same normaliser and making one of them the exception is how the
-    //     next type mismatch gets in.
-    //   - `company_name: domName` needs no fallback. The condition guarantees
-    //     `domName` is non-empty, so `domName || recordedName` would be dead —
-    //     and worse than dead: falling back to the record's name would pair
-    //     company A's name with company B's number, which is the two-moment
-    //     pair this whole function exists to prevent.
+    //   - Type. `twoincSoleTrader.setCompany()` writes the organisation number
+    //     straight out of parsed JSON, so the record can hold the NUMBER
+    //     123456789 while `#company_id` holds the string "123456789". Add a
+    //     re-render that rewrote `#billing_company` and left the plugin's own
+    //     `#company_id` alone, and an un-normalised compare takes the re-sync
+    //     branch and launders a GB-captured number into a self-consistent ES
+    //     pair.
+    //   - Whitespace, on either side, which this file produces itself: the
+    //     manual blur handler stores what the field holds.
+    //
+    // One thing here IS equivalent by construction, and is recorded so the next
+    // reader does not "fix" it into a difference: `company_name: domName` needs
+    // no fallback. The condition guarantees `domName` is non-empty, so
+    // `domName || recordedName` is dead — and worse than dead, because falling
+    // back to the record's name would pair company A's name with company B's
+    // number, the two-moment pair this whole function exists to prevent.
     if (domNumber && domName && domNumber !== recordedNumber && domName !== recordedName) {
       this.customerCompany = {
         company_name: domName,

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -3290,6 +3290,13 @@ let twoincSoleTrader = {
     const instance = Twoinc.getInstance();
     instance.customerCompany.organization_number = companyId;
     instance.customerCompany.company_name = companyName;
+    // Pin the capture country next to the number, same as the picker's select
+    // handler does and for the same reason (TWO-25333 — see there). Only on
+    // the capturing call: setMode("business") reaches this with both arguments
+    // falsy to CLEAR, and there is no capture then for a country to belong to.
+    if (companyId) {
+      instance.customerCompany.country_prefix = twoincSelectWooHelper.currentCountry();
+    }
     // Explicit rather than DOM-read: this function is the authority on what was
     // just captured, so the summary should not depend on the order the mirrors
     // above are written in (TWO-25288).
@@ -3513,6 +3520,18 @@ class Twoinc {
 
       // Set the company ID
       self.customerCompany.organization_number = data.company_id;
+
+      // Pin the country this company was captured UNDER, alongside the number
+      // (TWO-25333). Without this the pair could be assembled from two
+      // different moments: the number is written here, while `country_prefix`
+      // was last written by whichever DOM re-read ran most recently — so a
+      // country that moved with no `change` event before the pick left the
+      // OLD country next to a company from the NEW one, which getApproval()
+      // then posted as a self-consistent pair. It is also what makes
+      // `clearCompanyIfCountryStale` sound: a witness written at a different
+      // time from the thing it witnesses produces false positives, and a
+      // false positive there is a destructive clear.
+      self.customerCompany.country_prefix = twoincSelectWooHelper.currentCountry();
 
       // Set the company ID to HTML DOM
       $companyId.val(data.company_id);
@@ -4027,7 +4046,16 @@ class Twoinc {
     // destroy what the same re-render just put back — the TWO-25326 failure
     // on a new trigger. Throwing away a captured company needs the buyer's
     // gesture, and the `change` event is the only signal of one there is.
-    if (twoincSelectWooHelper.countryDidChange(twoincSelectWooHelper.currentCountry())) {
+    //
+    // Record-only is still not the whole answer, though: a country that moved
+    // to something the captured company does not belong to left that company
+    // captured and approved, and the mismatch surfaced as an opaque
+    // order-creation failure. `clearCompanyIfCountryStale` below is the
+    // discriminator for that — it fires on the countries DISAGREEING, not on
+    // the country having moved, so it stays silent on the restore-together
+    // case above (TWO-25333).
+    const movedCountry = twoincSelectWooHelper.currentCountry();
+    if (twoincSelectWooHelper.countryDidChange(movedCountry)) {
       // Invalidating in-flight work IS safe here, though, and record-only
       // would otherwise leave a hole: on this path nothing bumps either
       // counter, so a company-search response or a registry address for the
@@ -4041,6 +4069,11 @@ class Twoinc {
       // selected, which is not something the buyer can lose.
       twoincSelectWooHelper.companySearchSeq += 1;
       Twoinc.getInstance().addressLookupSeq += 1;
+
+      // BEFORE updateElements() below, which is what re-runs getApproval():
+      // called after it, the intent request for the stale pair would already
+      // have gone out and its answer would still be on screen.
+      Twoinc.getInstance().clearCompanyIfCountryStale(movedCountry);
     }
 
     Twoinc.getInstance().updateElements();
@@ -4068,6 +4101,12 @@ class Twoinc {
 
     if (inputName === "company_id") {
       Twoinc.getInstance().customerCompany.organization_number = $input.val();
+      // Pin the capture country next to the number the buyer just typed
+      // (TWO-25333 — see the picker's select handler for why the two have to
+      // be written together). Unconditional on the value: an emptied field
+      // leaves no capture for the country to be wrong about, and re-pinning it
+      // to the country now in the form is true either way.
+      Twoinc.getInstance().customerCompany.country_prefix = twoincSelectWooHelper.currentCountry();
     } else if (inputName === "billing_company_display") {
       Twoinc.getInstance().customerCompany.company_name = $input.val();
     }
@@ -4185,6 +4224,105 @@ class Twoinc {
     twoincSoleTrader.refresh();
 
     self.getApproval();
+  }
+
+  /**
+   * Drop a captured company that belongs to a country the checkout has since
+   * moved away from (TWO-25333).
+   *
+   * The gap this closes. `onUpdatedCheckout` records a country that moved with
+   * no `change` event and deliberately does NOT clear the capture, because
+   * those re-renders restore the country and the company together and
+   * clearing would destroy what the re-render just put back (TWO-24867 /
+   * TWO-25326 — see there). But when the country really did move to something
+   * the captured company does not belong to, that company survived and
+   * nothing downstream caught it: `getApproval()` posts `customerCompany`
+   * carrying the OLD `country_prefix` next to the OLD organisation number, so
+   * the pair is internally consistent and the intent check approves it and
+   * the buyer sees a green payment method; the order payload then pairs that
+   * `company_id` with the ORDER's billing country with no consistency check
+   * between the two. The mismatch reached the Two API at order creation and
+   * came back as an opaque failure the buyer could not act on.
+   *
+   * Discriminating rather than choosing between "always clear" and "never
+   * clear" is what keeps this from being TWO-25326 again: in the
+   * restore-together case the recorded country and the captured company's own
+   * country agree by construction, because the same re-render supplied both,
+   * so this stays silent exactly where clearing would be destructive.
+   *
+   * Called only from `onUpdatedCheckout`. The `change` path
+   * (`syncBillingCountry`) already clears unconditionally on a real country
+   * change, which is strictly stronger, so running this there as well would
+   * be dead code rather than extra safety.
+   *
+   * Three readings are NOT grounds to clear, and none of them is incidental:
+   *
+   *   - No organisation number on `customerCompany`. A company name with no
+   *     id is not a capture (TWO-25326 §6: the payment method is usable only
+   *     for a company captured WITH an id), and there is nothing about a bare
+   *     name that a country change invalidates.
+   *   - An unknown country on either side. `country_prefix` is null until the
+   *     first capture or DOM re-read, and an empty field reading means the
+   *     field was mid-replacement — the same rule the address-lookup guard
+   *     and `countryDidChange` already apply, for the same reason: only two
+   *     countries that are both KNOWN and DIFFERENT are evidence of anything.
+   *   - The DOM already holding a DIFFERENT company from the one recorded.
+   *     Then it is the record that is stale, not the fields: `customerCompany`
+   *     is refreshed from the DOM on a timer, so a re-render that swapped in
+   *     another saved address — country AND company together, a different pair
+   *     but a self-consistent one — reaches here with the previous capture
+   *     still in JS state. Clearing on that would destroy the company the
+   *     re-render had just restored, which is precisely the regression this
+   *     ticket must not reintroduce. Re-sync to the DOM instead.
+   *
+   * Compared case-insensitively because the two sides are written by
+   * different readers: `currentCountry()` upper-cases, `getCompanyData()`
+   * reads `#billing_country` raw (the inconsistency noted in the comment on
+   * `currentCountry`, still not swept up here). WooCommerce's country values
+   * are upper-case ISO codes today, so this normalisation is guarding the
+   * comparison against that known disagreement rather than against observed
+   * mixed-case data — a false positive here is a destructive clear.
+   *
+   * @param {string} country upper-cased ISO code the checkout has moved to
+   * @returns {boolean} whether a stale capture was dropped
+   */
+  clearCompanyIfCountryStale(country) {
+    const company = this.customerCompany || {};
+    if (!company.organization_number) return false;
+
+    const capturedCountry = (company.country_prefix || "").toUpperCase();
+    if (!country || !capturedCountry || capturedCountry === country) return false;
+
+    const domNumber = jQuery("#company_id").val() || "";
+    if (domNumber && domNumber !== company.organization_number) {
+      // Re-read both halves together, from the same DOM, in one go — the
+      // pairing is the whole point, so taking the company from the fields and
+      // the country from the tracker would rebuild the same mismatch this
+      // function exists to catch.
+      this.customerCompany = twoincDomHelper.getCompanyData();
+      return false;
+    }
+
+    // No supersession bump here, deliberately. `clearSelectedCompany()` below
+    // empties the fields, so a company search or a registry address issued
+    // under the outgoing country must not land on top of them afterwards — but
+    // the only caller has already bumped both counters, unconditionally on the
+    // country having moved, before it reaches this. A defensive repeat was
+    // written here first and then removed: it changed nothing observable, so no
+    // test could hold it in place, and an untestable line that reads as the
+    // guarantee is worse than the guarantee living plainly at the one call
+    // site. A second caller would have to bump them too, and its own test for
+    // that is what would say so.
+    twoincDomHelper.clearSelectedCompany();
+
+    // AFTER clearSelectedCompany, for the reason spelled out in
+    // syncBillingCountry: it resets `customerCompany` to {} wholesale, so an
+    // assignment made before it is dropped and leaves getApproval() and
+    // getDueInDays() with no country for the three seconds until its deferred
+    // re-read runs.
+    this.customerCompany.country_prefix = country;
+
+    return true;
   }
 }
 

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -4130,13 +4130,15 @@ class Twoinc {
       const numberMoved = twoincUtilHelper.blankToEmpty(typed) !== previousNumber;
       // Stored RAW, deliberately. Normalising on the way in was written here
       // first, to remove the asymmetry between this one writer and the readers
-      // that all normalise — and then reverted: no test could tell the
-      // difference, because the discriminator normalises the recorded value
-      // anyway and that normalisation IS tested. It would also have changed the
-      // organisation number this plugin POSTS on the order intent, which is a
-      // behaviour change nothing in this ticket asked for. The record may hold
-      // an unnormalised value; that is precisely why every comparison against
-      // it goes through `blankToEmpty` rather than trusting its shape.
+      // that all normalise — and then reverted, because it would have changed
+      // the organisation number this plugin POSTS on the order intent
+      // (`customerCompany` goes into `buyer.company` verbatim in getApproval),
+      // which is a behaviour change nothing in this ticket asked for. No test in
+      // this suite distinguishes the two, and that is a consequence of the
+      // choice rather than a justification for it — a test trivially could,
+      // by asserting the stored value keeps its padding. The record may hold an
+      // unnormalised value; that is precisely why every comparison against it
+      // goes through `blankToEmpty` rather than trusting its shape.
       Twoinc.getInstance().customerCompany.organization_number = typed;
       if (numberMoved && twoincUtilHelper.blankToEmpty(typed)) {
         Twoinc.getInstance().customerCompany.country_prefix =
@@ -4416,11 +4418,12 @@ class Twoinc {
     // `clearSelectedCompany` and `enterManualCompanyEntry` already treat as
     // authoritative.
     //
-    // Normalising the RECORDED values is load-bearing, not defence in depth —
-    // an earlier version of this comment claimed the name condition made it
-    // unreachable and that was wrong, so both halves now have their own test.
-    // Two reachable ways the record diverges from the DOM by representation
-    // alone, while the name has genuinely moved:
+    // Normalising is load-bearing on ALL FOUR values, not defence in depth — an
+    // earlier version of this comment claimed the name condition made the
+    // recorded number's normalisation unreachable, and that was wrong twice
+    // over, so each of the four now has its own test. Reachable ways a value
+    // diverges from its counterpart by representation alone, while the other
+    // mirror has genuinely moved:
     //
     //   - Type. `twoincSoleTrader.setCompany()` writes the organisation number
     //     straight out of parsed JSON, so the record can hold the NUMBER
@@ -4429,12 +4432,26 @@ class Twoinc {
     //     `#company_id` alone, and an un-normalised compare takes the re-sync
     //     branch and launders a GB-captured number into a self-consistent ES
     //     pair.
-    //   - Whitespace, on either side, which this file produces itself: the
-    //     manual blur handler stores what the field holds.
+    //   - Whitespace, on either side and in either direction. The record picks
+    //     it up because the manual blur handler stores what the field holds;
+    //     the DOM picks it up from a paste into `#company_id` or a trailing
+    //     space typed into `#billing_company` with no blur behind it.
     //
-    // One thing here IS equivalent by construction, and is recorded so the next
-    // reader does not "fix" it into a difference: `company_name: domName` needs
-    // no fallback. The condition guarantees `domName` is non-empty, so
+    // Not normalised, and equivalent by construction: `capturedCountry`. It is
+    // compared against a value `currentCountry()` produced, and WooCommerce's
+    // country values are unpadded upper-case ISO strings on both sides — the
+    // `.toUpperCase()` there is about the two READERS disagreeing, which is a
+    // real difference and is tested.
+    //
+    // `country_prefix: country` rather than a fresh `currentCountry()` read is
+    // also indistinguishable today — the caller took `country` from that same
+    // reader on this same tick. Written as the argument anyway, so the value
+    // this pairs the company with is provably the one the change was detected
+    // against rather than whatever the field says by the time this line runs.
+    //
+    // Also equivalent by construction, recorded so the next reader does not
+    // "fix" it into a difference: `company_name: domName` needs no fallback.
+    // The condition guarantees `domName` is non-empty, so
     // `domName || recordedName` is dead — and worse than dead, because falling
     // back to the record's name would pair company A's name with company B's
     // number, the two-moment pair this whole function exists to prevent.

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -4114,9 +4114,22 @@ class Twoinc {
       // `clearCompanyIfCountryStale` could never fire on it again. Pinning only
       // a number the buyer actually entered keeps the witness tied to a
       // capture rather than to a keystroke that passed through.
-      const numberMoved = typed !== Twoinc.getInstance().customerCompany.organization_number;
+      // Normalised on both sides, and requiring a value: `organization_number`
+      // is seeded null by the constructor and written from parsed JSON by the
+      // sole-trader prefill, so a raw `!==` reads the number 123456789 as
+      // different from the string "123456789" and re-pins on a blur that moved
+      // nothing — reopening the laundering this guard exists to close, through
+      // a type mismatch. And a blur on an EMPTY untouched field would otherwise
+      // count as movement ("" !== null), pinning a country onto a capture that
+      // does not exist; inert today, but it makes the witness look
+      // authoritative to the next reader, which is how this class of bug got
+      // here.
+      const previousNumber = twoincUtilHelper.blankToEmpty(
+        Twoinc.getInstance().customerCompany.organization_number
+      );
+      const numberMoved = twoincUtilHelper.blankToEmpty(typed) !== previousNumber;
       Twoinc.getInstance().customerCompany.organization_number = typed;
-      if (numberMoved) {
+      if (numberMoved && twoincUtilHelper.blankToEmpty(typed)) {
         Twoinc.getInstance().customerCompany.country_prefix =
           twoincSelectWooHelper.currentCountry();
       }
@@ -4283,7 +4296,14 @@ class Twoinc {
    *     re-read then pairs the old country's company with the new country via
    *     `getCompanyData()`, which reads `#billing_country` live and so
    *     UN-PINS the witness — leaving a self-consistent false pair nothing can
-   *     detect afterwards. Falling back to `#company_id` here would not help:
+   *     detect afterwards. The country is not the only half `getCompanyData()`
+   *     unpairs: it also sources the name from `getCompanyName()`, which in
+   *     company-search mode reads the `checkoutInputs` sessionStorage snapshot
+   *     rather than the DOM, so the name comes from a third moment again.
+   *     Benign in both windows as things stand, because `organization_number`
+   *     is empty there and every downstream guard refuses on that — but the
+   *     gap is two-axis, not one, and a later reader should not conclude the
+   *     name half is sound. Falling back to `#company_id` here would not help:
    *     the DOM has no per-company country to compare against, which is why
    *     the witness has to live in JS state at all. Closing it properly means
    *     stopping the DOM re-reads from overwriting a pinned `country_prefix`,
@@ -4312,43 +4332,92 @@ class Twoinc {
    * comparison against that known disagreement rather than against observed
    * mixed-case data — a false positive here is a destructive clear.
    *
+   * Returns nothing on purpose. It reported whether it had cleared, the only
+   * caller ignored it, and flipping the value broke no test — an unverified
+   * contract stated in a docblock is worse than none.
+   *
    * @param {string} country upper-cased ISO code the checkout has moved to
-   * @returns {boolean} whether a stale capture was dropped
+   * @returns {void}
    */
   clearCompanyIfCountryStale(country) {
     const company = this.customerCompany || {};
-    if (!company.organization_number) return false;
+    if (!company.organization_number) return;
 
-    const capturedCountry = (company.country_prefix || "").toUpperCase();
-    if (!country || !capturedCountry || capturedCountry === country) return false;
+    const capturedCountry = twoincUtilHelper.blankToEmpty(company.country_prefix).toUpperCase();
+    if (!country || !capturedCountry || capturedCountry === country) return;
 
-    const domNumber = jQuery("#company_id").val() || "";
-    if (domNumber && domNumber !== company.organization_number) {
-      // Built field by field rather than by `getCompanyData()`, which is what
-      // this did first and which was wrong on the half that matters. In
-      // company-search mode `getCompanyData()` takes the name from
-      // `getCompanyName()`, and that does not read the DOM at all: it reads the
-      // `checkoutInputs` sessionStorage snapshot, refreshed only by
-      // `saveCheckoutInputs()`'s own interval. So the name came from a
-      // different moment than the number and the country — up to three seconds
-      // stale, or `""` when no snapshot had been taken yet — which is the
-      // mismatched-pair defect this function exists to prevent, rebuilt by the
-      // function itself. An empty name is not cosmetic either:
-      // `isReadyApprovalCheck()` refuses on ANY empty value, so it left the
-      // payment method quietly unusable for a company the re-render had just
-      // restored, with nothing scheduled to re-read it (this branch never arms
-      // clearSelectedCompany's deferred pass).
-      //
-      // `#billing_company` is the right name source here: it is the field
-      // WooCommerce posts, the mirror a restore writes, and the one
-      // `clearSelectedCompany` and `enterManualCompanyEntry` already treat as
-      // authoritative. All three values are now read within this one tick.
+    // Every comparison below goes through `blankToEmpty`, which normalises
+    // null/undefined to "" and coerces to a trimmed string. Not defensive
+    // noise: `organization_number` is seeded null by the constructor and
+    // written from parsed JSON by the sole-trader prefill, so it is not
+    // guaranteed to be a string, while `.val()` always is. A raw `!==` between
+    // the number 123456789 and the string "123456789" is true, and every
+    // comparison here treats "different" as evidence — so an un-normalised
+    // compare turns a type mismatch into either a laundered stale pair or a
+    // destructive clear of a valid capture.
+    const domNumber = twoincUtilHelper.blankToEmpty(jQuery("#company_id").val());
+    const domName = twoincUtilHelper.blankToEmpty(jQuery("#billing_company").val());
+    const recordedNumber = twoincUtilHelper.blankToEmpty(company.organization_number);
+    const recordedName = twoincUtilHelper.blankToEmpty(company.company_name);
+
+    // The DOM holds a DIFFERENT company than the record: BOTH halves present
+    // and BOTH diverged. Then it is the record that is stale rather than the
+    // fields — a re-render swapped in another saved address, country and
+    // company together, a different pair but a self-consistent one — and
+    // clearing would destroy what that re-render just restored.
+    //
+    // Both halves, and both non-empty, is the whole discriminator. Requiring
+    // only the number to diverge was fail-OPEN: a buyer typing into
+    // `#company_id` without blurring produces the same divergence, and this
+    // branch then pinned the new country onto a number no capture path had
+    // witnessed, next to the PREVIOUS company's name — a two-moment pair made
+    // self-consistent, which is the exact defect this function exists to catch.
+    // Requiring the name to have moved too is what separates a restore (which
+    // writes both mirrors) from a keystroke (which writes one).
+    //
+    // Anything else falls through to the clear, deliberately fail-CLOSED. In
+    // particular a diverged number with an EMPTY `#billing_company` is NOT
+    // trusted: taking the name from the record instead would pair company A's
+    // name with company B's number, and writing the empty name through would
+    // leave `isReadyApprovalCheck()` refusing forever — this branch arms no
+    // deferred re-read, and the next re-render would see a self-consistent
+    // pair and never fire again, so the payment method would be stuck unusable
+    // with no way back. A clear is recoverable; that is not.
+    //
+    // Read field by field rather than through `getCompanyData()`, which is what
+    // this did first and which was wrong on the half that matters: in
+    // company-search mode that takes the name from `getCompanyName()`, and that
+    // does not read the DOM at all — it reads the `checkoutInputs`
+    // sessionStorage snapshot, refreshed only by `saveCheckoutInputs()`'s own
+    // interval. So the name came from a different moment than the number and
+    // the country. `#billing_company` is the right source here: the field
+    // WooCommerce posts, the mirror a restore writes, and the one
+    // `clearSelectedCompany` and `enterManualCompanyEntry` already treat as
+    // authoritative.
+    //
+    // Two things here are deliberately NOT independently covered, because no
+    // reachable case can distinguish them — recorded rather than left for the
+    // next reader to "fix" into a difference:
+    //
+    //   - Normalising `recordedNumber` is defence in depth, not an independent
+    //     guard. A number-vs-string mismatch on its own cannot reach the
+    //     re-sync, because the name condition rejects it first; it would take a
+    //     re-render that moved the name while leaving a numerically identical
+    //     but differently typed number. Kept because all four values go through
+    //     the same normaliser and making one of them the exception is how the
+    //     next type mismatch gets in.
+    //   - `company_name: domName` needs no fallback. The condition guarantees
+    //     `domName` is non-empty, so `domName || recordedName` would be dead —
+    //     and worse than dead: falling back to the record's name would pair
+    //     company A's name with company B's number, which is the two-moment
+    //     pair this whole function exists to prevent.
+    if (domNumber && domName && domNumber !== recordedNumber && domName !== recordedName) {
       this.customerCompany = {
-        company_name: jQuery("#billing_company").val() || "",
+        company_name: domName,
         country_prefix: country,
         organization_number: domNumber
       };
-      return false;
+      return;
     }
 
     // No supersession bump here, deliberately. `clearSelectedCompany()` below
@@ -4369,8 +4438,6 @@ class Twoinc {
     // getDueInDays() with no country for the three seconds until its deferred
     // re-read runs.
     this.customerCompany.country_prefix = country;
-
-    return true;
   }
 }
 

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -4355,6 +4355,11 @@ class Twoinc {
     if (!company.organization_number) return;
 
     const capturedCountry = twoincUtilHelper.blankToEmpty(company.country_prefix).toUpperCase();
+    // `!country` is unreachable from the only caller today and no test covers
+    // it: `countryDidChange` already returns false on an empty reading, so this
+    // is never entered with one. Kept as the guard a second caller would need,
+    // and said out loud so the docblock's "an unknown country on either side"
+    // is not read as two tested readings when only the captured side is.
     if (!country || !capturedCountry || capturedCountry === country) return;
 
     // Every comparison below goes through `blankToEmpty`, which normalises

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -284,18 +284,30 @@ about the company-search helper, so the bootstrap is left to no-op.
   therefore clears the capture when the recorded country and the captured company's own
   `country_prefix` actually **disagree**, and only then. Pinned in both directions, because the
   discriminator is the whole fix: a company captured under the country just left is cleared and
-  `isReadyApprovalCheck()` comes back down with it (TWO-25326 §6 — the method is usable only for
-  a company captured _with_ an id); a matching pair is untouched, on either
-  `enable_address_lookup` setting. Three readings are deliberately not grounds to clear, each
-  with its own test — a company name with no organisation number (not a capture), an unknown
-  country on either side (`country_prefix` is null until the first capture, and an empty field
-  reading means mid-replacement), and the DOM already holding a **different** company from the
-  one recorded, which means the record is what is stale rather than the fields, so it is
-  re-synced to the DOM instead of destroying a company the re-render had just restored. The
-  comparison is case-insensitive, because `currentCountry()` upper-cases and `getCompanyData()`
-  reads the field raw — a false positive here is a destructive clear. This path can now reach
-  `clearSelectedCompany()`, so the loop it used to be immune to by construction
-  (clear → `setAddress()` → `update_checkout`) is pinned again for it.
+  the approval gate comes back down with it; a matching pair is untouched. Both directions are
+  pinned on **both** `enable_address_lookup` settings and **both** `enable_company_search`
+  settings — the manual-entry leg differs, because `clearSelectedCompany` deliberately keeps the
+  buyer's typed `#billing_company` there while still blanking `#company_id`. Three readings are
+  deliberately not grounds to clear, each with its own test — a company name with no
+  organisation number (not a capture), an unknown country on either side (`country_prefix` is
+  null until the first capture, and an empty field reading means mid-replacement), and the DOM
+  already holding a **different** company from the one recorded, which means the record is what
+  is stale rather than the fields, so it is re-synced from the fields instead of destroying a
+  company the re-render had just restored. That re-sync reads `#billing_company`,
+  `#company_id` and the country within one tick rather than calling `getCompanyData()`: in
+  company-search mode that takes the name from the `checkoutInputs` **sessionStorage** snapshot
+  rather than the DOM, so it rebuilt a two-moment pair — and an empty name takes
+  `isReadyApprovalCheck()` down with it, leaving the method unusable for a company that was
+  legitimately restored. The comparison is case-insensitive, because `currentCountry()`
+  upper-cases and `getCompanyData()` reads the field raw — a false positive here is a
+  destructive clear. This path can now reach `clearSelectedCompany()`, so the loop it used to be
+  immune to by construction (clear → `setAddress()` → `update_checkout`) is pinned again for it.
+- **what the approval-gate test does and does not prove.** `isReadyApprovalCheck()` coming back
+  down stops a fresh intent being sought for the dropped pair, and that is what is asserted. It
+  is _not_ the same as the payment method becoming unselectable: nothing in the file deselects
+  the gateway radio and `isTwoincApproved` is written but never read, so a buyer already approved
+  keeps a selected Two method over an emptied company until the next intent pass. Enforcing
+  TWO-25326 §6 by deselecting is the deferred half of that design and is not in this suite.
 - **the capture country is pinned when the company is captured** (TWO-25333), at all three
   capture sites: the picker's `select2:select` handler, a manually typed organisation number,
   and the sole-trader setter — which does _not_ re-pin on the clearing call `setMode("business")`
@@ -303,7 +315,25 @@ about the company-search helper, so the bootstrap is left to no-op.
   moments, the number at capture and `country_prefix` from whichever DOM re-read ran last, so a
   country that moved with no `change` event _before_ the capture left the old country next to a
   company from the new one — posted by `getApproval()` as a self-consistent pair, and read by
-  the discriminator above as a mismatch it would clear.
+  the discriminator above as a mismatch it would clear. The manual-entry pin fires only when the
+  blur actually **moved** the number: that handler is bound to `blur`, not `change`, so tabbing
+  through an untouched `#company_id` would otherwise launder a stale pair into a
+  consistent-looking one the discriminator could never fire on again. Pinned, in both
+  directions.
+
+A **known residual gap** is recorded in the code rather than fixed here: `customerCompany` is
+populated from the DOM on a timer, so `#company_id` can hold a real capture while that object
+still holds nulls — during `initialize()`'s deferred seed, and for three seconds after
+`clearSelectedCompany`. A silent country move inside one of those windows is missed, and the
+deferred re-read then re-pairs the old country's company with the new country via
+`getCompanyData()`, which reads `#billing_country` live and so un-pins the witness. Closing it
+means stopping the DOM re-reads from overwriting a pinned `country_prefix`, which changes
+`getCompanyData()`'s contract for its other callers, so it wants its own ticket. The suite also
+cannot observe those timers: advancing them throws from `setTimeout(this.enableCompanySearch, 800)`
+in `initialize()` — an unbound `this` in a strict class body, pre-existing and firing on every
+real page load with company search on. That wants fixing first, in its own commit, before any
+timer-based test here is possible.
+
 - **the whole suite drives the real wiring**: a real `initialize(false)`, then
   `trigger("change")` on the field, so unwiring the delegated binding or moving the seed out
   of `initialize()`'s reach fails it. `afterEach` unbinds `document.body` — jsdom's document

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -293,7 +293,19 @@ about the company-search helper, so the bootstrap is left to no-op.
   null until the first capture, and an empty field reading means mid-replacement), and the DOM
   already holding a **different** company from the one recorded, which means the record is what
   is stale rather than the fields, so it is re-synced from the fields instead of destroying a
-  company the re-render had just restored. That re-sync reads `#billing_company`,
+  company the re-render had just restored. That last one needs **both** mirrors to have moved and
+  both to be non-empty, and every leg of that is pinned: a diverged number alone is a buyer
+  typing into `#company_id` without blurring, a diverged name alone is the mirror of it, and a
+  diverged number with an empty `#billing_company` is trusted by neither of the two available
+  fallbacks — the record's name would pair company A's name with company B's number, and an empty
+  name would leave `isReadyApprovalCheck()` refusing forever, since this branch arms no deferred
+  re-read and the next re-render would see a self-consistent pair and never fire again. All three
+  fall through to the clear, deliberately fail-closed: a clear is recoverable, a permanently
+  unusable payment method is not. Every comparison goes through `blankToEmpty`, because
+  `organization_number` is seeded null and written from parsed JSON by the sole-trader prefill
+  while `.val()` is always a string — `123456789 !== "123456789"` would otherwise turn a type
+  mismatch into either a laundered pair or a destructive clear, and both directions are pinned.
+  That re-sync reads `#billing_company`,
   `#company_id` and the country within one tick rather than calling `getCompanyData()`: in
   company-search mode that takes the name from the `checkoutInputs` **sessionStorage** snapshot
   rather than the DOM, so it rebuilt a two-moment pair — and an empty name takes
@@ -318,8 +330,27 @@ about the company-search helper, so the bootstrap is left to no-op.
   the discriminator above as a mismatch it would clear. The manual-entry pin fires only when the
   blur actually **moved** the number: that handler is bound to `blur`, not `change`, so tabbing
   through an untouched `#company_id` would otherwise launder a stale pair into a
-  consistent-looking one the discriminator could never fire on again. Pinned, in both
-  directions.
+  consistent-looking one the discriminator could never fire on again. Pinned in both directions,
+  with a positive control in the same fixture — without one the test could not tell "the guard
+  works" from "the handler never ran" — plus the normalisation cases that reopen the same
+  laundering by another route: a recorded number that arrived as a number rather than a string,
+  a value differing only by stray whitespace, and emptying a populated number (which is not a
+  capture and must leave no witness claiming one).
+
+Two mutations in this area deliberately **survive**, and the reasons are written into the code
+next to them: normalising the recorded number is defence in depth the name condition already
+covers, so no reachable case can distinguish it; and a `domName || recordedName` fallback in the
+re-sync is dead, because the condition guarantees the name is non-empty — and would be actively
+wrong if it were reachable. They are recorded so the next reader does not "fix" them into a
+difference.
+
+The clear in manual-entry mode also carries one **characterisation** assertion:
+`clearSelectedCompany` re-attaches selectWoo to `#billing_company_display` unconditionally, so a
+clear resurrects the picker the buyer had dismissed even with company search off. That is
+pre-existing — the `change` path has done it on every real country change in manual entry since
+long before this ticket — and the assertion records the behaviour rather than endorsing it.
+Fixing it changes a shared destructive function on that path too, which is the kind of stacking
+TWO-25333 was split out of TWO-24867 to avoid.
 
 A **known residual gap** is recorded in the code rather than fixed here: `customerCompany` is
 populated from the DOM on a timer, so `#company_id` can hold a real capture while that object

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -250,7 +250,7 @@ about the company-search helper, so the bootstrap is left to no-op.
   writes `#company_id` _after_ it renders.
 
 `country-switch.test.js` — what a billing-country change does, and what a fake one must not
-(TWO-24867, with TWO-25326):
+(TWO-24867, with TWO-25326 and TWO-25333):
 
 - **a `change` event that is not a country change is inert.** WooCommerce re-renders the
   billing fields on `updated_checkout`, and core's `address-i18n.js` re-triggers the country
@@ -272,9 +272,38 @@ about the company-search helper, so the bootstrap is left to no-op.
   adopted, not acted on; an empty reading — WooCommerce replacing `#billing_country` wholesale
   mid-re-render — is neither acted on _nor recorded_, so the switch that completes afterwards
   still acts; `updated_checkout` **records** a country that moved with no `change` event;
-  it records **without** clearing the capture, because those re-renders restore the country and
-  the company together and clearing would destroy what they just restored; and the recording
-  path cannot loop, even though a change reaching `setAddress()` triggers `update_checkout`.
+  it records **without** clearing a capture the same re-render is consistent with (see the
+  next bullet, which narrowed this); and the recording path cannot loop, even though a change
+  reaching `setAddress()` triggers `update_checkout`.
+- **a capture stranded in the wrong country is dropped** (TWO-25333), which is the one case
+  record-only got wrong. Recording without clearing is right when the re-render restores the
+  country and the company **together** — they agree by construction — but it left a company
+  captured under the country just left still captured, still approved, and paired with the new
+  billing country in the order payload with no consistency check anywhere between the two: the
+  buyer saw a green payment method and an opaque order-creation failure. `updated_checkout`
+  therefore clears the capture when the recorded country and the captured company's own
+  `country_prefix` actually **disagree**, and only then. Pinned in both directions, because the
+  discriminator is the whole fix: a company captured under the country just left is cleared and
+  `isReadyApprovalCheck()` comes back down with it (TWO-25326 §6 — the method is usable only for
+  a company captured _with_ an id); a matching pair is untouched, on either
+  `enable_address_lookup` setting. Three readings are deliberately not grounds to clear, each
+  with its own test — a company name with no organisation number (not a capture), an unknown
+  country on either side (`country_prefix` is null until the first capture, and an empty field
+  reading means mid-replacement), and the DOM already holding a **different** company from the
+  one recorded, which means the record is what is stale rather than the fields, so it is
+  re-synced to the DOM instead of destroying a company the re-render had just restored. The
+  comparison is case-insensitive, because `currentCountry()` upper-cases and `getCompanyData()`
+  reads the field raw — a false positive here is a destructive clear. This path can now reach
+  `clearSelectedCompany()`, so the loop it used to be immune to by construction
+  (clear → `setAddress()` → `update_checkout`) is pinned again for it.
+- **the capture country is pinned when the company is captured** (TWO-25333), at all three
+  capture sites: the picker's `select2:select` handler, a manually typed organisation number,
+  and the sole-trader setter — which does _not_ re-pin on the clearing call `setMode("business")`
+  makes with both arguments falsy. Without this the pair is assembled from two different
+  moments, the number at capture and `country_prefix` from whichever DOM re-read ran last, so a
+  country that moved with no `change` event _before_ the capture left the old country next to a
+  company from the new one — posted by `getApproval()` as a self-consistent pair, and read by
+  the discriminator above as a mismatch it would clear.
 - **the whole suite drives the real wiring**: a real `initialize(false)`, then
   `trigger("change")` on the field, so unwiring the delegated binding or moving the seed out
   of `initialize()`'s reach fails it. `afterEach` unbinds `document.body` — jsdom's document

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -347,18 +347,33 @@ holds a string; and **whitespace** in either direction — the record picks it u
 blur handler storing what the field holds, the DOM from a paste into `#company_id` or a trailing
 space typed into `#billing_company` with no blur behind it.
 
-Mutation state, stated as a scope rather than a bare count, because "exactly one survivor" was
-claimed here twice while the harness simply had not covered the rest: of 25 mutations aimed at
-this change, 22 are caught by the test named in the mutation, and **three survive, each documented
-in the code beside it** — `capturedCountry` left un-normalised (equivalent: country values are
-unpadded upper-case ISO strings on both sides, and the `.toUpperCase()` that does matter is
-tested); `country_prefix: country` swapped for a fresh `currentCountry()` read (indistinguishable
-today, written as the argument so the pairing is provably against the value the change was
-detected on); and a `domName || recordedName` fallback in the re-sync (dead, because the condition
-guarantees a non-empty name — and actively wrong if it were reachable, since it would pair one
-company's name with another's number). The blur handler storing raw is a fourth deliberate,
-documented choice rather than an oversight: normalising on the way in would change the
-organisation number the plugin posts on the order intent, which nothing here asked for.
+Mutation state is stated as a scope rather than a bare count, because a count was claimed here
+wrongly three times running — twice as "exactly one survivor", then as three — each time
+describing the harness rather than the code. Every mutation aimed at this change is either caught
+by the test named in the mutation, or is one of the following, each with its reason written into
+the code beside it:
+
+- `capturedCountry` left un-normalised — equivalent: country values are unpadded upper-case ISO
+  strings on both sides. The `.toUpperCase()` that _does_ matter, because two readers disagree
+  about it, is tested.
+- `country_prefix: country` swapped for a fresh `currentCountry()` read — indistinguishable
+  today; written as the argument so the pairing is provably against the value the change was
+  detected on.
+- `domName || recordedName` in the re-sync — dead, because the condition guarantees a non-empty
+  name, and actively wrong if it were reachable, since it would pair one company's name with
+  another's number.
+- `!country` in the early guard — unreachable from the only caller, because `countryDidChange`
+  already refuses an empty reading. Kept as the guard a second caller would need. Only the
+  captured side of "an unknown country on either side" is actually tested.
+- `this.customerCompany || {}` — equivalent: the property is an object from construction onward,
+  and `clearSelectedCompany` sets `{}` rather than null.
+- The blur handler storing the raw field value — a deliberate choice, not an oversight:
+  normalising on the way in would change the organisation number the plugin posts on the order
+  intent, which nothing here asked for.
+
+The re-sync branch's own stored values are a different matter and _are_ pinned: once the branch
+has decided the DOM holds a different company, what it stores is what `getApproval()` posts inside
+`buyer.company`, so padding there would reach the order intent verbatim.
 
 The both-mirrors rule holds on WooCommerce's own re-render paths for a concrete reason worth
 knowing: `#company_id` is a registered billing field (`$fields['billing']['company_id']` in

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -337,12 +337,27 @@ about the company-search helper, so the bootstrap is left to no-op.
   a value differing only by stray whitespace, and emptying a populated number (which is not a
   capture and must leave no witness claiming one).
 
-Two mutations in this area deliberately **survive**, and the reasons are written into the code
-next to them: normalising the recorded number is defence in depth the name condition already
-covers, so no reachable case can distinguish it; and a `domName || recordedName` fallback in the
-re-sync is dead, because the condition guarantees the name is non-empty — and would be actively
-wrong if it were reachable. They are recorded so the next reader does not "fix" them into a
-difference.
+Normalising the **recorded** values is load-bearing rather than defensive, and an earlier version
+of this note claimed otherwise. Two reachable ways the record diverges from the DOM by
+representation alone while the name has genuinely moved, each with its own test: the type, because
+`twoincSoleTrader.setCompany()` writes the organisation number straight out of parsed JSON so the
+record can hold a number where the field holds a string; and whitespace, which the manual blur
+handler produces itself by storing what the field holds. The blur handler storing raw is
+deliberate — normalising on the way in was written and then reverted, because no test could tell
+the difference and it would have changed the organisation number the plugin posts on the order
+intent, which nothing here asked for.
+
+Exactly **one** mutation in this area deliberately survives, and the reason is written into the
+code next to it: a `domName || recordedName` fallback in the re-sync is dead, because the
+condition guarantees the name is non-empty — and would be actively wrong if it were reachable,
+since it would pair one company's name with another's number. Recorded so the next reader does
+not "fix" it into a difference.
+
+The both-mirrors rule holds on WooCommerce's own re-render paths for a concrete reason worth
+knowing: `#company_id` is a registered billing field (`$fields['billing']['company_id']` in
+`WC_Twoinc_Checkout`), so it sits in the same billing fragment as `#billing_company` and every
+WC-driven re-render writes both from the same vintage. One mirror moving alone is therefore
+evidence of something that is not a re-render.
 
 The clear in manual-entry mode also carries one **characterisation** assertion:
 `clearSelectedCompany` re-attaches selectWoo to `#billing_company_display` unconditionally, so a

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -337,21 +337,28 @@ about the company-search helper, so the bootstrap is left to no-op.
   a value differing only by stray whitespace, and emptying a populated number (which is not a
   capture and must leave no witness claiming one).
 
-Normalising the **recorded** values is load-bearing rather than defensive, and an earlier version
-of this note claimed otherwise. Two reachable ways the record diverges from the DOM by
-representation alone while the name has genuinely moved, each with its own test: the type, because
-`twoincSoleTrader.setCompany()` writes the organisation number straight out of parsed JSON so the
-record can hold a number where the field holds a string; and whitespace, which the manual blur
-handler produces itself by storing what the field holds. The blur handler storing raw is
-deliberate — normalising on the way in was written and then reverted, because no test could tell
-the difference and it would have changed the organisation number the plugin posts on the order
-intent, which nothing here asked for.
+Normalising is load-bearing on **all four** compared values, not defensive, and two earlier
+versions of this note claimed otherwise — first that the recorded number's normaliser was
+unreachable, then that only the record side mattered. Each of the four now has its own test.
+Reachable ways one value diverges from its counterpart by representation alone while the other
+mirror has genuinely moved: the **type**, because `twoincSoleTrader.setCompany()` writes the
+organisation number straight out of parsed JSON so the record can hold a number where the field
+holds a string; and **whitespace** in either direction — the record picks it up from the manual
+blur handler storing what the field holds, the DOM from a paste into `#company_id` or a trailing
+space typed into `#billing_company` with no blur behind it.
 
-Exactly **one** mutation in this area deliberately survives, and the reason is written into the
-code next to it: a `domName || recordedName` fallback in the re-sync is dead, because the
-condition guarantees the name is non-empty — and would be actively wrong if it were reachable,
-since it would pair one company's name with another's number. Recorded so the next reader does
-not "fix" it into a difference.
+Mutation state, stated as a scope rather than a bare count, because "exactly one survivor" was
+claimed here twice while the harness simply had not covered the rest: of 25 mutations aimed at
+this change, 22 are caught by the test named in the mutation, and **three survive, each documented
+in the code beside it** — `capturedCountry` left un-normalised (equivalent: country values are
+unpadded upper-case ISO strings on both sides, and the `.toUpperCase()` that does matter is
+tested); `country_prefix: country` swapped for a fresh `currentCountry()` read (indistinguishable
+today, written as the argument so the pairing is provably against the value the change was
+detected on); and a `domName || recordedName` fallback in the re-sync (dead, because the condition
+guarantees a non-empty name — and actively wrong if it were reachable, since it would pair one
+company's name with another's number). The blur handler storing raw is a fourth deliberate,
+documented choice rather than an oversight: normalising on the way in would change the
+organisation number the plugin posts on the order intent, which nothing here asked for.
 
 The both-mirrors rule holds on WooCommerce's own re-render paths for a concrete reason worth
 knowing: `#company_id` is a registered billing field (`$fields['billing']['company_id']` in

--- a/tests/js/country-switch.test.js
+++ b/tests/js/country-switch.test.js
@@ -652,6 +652,25 @@ describe("billing country switch", () => {
       expect(ctx.Twoinc.getInstance().customerCompany.company_name).toBe("Ejemplo SL");
     });
 
+    test("the re-synced record holds trimmed values, which are what get posted", () => {
+      // Not the same assertion as "padding is not read as divergence" above.
+      // Once the branch HAS decided the DOM holds a different company, what it
+      // stores is what `getApproval()` posts inside `buyer.company` — so a
+      // padded field value would reach the order intent verbatim. The opposite
+      // direction from the blur handler's deliberate raw store, and unlike that
+      // one this is observable and therefore pinned.
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+
+      ctx.$("#billing_company").val("  Ejemplo SL  ");
+      ctx.$("#company_id").val("  B12345678  ");
+      moveCountrySilently("ES");
+
+      expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBe("B12345678");
+      expect(ctx.Twoinc.getInstance().customerCompany.company_name).toBe("Ejemplo SL");
+    });
+
     test("clears when only the NUMBER diverged — a keystroke, not a restore", () => {
       // Fail-closed, and the reason the discriminator needs both halves. A
       // buyer typing into #company_id without blurring diverges the number

--- a/tests/js/country-switch.test.js
+++ b/tests/js/country-switch.test.js
@@ -97,13 +97,17 @@ describe("billing country switch", () => {
    * @param {string} id
    * @returns {void}
    */
-  function captureCompany(name, id) {
+  function captureCompany(name, id, country) {
     ctx.$("#billing_company").val(name);
     ctx.$("#company_id").val(id);
     ctx.Twoinc.getInstance().customerCompany = {
       company_name: name,
       organization_number: id,
-      country_prefix: "GB"
+      // The country the company was captured UNDER, which is not necessarily
+      // the one in the field by the time a test asserts (TWO-25333). Defaults
+      // to the fixture's country so the callers that predate the parameter
+      // still describe a company captured under the country then selected.
+      country_prefix: country || "GB"
     };
   }
 
@@ -301,13 +305,20 @@ describe("billing country switch", () => {
       // re-render just put back — TWO-25326 again on a new trigger. Nothing
       // is thrown away without the buyer's gesture, and a `change` event is
       // the only signal of one this checkout has.
+      //
+      // The company is captured under ES, the country the re-render moves the
+      // field to, because "together" is the whole point: this fixture used to
+      // pair a GB company with a move to ES, which is not the restore case at
+      // all but the stale-pairing case TWO-25333 now clears. The assertion the
+      // test was written to make — a record-only path throws nothing away —
+      // needs a pair the re-render could actually have supplied.
       initializeCheckout();
-      captureCompany("Example Co", "123456789");
-
       ctx.$("#billing_country").val("ES");
+      captureCompany("Ejemplo SL", "B12345678", "ES");
+
       ctx.$(document.body).trigger("updated_checkout");
 
-      expect(capturedCompany()).toEqual({ name: "Example Co", id: "123456789" });
+      expect(capturedCompany()).toEqual({ name: "Ejemplo SL", id: "B12345678" });
     });
 
     test("the seed is taken AFTER the saved-input restore, not before", () => {
@@ -485,6 +496,332 @@ describe("billing country switch", () => {
       $country.html(restore).val("ES");
       fireCountryChange();
       expect(capturedCompany()).toEqual({ name: "", id: "" });
+    });
+  });
+
+  describe("a capture stranded in the wrong country (TWO-25333)", () => {
+    /**
+     * The four core billing address inputs `setAddress` writes. Needed by any
+     * test that lets the clear run with `enable_address_lookup` on, since
+     * `clearSelectedCompany` blanks them on that setting.
+     *
+     * @returns {void}
+     */
+    function addAddressFields() {
+      ctx
+        .$("form[name='checkout']")
+        .append(
+          [
+            "<input type='text' id='billing_address_1' value='' />",
+            "<input type='text' id='billing_address_2' value='' />",
+            "<input type='text' id='billing_city' value='' />",
+            "<input type='text' id='billing_postcode' value='' />"
+          ].join("\n")
+        );
+    }
+
+    /**
+     * Move the country with NO `change` event and let the re-render land —
+     * the path this whole block is about. WooCommerce writes
+     * #billing_country with `.val()` / `selectElem.value =` on a
+     * checkout_error re-render, a multi-step theme and a server-side session
+     * restore, and fires `updated_checkout` rather than `change`.
+     *
+     * @param {string} country
+     * @returns {void}
+     */
+    function moveCountrySilently(country) {
+      ctx.$("#billing_country").val(country);
+      ctx.$(document.body).trigger("updated_checkout");
+    }
+
+    test("clears a company captured under the country just left", () => {
+      // The defect. Nothing downstream catches this pair: getApproval() posts
+      // customerCompany carrying the OLD country_prefix next to the OLD
+      // organisation number, so the intent check sees a self-consistent pair
+      // and approves it, and the order payload pairs that company_id with the
+      // order's billing country with no check between the two. The buyer got a
+      // green payment method and an opaque order-creation failure.
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+
+      moveCountrySilently("ES");
+
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
+      expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBeFalsy();
+    });
+
+    test("the cleared capture leaves the payment method unusable again", () => {
+      // TWO-25326 §6: the method is selectable and usable only for a company
+      // captured WITH an id. `isReadyApprovalCheck` is the gate that decides
+      // whether an intent is even asked for, so it is what has to come back
+      // down — asserting the fields are empty would not prove the approval
+      // path noticed.
+      ctx.twoinc.enable_order_intent = "yes";
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+      // Everything else the gate needs, so that it is genuinely true BEFORE
+      // and the assertion after it is not passing for an unrelated reason.
+      ctx.Twoinc.getInstance().customerRepresentative = {
+        email: "buyer@example.test",
+        first_name: "Ex",
+        last_name: "Ample",
+        phone_number: "+441234567890"
+      };
+      expect(ctx.Twoinc.getInstance().isReadyApprovalCheck()).toBe(true);
+
+      moveCountrySilently("ES");
+
+      expect(ctx.Twoinc.getInstance().isReadyApprovalCheck()).toBe(false);
+    });
+
+    test("leaves the new country on customerCompany, not the cleared {}", () => {
+      // Same trap as on the `change` path: clearSelectedCompany() resets
+      // customerCompany wholesale and only re-reads it from the DOM three
+      // seconds later, so an assignment made before it is silently dropped and
+      // getDueInDays() — which early-returns without a country — is dead for
+      // that whole window.
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+
+      moveCountrySilently("ES");
+
+      expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("ES");
+    });
+
+    test("invalidates in-flight work for the company it just dropped", () => {
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+      const searchSeqBefore = ctx.helper.companySearchSeq;
+      const lookupSeqBefore = ctx.Twoinc.getInstance().addressLookupSeq;
+
+      moveCountrySilently("ES");
+
+      expect(ctx.helper.companySearchSeq).toBeGreaterThan(searchSeqBefore);
+      expect(ctx.Twoinc.getInstance().addressLookupSeq).toBeGreaterThan(lookupSeqBefore);
+    });
+
+    test("does NOT clear when the restore supplies country and company together", () => {
+      // The regression guard, and the reason this is a discriminator rather
+      // than a return to clearing on every country movement. This is the
+      // TWO-24867 / TWO-25326 case: the same re-render that moved the country
+      // also supplied the company, so the two agree and there is nothing
+      // stale. Reverting the discriminator to "always clear" fails here.
+      addAddressFields();
+      initializeCheckout();
+      ctx.$("#billing_country").val("ES");
+      captureCompany("Ejemplo SL", "B12345678", "ES");
+
+      ctx.$(document.body).trigger("updated_checkout");
+
+      expect(capturedCompany()).toEqual({ name: "Ejemplo SL", id: "B12345678" });
+      expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBe("B12345678");
+    });
+
+    test("does NOT clear when the re-render restored a DIFFERENT company too", () => {
+      // The second shape of "supplied together", and the one a naive
+      // discriminator gets wrong. `customerCompany` is refreshed from the DOM
+      // on a timer, so a re-render that swapped in another saved address —
+      // country AND company together, a different pair but a self-consistent
+      // one — arrives here with the PREVIOUS capture still in JS state. The
+      // record is what is stale, not the fields, and clearing would destroy
+      // the company the re-render had just restored.
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+
+      // The re-render's own doing: new country, new company, both in the DOM.
+      ctx.$("#billing_company").val("Ejemplo SL");
+      ctx.$("#company_id").val("B12345678");
+      moveCountrySilently("ES");
+
+      expect(capturedCompany()).toEqual({ name: "Ejemplo SL", id: "B12345678" });
+      // And the stale record is re-synced to the pair the DOM actually holds,
+      // rather than left describing a company that is no longer in the form.
+      expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBe("B12345678");
+      expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("ES");
+    });
+
+    test("does NOT clear a company name with no organisation number", () => {
+      // Not a capture (TWO-25326 §6), and nothing about a bare name is
+      // invalidated by a country change — the buyer typed it, and manual entry
+      // deliberately keeps it. Clearing here would delete their own input on a
+      // re-render they never asked for.
+      addAddressFields();
+      initializeCheckout();
+      ctx.$("#billing_company").val("Some Buyer Ltd");
+      ctx.Twoinc.getInstance().customerCompany = {
+        company_name: "Some Buyer Ltd",
+        organization_number: "",
+        country_prefix: "GB"
+      };
+
+      moveCountrySilently("ES");
+
+      expect(ctx.$("#billing_company").val()).toBe("Some Buyer Ltd");
+    });
+
+    test("does NOT clear when the captured country is unknown", () => {
+      // `country_prefix` is null until the first capture or DOM re-read. An
+      // unknown witness is not evidence of a mismatch, and treating it as one
+      // would clear on the first re-render of any checkout whose company came
+      // from somewhere that had not pinned a country yet.
+      addAddressFields();
+      initializeCheckout();
+      ctx.$("#billing_company").val("Example Co");
+      ctx.$("#company_id").val("123456789");
+      ctx.Twoinc.getInstance().customerCompany = {
+        company_name: "Example Co",
+        organization_number: "123456789",
+        country_prefix: null
+      };
+
+      moveCountrySilently("ES");
+
+      expect(capturedCompany()).toEqual({ name: "Example Co", id: "123456789" });
+    });
+
+    test("compares the two countries case-insensitively", () => {
+      // The two sides are written by different readers: currentCountry()
+      // upper-cases, getCompanyData() reads #billing_country raw. A
+      // case-sensitive comparison would read `es` vs `ES` as a mismatch and
+      // clear a perfectly good capture — a false positive here is destructive,
+      // which is why the normalisation is pinned rather than left to the
+      // observation that WooCommerce's values happen to be upper-case.
+      addAddressFields();
+      initializeCheckout();
+      ctx.$("#billing_country").val("ES");
+      captureCompany("Ejemplo SL", "B12345678", "es");
+
+      ctx.$(document.body).trigger("updated_checkout");
+
+      expect(capturedCompany()).toEqual({ name: "Ejemplo SL", id: "B12345678" });
+    });
+
+    test("clears with address lookup OFF as well as on", () => {
+      // Neither behaviour may depend on `enable_address_lookup`: it decides
+      // whether clearSelectedCompany also blanks the address fields, and the
+      // recursion the clear can start (setAddress -> update_checkout) only
+      // exists on the `yes` leg — so a fix that worked on one setting and not
+      // the other would be invisible on half the shops.
+      ctx.twoinc.enable_address_lookup = "no";
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+
+      moveCountrySilently("ES");
+
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
+    });
+
+    test("does NOT clear the matching pair with address lookup OFF either", () => {
+      ctx.twoinc.enable_address_lookup = "no";
+      initializeCheckout();
+      ctx.$("#billing_country").val("ES");
+      captureCompany("Ejemplo SL", "B12345678", "ES");
+
+      ctx.$(document.body).trigger("updated_checkout");
+
+      expect(capturedCompany()).toEqual({ name: "Ejemplo SL", id: "B12345678" });
+    });
+
+    test("the clear terminates instead of looping", () => {
+      // The loop the record-only design used to be immune to by construction,
+      // and is not any more: this path now CAN reach clearSelectedCompany, so
+      // `updated_checkout` -> clear -> setAddress -> `update_checkout` ->
+      // WooCommerce refreshes -> `updated_checkout` is live again. What stops
+      // it is that the country was recorded on the way through and the capture
+      // is gone by the second pass, so neither the change test nor the
+      // mismatch test is true a second time. Behind `enable_address_lookup`,
+      // so a regression would only show on shops that turn it on.
+      ctx.twoinc.enable_address_lookup = "yes";
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+      // Stand in for WooCommerce core's checkout.js, which is what turns a
+      // requested `update_checkout` into a completed `updated_checkout`.
+      let passes = 0;
+      ctx.$(document.body).on("update_checkout", function () {
+        passes += 1;
+        if (passes > 20) throw new Error("update_checkout did not settle");
+        ctx.$(document.body).trigger("updated_checkout");
+      });
+
+      moveCountrySilently("ES");
+
+      expect(passes).toBeLessThan(5);
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
+    });
+
+    test("a second re-render after the clear is inert", () => {
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+
+      moveCountrySilently("ES");
+      // A fresh capture under the country now selected must survive the next
+      // re-render — the clear must not leave the tracker or the witness in a
+      // state that condemns everything captured afterwards.
+      captureCompany("Ejemplo SL", "B12345678", "ES");
+      ctx.$(document.body).trigger("updated_checkout");
+
+      expect(capturedCompany()).toEqual({ name: "Ejemplo SL", id: "B12345678" });
+    });
+  });
+
+  describe("the capture country is pinned when the company is captured (TWO-25333)", () => {
+    // Without this the pair is assembled from two different moments: the
+    // organisation number is written at capture, while `country_prefix` was
+    // last written by whichever DOM re-read ran most recently. A country that
+    // moved with no `change` event BEFORE the capture therefore left the old
+    // country next to a company from the new one — which getApproval() posts
+    // as a self-consistent pair, and which the discriminator above would read
+    // as a mismatch and clear, destroying a capture that was never stale.
+
+    test("the picker's select handler pins the country it picked under", () => {
+      initializeCheckout();
+      // A silent country move that the record-only path has not seen yet, so
+      // customerCompany.country_prefix still holds the country before it.
+      ctx.Twoinc.getInstance().customerCompany.country_prefix = "GB";
+      ctx.$("#billing_country").val("ES");
+
+      ctx.$("#billing_company_display").trigger({
+        type: "select2:select",
+        params: { data: { id: "Ejemplo SL", company_id: "B12345678" } }
+      });
+
+      expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("ES");
+    });
+
+    test("a manually typed organisation number pins the country too", () => {
+      initializeCheckout();
+      ctx.Twoinc.getInstance().customerCompany.country_prefix = "GB";
+      ctx.$("#billing_country").val("ES");
+
+      ctx.$("#company_id").val("B12345678").trigger("blur");
+
+      expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBe("B12345678");
+      expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("ES");
+    });
+
+    test("a sole-trader capture pins the country, and clearing does not", () => {
+      initializeCheckout();
+      ctx.Twoinc.getInstance().customerCompany.country_prefix = "GB";
+      ctx.$("#billing_country").val("ES");
+
+      ctx.soleTrader.setCompany("B12345678", "Ejemplo SL");
+      expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("ES");
+
+      // setMode("business") reaches setCompany with both arguments falsy to
+      // CLEAR. There is no capture then for a country to belong to, so this
+      // must not re-pin one — a witness written for an empty capture is the
+      // kind of thing that reads as authoritative later.
+      ctx.$("#billing_country").val("GB");
+      ctx.soleTrader.setCompany("", "");
+      expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("ES");
     });
   });
 

--- a/tests/js/country-switch.test.js
+++ b/tests/js/country-switch.test.js
@@ -552,12 +552,21 @@ describe("billing country switch", () => {
       expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBeFalsy();
     });
 
-    test("the cleared capture leaves the payment method unusable again", () => {
-      // TWO-25326 §6: the method is selectable and usable only for a company
-      // captured WITH an id. `isReadyApprovalCheck` is the gate that decides
-      // whether an intent is even asked for, so it is what has to come back
-      // down — asserting the fields are empty would not prove the approval
-      // path noticed.
+    test("the cleared capture takes the approval gate back down", () => {
+      // Named for what it proves, which is narrower than "the payment method
+      // becomes unusable". `isReadyApprovalCheck` is the gate deciding whether
+      // an intent is asked for at all, so it coming back down is what stops a
+      // fresh approval being sought for the dropped pair — and it is a real
+      // assertion the emptied fields would not give us.
+      //
+      // What it does NOT prove: the gateway radio stays `checked` and
+      // `isTwoincApproved` stays true after this, because nothing in the file
+      // deselects the method and `isTwoincApproved` is written but never read.
+      // So a buyer who had already been approved keeps a selected Two method
+      // over an emptied company until the next intent pass. Enforcing §6 by
+      // deselecting is the DEFERRED half of that design and belongs to its own
+      // ticket, not to this one — recorded here so the gap is not mistaken for
+      // something this test covers.
       ctx.twoinc.enable_order_intent = "yes";
       addAddressFields();
       initializeCheckout();
@@ -592,18 +601,12 @@ describe("billing country switch", () => {
       expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("ES");
     });
 
-    test("invalidates in-flight work for the company it just dropped", () => {
-      addAddressFields();
-      initializeCheckout();
-      captureCompany("Example Co", "123456789", "GB");
-      const searchSeqBefore = ctx.helper.companySearchSeq;
-      const lookupSeqBefore = ctx.Twoinc.getInstance().addressLookupSeq;
-
-      moveCountrySilently("ES");
-
-      expect(ctx.helper.companySearchSeq).toBeGreaterThan(searchSeqBefore);
-      expect(ctx.Twoinc.getInstance().addressLookupSeq).toBeGreaterThan(lookupSeqBefore);
-    });
+    // No test here for the supersession counters being bumped. They are bumped
+    // by the caller, unconditionally on the country having moved, which is
+    // pre-existing TWO-24867 behaviour already pinned by "updated_checkout
+    // invalidates in-flight work for the outgoing country" above. A copy inside
+    // this block passed with this whole feature reverted, so it asserted
+    // nothing about it.
 
     test("does NOT clear when the restore supplies country and company together", () => {
       // The regression guard, and the reason this is a discriminator rather
@@ -644,6 +647,7 @@ describe("billing country switch", () => {
       // rather than left describing a company that is no longer in the form.
       expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBe("B12345678");
       expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("ES");
+      expect(ctx.Twoinc.getInstance().customerCompany.company_name).toBe("Ejemplo SL");
     });
 
     test("does NOT clear a company name with no organisation number", () => {
@@ -756,16 +760,52 @@ describe("billing country switch", () => {
       expect(capturedCompany()).toEqual({ name: "", id: "" });
     });
 
-    test("a second re-render after the clear is inert", () => {
+    test("a clear does not condemn what is captured after it", () => {
       addAddressFields();
       initializeCheckout();
       captureCompany("Example Co", "123456789", "GB");
 
       moveCountrySilently("ES");
+      // Asserted mid-test on purpose. Without this the test passes with the
+      // whole feature reverted: `captureCompany` overwrites `customerCompany`
+      // wholesale, so with nothing cleared the only state it could witness is
+      // `lastObservedCountry`, which is already ES either way.
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
+
       // A fresh capture under the country now selected must survive the next
       // re-render — the clear must not leave the tracker or the witness in a
       // state that condemns everything captured afterwards.
       captureCompany("Ejemplo SL", "B12345678", "ES");
+      ctx.$(document.body).trigger("updated_checkout");
+
+      expect(capturedCompany()).toEqual({ name: "Ejemplo SL", id: "B12345678" });
+    });
+
+    test("clears with company search OFF (manual entry) as well as on", () => {
+      // The manual-entry leg behaves differently inside
+      // `clearSelectedCompany`: it deliberately KEEPS the buyer's typed
+      // `#billing_company` (it is their own input, not a picked company) while
+      // still blanking `#company_id`. So the assertion is not the same one the
+      // search-mode tests make, and running only those left this leg unproven.
+      ctx.twoinc.enable_company_search = "no";
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+
+      moveCountrySilently("ES");
+
+      expect(ctx.$("#company_id").val()).toBe("");
+      expect(ctx.$("#billing_company").val()).toBe("Example Co");
+      expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBeFalsy();
+    });
+
+    test("does NOT clear the matching pair with company search OFF either", () => {
+      ctx.twoinc.enable_company_search = "no";
+      addAddressFields();
+      initializeCheckout();
+      ctx.$("#billing_country").val("ES");
+      captureCompany("Ejemplo SL", "B12345678", "ES");
+
       ctx.$(document.body).trigger("updated_checkout");
 
       expect(capturedCompany()).toEqual({ name: "Ejemplo SL", id: "B12345678" });
@@ -805,6 +845,25 @@ describe("billing country switch", () => {
 
       expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBe("B12345678");
       expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("ES");
+    });
+
+    test("tabbing THROUGH an untouched number does not launder a stale pair", () => {
+      // This handler is bound to `blur`, not `change`, so it also fires when
+      // focus merely passes through the field. Re-pinning there would rewrite
+      // the witness to the country the form has since moved to while the number
+      // is still the previous country's company — a stale pair made to look
+      // consistent, which `clearCompanyIfCountryStale` could then never fire on.
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+      // A silent country move the record-only path has not seen yet.
+      ctx.$("#billing_country").val("ES");
+
+      ctx.$("#company_id").trigger("blur");
+
+      expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("GB");
+      // And the stale pair is therefore still catchable on the next re-render.
+      ctx.$(document.body).trigger("updated_checkout");
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
     });
 
     test("a sole-trader capture pins the country, and clearing does not", () => {

--- a/tests/js/country-switch.test.js
+++ b/tests/js/country-switch.test.js
@@ -762,6 +762,38 @@ describe("billing country switch", () => {
       expect(capturedCompany()).toEqual({ name: "", id: "" });
     });
 
+    test("a whitespace-padded DOM number is not read as diverged", () => {
+      // The DOM side of the same normalisation, and it needed its own test for
+      // the same reason the record side did: the reasoning applies identically
+      // to both, so testing only one left half the guard resting on an
+      // assumption. A buyer pasting a padded number into #company_id without
+      // blurring leaves the record holding the picker's clean value, so an
+      // un-normalised compare reads it as a different company — and with the
+      // name moved by a re-render, launders the GB capture into an ES pair.
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+
+      ctx.$("#company_id").val("  123456789  ");
+      ctx.$("#billing_company").val("Other Saved Ltd");
+      moveCountrySilently("ES");
+
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
+    });
+
+    test("a whitespace-padded DOM name is not read as diverged", () => {
+      // The mirror of the above, on the name half.
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+
+      ctx.$("#billing_company").val("  Example Co  ");
+      ctx.$("#company_id").val("B12345678");
+      moveCountrySilently("ES");
+
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
+    });
+
     test("a numeric organisation number is not read as a different company", () => {
       // `organization_number` is seeded null and written from parsed JSON by
       // the sole-trader prefill, so it is not guaranteed to be a string while

--- a/tests/js/country-switch.test.js
+++ b/tests/js/country-switch.test.js
@@ -709,6 +709,59 @@ describe("billing country switch", () => {
       expect(ctx.Twoinc.getInstance().isReadyApprovalCheck()).toBe(false);
     });
 
+    test("a sole-trader numeric number survives a re-render of the NAME alone", () => {
+      // The reachable chain the recorded-number normalisation actually guards,
+      // driven through the real setter rather than by poking the record.
+      // `setCompany` writes the organisation number straight out of parsed
+      // JSON, so the record holds a NUMBER while `#company_id` holds a string.
+      // Then a re-render rewrites WooCommerce's own `#billing_company` and
+      // leaves the plugin's `#company_id` untouched — the mirror asymmetry this
+      // whole ticket is about. Un-normalised, the number reads as diverged, the
+      // name genuinely has diverged, and the re-sync branch launders a
+      // GB-captured number into a self-consistent ES pair with nothing left
+      // downstream to catch it.
+      addAddressFields();
+      initializeCheckout();
+      ctx.soleTrader.setCompany(123456789, "Sole Trader Co");
+      expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBe(123456789);
+
+      ctx.$("#billing_company").val("Other Saved Ltd");
+      moveCountrySilently("ES");
+
+      expect(ctx.$("#company_id").val()).toBe("");
+      expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBeFalsy();
+    });
+
+    test("a whitespace-padded recorded number is not read as diverged", () => {
+      // The other representation-only divergence, and one this file produces
+      // itself. Same shape as the test above: the name has genuinely moved, so
+      // only the number comparison stands between a correct clear and a
+      // laundered re-sync.
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+      ctx.Twoinc.getInstance().customerCompany.organization_number = "  123456789  ";
+
+      ctx.$("#billing_company").val("Other Saved Ltd");
+      moveCountrySilently("ES");
+
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
+    });
+
+    test("a whitespace-padded recorded NAME is not read as diverged either", () => {
+      // The recorded name goes through the same normaliser, for the same
+      // reason and with the same consequence if it does not.
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+      ctx.Twoinc.getInstance().customerCompany.company_name = "  Example Co  ";
+
+      ctx.$("#company_id").val("B12345678");
+      moveCountrySilently("ES");
+
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
+    });
+
     test("a numeric organisation number is not read as a different company", () => {
       // `organization_number` is seeded null and written from parsed JSON by
       // the sole-trader prefill, so it is not guaranteed to be a string while
@@ -1001,11 +1054,19 @@ describe("billing country switch", () => {
       expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("GB");
     });
 
-    test("a blur on an empty untouched field pins nothing", () => {
+    test("a blur on an empty untouched field pins nothing (conjunction)", () => {
       // "" !== null counts as movement without normalisation, so a fresh
       // checkout's first stray blur pinned a country onto a capture that does
       // not exist. Inert downstream, but a witness that looks authoritative and
       // is not is how this class of bug arrives.
+      //
+      // Labelled a CONJUNCTION test on purpose: no single revert breaks it, and
+      // it should not be read as independent coverage of either guard.
+      // Un-normalising `previousNumber` alone is still stopped by the emptiness
+      // check, and dropping the emptiness check alone is still stopped by
+      // `numberMoved` being false. The two tests above cover each guard on its
+      // own; this one covers them holding together on the path a real page
+      // takes first.
       initializeCheckout();
       ctx.$("#billing_country").val("ES");
 

--- a/tests/js/country-switch.test.js
+++ b/tests/js/country-switch.test.js
@@ -637,7 +637,9 @@ describe("billing country switch", () => {
       initializeCheckout();
       captureCompany("Example Co", "123456789", "GB");
 
-      // The re-render's own doing: new country, new company, both in the DOM.
+      // The re-render's own doing: new country, new company, BOTH mirrors in
+      // the DOM. Both halves matter — see the two tests below, where only one
+      // of them moved.
       ctx.$("#billing_company").val("Ejemplo SL");
       ctx.$("#company_id").val("B12345678");
       moveCountrySilently("ES");
@@ -648,6 +650,80 @@ describe("billing country switch", () => {
       expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBe("B12345678");
       expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("ES");
       expect(ctx.Twoinc.getInstance().customerCompany.company_name).toBe("Ejemplo SL");
+    });
+
+    test("clears when only the NUMBER diverged — a keystroke, not a restore", () => {
+      // Fail-closed, and the reason the discriminator needs both halves. A
+      // buyer typing into #company_id without blurring diverges the number
+      // exactly as a restore does; trusting that pinned the new country onto a
+      // number no capture path had witnessed, next to the PREVIOUS company's
+      // name — a two-moment pair made to look self-consistent, which is the
+      // defect this whole function exists to catch. A restore writes both
+      // mirrors; a keystroke writes one.
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+
+      ctx.$("#company_id").val("999999999");
+      moveCountrySilently("ES");
+
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
+      expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBeFalsy();
+    });
+
+    test("clears when only the NAME diverged — the mirror of the case above", () => {
+      // The other half of "both mirrors must have moved". A name that changed
+      // under an unchanged number is not a restored company either; treating it
+      // as one would pin the new country onto the number still sitting there
+      // from the previous country's capture.
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+
+      ctx.$("#billing_company").val("Ejemplo SL");
+      moveCountrySilently("ES");
+
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
+    });
+
+    test("clears when the number diverged but #billing_company reads empty", () => {
+      // The other fail-closed leg, and the one with the worst alternative. Both
+      // ways of trusting a nameless DOM pair are traps: taking the name from
+      // the record pairs company A's name with company B's number, and writing
+      // the empty name through leaves isReadyApprovalCheck() refusing forever —
+      // this branch arms no deferred re-read, so the next re-render would see a
+      // self-consistent pair, never fire again, and the payment method would be
+      // stuck unusable with no way back. Clearing is recoverable; that is not.
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+
+      ctx.$("#billing_company").val("");
+      ctx.$("#company_id").val("B12345678");
+      moveCountrySilently("ES");
+
+      expect(ctx.$("#company_id").val()).toBe("");
+      expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBeFalsy();
+      // And the approval gate is down rather than stuck refusing on an empty
+      // name it can never be rid of.
+      expect(ctx.Twoinc.getInstance().isReadyApprovalCheck()).toBe(false);
+    });
+
+    test("a numeric organisation number is not read as a different company", () => {
+      // `organization_number` is seeded null and written from parsed JSON by
+      // the sole-trader prefill, so it is not guaranteed to be a string while
+      // `.val()` always is. Un-normalised, `123456789 !== "123456789"` is true
+      // and the DOM-differs branch would fire on a capture that had not moved
+      // at all — trusting the fields and pinning the NEW country onto the same
+      // old company, which is a laundered stale pair rather than a clear.
+      addAddressFields();
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+      ctx.Twoinc.getInstance().customerCompany.organization_number = 123456789;
+
+      moveCountrySilently("ES");
+
+      expect(capturedCompany()).toEqual({ name: "", id: "" });
     });
 
     test("does NOT clear a company name with no organisation number", () => {
@@ -797,6 +873,18 @@ describe("billing country switch", () => {
       expect(ctx.$("#company_id").val()).toBe("");
       expect(ctx.$("#billing_company").val()).toBe("Example Co");
       expect(ctx.Twoinc.getInstance().customerCompany.organization_number).toBeFalsy();
+
+      // CHARACTERISATION, not endorsement. `clearSelectedCompany` re-attaches
+      // selectWoo to #billing_company_display unconditionally, so a clear in
+      // manual-entry mode resurrects the picker the buyer had dismissed even
+      // with company search off. That is PRE-EXISTING — the `change` path has
+      // called this on every real country change in manual entry since long
+      // before this ticket — and fixing it means changing a shared destructive
+      // function's behaviour on that path too, which is exactly the kind of
+      // stacking TWO-25333 was split out of TWO-24867 to avoid. Pinned here so
+      // the behaviour is recorded and a later fix has something to flip, not
+      // because it is right.
+      expect(ctx.$("#billing_company_display").data("select2")).toBeTruthy();
     });
 
     test("does NOT clear the matching pair with company search OFF either", () => {
@@ -861,9 +949,69 @@ describe("billing country switch", () => {
       ctx.$("#company_id").trigger("blur");
 
       expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("GB");
-      // And the stale pair is therefore still catchable on the next re-render.
-      ctx.$(document.body).trigger("updated_checkout");
-      expect(capturedCompany()).toEqual({ name: "", id: "" });
+
+      // Positive control, in the same fixture. Without it this test also passes
+      // when the whole `company_id` blur branch is dead, so it could not tell
+      // "the guard works" from "the handler never ran".
+      ctx.$("#company_id").val("B12345678").trigger("blur");
+      expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("ES");
+    });
+
+    test("a numeric recorded number does not read as movement on blur", () => {
+      // Same normalisation hazard as in the discriminator, at the other end: an
+      // `organization_number` that arrived as a number (the sole-trader prefill
+      // writes parsed JSON) compared raw against `.val()`'s string counts as
+      // movement, and re-pins the country on a blur that changed nothing.
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+      ctx.Twoinc.getInstance().customerCompany.organization_number = 123456789;
+      ctx.$("#billing_country").val("ES");
+
+      ctx.$("#company_id").trigger("blur");
+
+      expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("GB");
+    });
+
+    test("EMPTYING a populated number pins nothing", () => {
+      // The only case the emptiness half of the guard is reachable in:
+      // `numberMoved` alone already excludes a blur that changed nothing, so
+      // this is what distinguishes "pin when a number was entered" from "pin
+      // whenever the field moved". Clearing the number is not a capture, so it
+      // must not leave a witness behind claiming one was made under ES.
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+      ctx.$("#billing_country").val("ES");
+
+      ctx.$("#company_id").val("").trigger("blur");
+
+      expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("GB");
+    });
+
+    test("re-blurring the same number with stray whitespace is not movement", () => {
+      // `.val()` hands back exactly what is in the field, so a pasted value can
+      // differ from the recorded one by padding alone. Compared untrimmed that
+      // counts as movement and re-pins the country on a number that did not
+      // change — the laundering path again, through whitespace this time.
+      initializeCheckout();
+      captureCompany("Example Co", "123456789", "GB");
+      ctx.$("#billing_country").val("ES");
+
+      ctx.$("#company_id").val("  123456789  ").trigger("blur");
+
+      expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBe("GB");
+    });
+
+    test("a blur on an empty untouched field pins nothing", () => {
+      // "" !== null counts as movement without normalisation, so a fresh
+      // checkout's first stray blur pinned a country onto a capture that does
+      // not exist. Inert downstream, but a witness that looks authoritative and
+      // is not is how this class of bug arrives.
+      initializeCheckout();
+      ctx.$("#billing_country").val("ES");
+
+      ctx.$("#company_id").trigger("blur");
+
+      expect(ctx.Twoinc.getInstance().customerCompany.country_prefix).toBeFalsy();
     });
 
     test("a sole-trader capture pins the country, and clearing does not", () => {


### PR DESCRIPTION
## The gap

PR #430 (TWO-24867) made `onUpdatedCheckout` **record** a billing country that moved with no `change` event, and deliberately **not** clear the captured company — right for the case it was made for, because a `checkout_error` re-render, a multi-step theme or a server-side session restore supplies the country and the company *together*, and clearing there destroys what the same re-render just put back.

It left one case wrong. When the country really did move to something the captured company does not belong to, that company survived and nothing downstream caught it:

- `getApproval()` posts `customerCompany` carrying the **old** `country_prefix` next to the **old** organisation number, so the pair is internally consistent and the intent check approves it. The buyer sees a green payment method.
- The order payload pairs that `company_id` with the **order's** billing country, with no consistency check between the two.

So the mismatch was not caught at checkout. It reached order creation and came back as an opaque failure the buyer could not act on and the merchant could not diagnose from the storefront.

## The fix

Discriminate, rather than choosing between "always clear" and "never clear". On the record-only path, clear the capture **only when the recorded country and the captured company's own `country_prefix` actually disagree**.

This is specifically not a return of the TWO-25326 defect: in the restore-together case those two values agree by construction, because the same re-render supplied both, so the guard stays silent exactly where clearing would be destructive and fires only where the capture is genuinely stale. When a restore has a genuine mismatch — a stored company from a different country — clearing it is the correct behaviour, not a regression.

Three readings are deliberately **not** grounds to clear, each with its own test:

- **A company name with no organisation number.** Not a capture (TWO-25326 §6: the method is usable only for a company captured *with* an id), and nothing about a bare name is invalidated by a country change — the buyer typed it.
- **An unknown country on either side.** `country_prefix` is null until the first capture, and an empty field reading means the field was mid-replacement. Same rule the address-lookup guard and `countryDidChange` already apply.
- **The DOM already holding a *different* company from the one recorded.** `customerCompany` is refreshed from the DOM on a timer, so a re-render that swapped in another saved address — country *and* company together, a different pair but a self-consistent one — arrives with the previous capture still in JS state. There the record is stale rather than the fields, so it is re-synced to the DOM instead of destroying a company the re-render had just restored.

The comparison is case-insensitive, because the two sides are written by different readers: `currentCountry()` upper-cases and `getCompanyData()` reads the field raw (the inconsistency flagged in a comment on #430 and still not swept up). A false positive here is a destructive clear, so that is guarded rather than left to the observation that WooCommerce's values happen to be upper-case.

## Making the witness reliable

The ticket asked whether `country_prefix` is a reliable enough witness on every path. It was not, so this also **pins the capture country at all three capture sites**: the picker's `select2:select` handler, a manually typed organisation number, and the sole-trader setter (not on the clearing call `setMode("business")` makes with both arguments falsy).

Without that, the pair is assembled from two different moments — the number at capture, `country_prefix` from whichever DOM re-read ran last — so a country that moved with no `change` event *before* the capture left the old country next to a company from the new one. That both mis-posts the country on the intent and hands the discriminator a witness that can produce a false positive. Not scope creep: the discriminator is unsound without it.

## Verification

- **Unit: 283/283 pass** (`npm run test:js`, 8 suites), 41 in `country-switch.test.js` — 16 of them new.
- **Mutation-checked, 10 mutations, 0 survivors**, each caught by the intended test. Both directions the ticket demands are caught by disjoint sets: reverting the discriminator fails the stale-capture tests, widening it to "always clear" fails `updated_checkout records WITHOUT clearing the captured company`, `does NOT clear when the restore supplies country and company together`, `does NOT clear when the captured country is unknown` and both address-lookup variants.
- Also mutation-covered: the case normalisation, the DOM-differs guard, the no-capture guard, the post-clear country assignment, and each of the three capture-site pins (including making the sole-trader pin unconditional).
- Neither behaviour depends on `enable_address_lookup` — pinned on both settings, and the clear→`setAddress()`→`update_checkout` loop is pinned again for this path, which can now reach `clearSelectedCompany()`.
- **Not** browser-verified. The Chrome bridge is disconnected (checked, returns no connected extension instance), so this is unit and mutation evidence only.

## Note on a line removed rather than kept

A defensive supersession bump was written into the new helper and then removed: the only caller already bumps both counters unconditionally before reaching it, so the repeat changed nothing observable and no test could hold it in place. An untestable line that reads as the guarantee is worse than the guarantee living plainly at the call site.

## Docs

`tests/js/README.md` updated — the bullet stating that `updated_checkout` records "without clearing the capture" described behaviour this PR narrows.

Closes TWO-25333.
