### PR TITLE
fix(checkout): run the deferred company-search pass against the instance (TWO-25337)

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -3612,9 +3612,92 @@ class Twoinc {
       twoincSelectWooHelper.waitToFocus("billing_country");
     });
 
-    // Enable company search
+    // Enable company search, then again on a delay to catch a billing fragment
+    // that WooCommerce had not rendered yet when initialize() ran. This retry is
+    // the only one this code owns: `updated_checkout` re-syncs plenty of other
+    // state but does not re-attach the picker itself. The other callers of
+    // enableCompanySearch are the manual-entry exit and the sole-trader mode
+    // switch — so a checkout whose deferred pass misses can still be recovered
+    // by going through one of those, but nothing here is aiming for that, and it
+    // is not a path to rely on. Treat this timer as the one that has to work.
+    //
+    // Wrapped rather than passed by reference (TWO-25337). `setTimeout` invokes
+    // a bare method reference with the GLOBAL as its receiver: the timer steps
+    // supply `window` as the callback's this-value, and a strict-mode class body
+    // does not change that, because the global is only substituted for a
+    // null/undefined receiver in sloppy mode and here a receiver was passed. So
+    // `this` inside enableCompanySearch was `window`, and the deferred pass
+    // wrote its `billingCompanySelect` onto `window` rather than onto this
+    // instance.
+    //
+    // That did NOT throw and did not break the retry: nothing outside
+    // enableCompanySearch reads `billingCompanySelect`, so the widget still
+    // attached, and every other lookup in there goes through the DOM or
+    // `Twoinc.getInstance()`. What it left behind was a live selectWoo object on
+    // `window`, plus an instance property still holding whatever the
+    // synchronous pass wrote. Note what that value is, because it is NOT null:
+    // `.selectWoo()` on an empty jQuery set returns that same empty set. So in
+    // the late-render case this timer exists for, the property held a truthy
+    // empty set — a widget-shaped object wrapping no element, which is worse
+    // than null for anyone testing it for presence. (`null` survives only when
+    // company search is off, where the early return sits above the assignment.)
+    // The first reader of `this.billingCompanySelect` after a deferred
+    // re-attach would get that stale value, which is the trap
+    // `clearSelectedCompany` already avoids by looking the widget up from the
+    // DOM instead.
+    //
+    // Verified in real Chromium rather than reasoned about: the receiver is
+    // `window`, the assignment succeeds, and the console stays clean. Under
+    // Jest's fake timers the same call throws instead, because Sinon invokes
+    // the callback with `null` rather than the global — so the suite sees a
+    // TypeError that no browser ever produces. Do not restate that TypeError as
+    // production behaviour; it is a test-harness artefact.
+    //
+    // NOT fixed here, and not caused here: the deferred re-run leaves the
+    // picker's own `select2:select` / `select2:open` handlers DUPLICATED. Those
+    // are bound unnamespaced with no preceding `.off()`, and selectWoo's re-init
+    // destroys the previous instance with `.off(".select2")`, which cannot match
+    // them — so after the retry a single pick runs the whole select body twice.
+    //
+    // What that costs, per handler, neither overstated nor waved away. The
+    // `select2:select` copy is the one that costs anything.
+    //
+    // From the duplicated `select2:select`: `renderCompanySummary()` and
+    // `togglePaySubtitleDesc()` genuinely run twice, and `addressLookup()` does
+    // too when address lookup is enabled. The DOM and `customerCompany` writes
+    // are idempotent — same data both times. `getApproval()` costs nothing: the
+    // second entry finds `orderIntentCheck.interval` already set, flags
+    // `pendingCheck` and returns, and that flag cannot buy a later extra round
+    // either, because `pendingCheck` is only ever set inside that same guard and
+    // every site that nulls `interval` clears it in the same block — so the 3s
+    // poller only sees it set while the interval is still running, and the call
+    // it makes re-enters the guard and returns. The duplicate is simply dropped.
+    //
+    // From the duplicated `select2:open`: very little, and specifically NOT a
+    // pair of racing focus pollers. `addSelectWooFocusFixHandler` is idempotent
+    // (it guards on its own `two-focused-handler` attribute), and while
+    // `waitToFocus` has no dedupe, the arguments this site passes it —
+    // `("billing_company_display", null, null)` — defeat its own defaults: it
+    // guards them with `isNaN`, and `isNaN(null)` is false, so `hitsRequired`
+    // stays null and `attemptsLeft` becomes `null * 8`, i.e. 0. The interval
+    // clears itself on its first tick. Duplicating it therefore costs two
+    // single-shot focus nudges, each already a no-op when the input is focused.
+    //
+    // One stale figure to distrust while reading around this:
+    // `focusStillWithinCompanySearch`'s docblock says the poll can nudge "up to
+    // ~4.8s from `select2:open`", which is 2 x 8 x 300ms — the numbers you get by
+    // assuming those `isNaN` defaults apply. They do not apply to this call site,
+    // so that bound does not describe it. Left as-is rather than corrected here
+    // because it belongs with the `waitToFocus` work in TWO-25338, but do not
+    // take it as evidence of a focus race on the company picker.
+    //
+    // Pre-existing and unchanged by this commit: the retry ran on a live widget
+    // before it too, only storing its reference elsewhere. Its own ticket,
+    // TWO-25338.
     this.enableCompanySearch();
-    setTimeout(this.enableCompanySearch, 800);
+    setTimeout(function () {
+      self.enableCompanySearch();
+    }, 800);
 
     // Disable or enable actions based on the account type
     $body.on("updated_checkout", Twoinc.getInstance().onUpdatedCheckout);

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -396,11 +396,41 @@ still holds nulls — during `initialize()`'s deferred seed, and for three secon
 deferred re-read then re-pairs the old country's company with the new country via
 `getCompanyData()`, which reads `#billing_country` live and so un-pins the witness. Closing it
 means stopping the DOM re-reads from overwriting a pinned `country_prefix`, which changes
-`getCompanyData()`'s contract for its other callers, so it wants its own ticket. The suite also
-cannot observe those timers: advancing them throws from `setTimeout(this.enableCompanySearch, 800)`
-in `initialize()` — an unbound `this` in a strict class body, pre-existing and firing on every
-real page load with company search on. That wants fixing first, in its own commit, before any
-timer-based test here is possible.
+`getCompanyData()`'s contract for its other callers, so it wants its own ticket.
+
+Advancing `initialize()`'s timers is now possible — see `company-search-deferred-init.test.js`.
+It used to throw from `setTimeout(this.enableCompanySearch, 800)`, which TWO-25337 fixed. Note
+what that throw was and was not, because an earlier version of this paragraph had it wrong: it
+was **not** a production error. `setTimeout` invokes a bare method reference with the global as
+its receiver — the timer steps supply `window` as the callback's this-value, and a strict-mode
+class body does not change that, since the global is only substituted for a null/undefined
+receiver in sloppy mode and here a receiver was passed. Real Chromium runs that call with
+`this === window`, completes it, and logs nothing. The real defect was a misdirected write: the
+deferred pass set `billingCompanySelect` on `window` and left the instance property stale.
+
+**This harness cannot see that.** Jest's fake timers invoke the callback with `null` rather than
+the global, so pre-fix code throws a `TypeError` here where a browser completes it — the crash is
+Sinon's, not the plugin's, and the browser's actual misbehaviour is not reproducible in jsdom at
+all. Evidence for it came from a real Chromium run, recorded on the ticket, not from this suite.
+So do not cite a green run here as proof of browser `this`-binding, and do not write
+`expect(...).not.toThrow()` against these timers: all of its discriminating power is Sinon's, so
+it would go quietly vacuous the moment the timer implementation stopped manufacturing that
+TypeError. Assert the deferred pass's effect on the instance and the DOM instead.
+
+Two traps when you do.
+
+Most of what the retry does is **idempotent** — re-attaching to a field that already has a picker
+leaves the DOM as it was — so an end-state assertion passes whether the timer fired or not, and
+deleting the `setTimeout` outright leaves it green. Give any such test a witness that the deferred
+pass actually ran.
+
+But make that witness invariant to how the call is bound. Spying the INSTANCE after `initialize()`
+returns works against a wrapper (`function () { self.enableCompanySearch(); }`, a late property
+lookup) and fails against `this.enableCompanySearch.bind(this)`, which resolves the method when
+the timer is _scheduled_ — an equally correct fix that such a test would reject. Spy
+`Twoinc.prototype.enableCompanySearch` BEFORE `initialize()` instead: every binding shape reaches
+the prototype, so the witness survives all of them. The cost is that the synchronous pass is
+counted too, so assert 1 call before advancing and 2 after.
 
 - **the whole suite drives the real wiring**: a real `initialize(false)`, then
   `trigger("change")` on the field, so unwiring the delegated binding or moving the seed out

--- a/tests/js/company-search-deferred-init.test.js
+++ b/tests/js/company-search-deferred-init.test.js
@@ -1,0 +1,347 @@
+/**
+ * TWO-25337. `initialize()`'s deferred second pass at enabling company search.
+ *
+ * `initialize()` calls `enableCompanySearch()` twice: once synchronously, and
+ * once on an 800ms timer. The timer exists because the gate `initialize()`
+ * returns on is `#order_review`, which a multi-step or late-rendering theme can
+ * put in the document before the billing fragment — so the synchronous pass can
+ * find no `#billing_company_display` to attach to. That retry is the only one
+ * `initialize()` owns: `updated_checkout` re-syncs a good deal of other state but
+ * does not re-attach the picker itself. The other callers of
+ * `enableCompanySearch` are the manual-entry exit and the sole-trader mode
+ * switch, so a checkout whose deferred pass misses is not necessarily stuck
+ * forever — but nothing is aiming for that, and this timer is the one that has
+ * to work.
+ *
+ * The call was `setTimeout(this.enableCompanySearch, 800)` — a bare method
+ * reference, so the deferred pass ran with the wrong receiver.
+ *
+ * ## What that actually did, measured rather than assumed
+ *
+ * It did NOT throw in a browser. `setTimeout` invokes its callback with the
+ * global as the receiver: the timer steps supply `window` as the this-value, and
+ * a strict-mode class body does not change that, because the global is only
+ * substituted for a null/undefined receiver in sloppy mode and here a receiver
+ * was passed. Confirmed in real Chromium: receiver is `window`, the assignment
+ * succeeds, the console stays clean.
+ *
+ * So the defect was a misdirected write, not a crash. The deferred pass put its
+ * `billingCompanySelect` on `window`, and the instance property kept whatever
+ * the synchronous pass had left there. The widget itself still attached, because
+ * nothing outside `enableCompanySearch` reads that property. What remained was a
+ * live selectWoo object leaked onto `window` and a stale instance property
+ * waiting for its first reader; `clearSelectedCompany` already dodges that trap
+ * by looking the widget up from the DOM instead of trusting the cached
+ * reference.
+ *
+ * ## What this suite can and cannot see
+ *
+ * Be precise about this, because the obvious reading of these tests is wrong.
+ * Jest's fake timers invoke the callback with `null`, not with the global, so
+ * the pre-fix code throws `TypeError` HERE where a browser completes it. The
+ * browser's actual misbehaviour — receiver is `window`, write lands on the
+ * global — is therefore **not reproducible in this harness at all**, and the
+ * evidence for it is the Chromium run recorded above and on the PR, not
+ * anything below.
+ *
+ * What that means for these tests: pre-fix, four of the five fail on the Sinon
+ * TypeError. That is the mechanism, and pretending otherwise would be dishonest.
+ *
+ * The company-search-off test is deliberately not one of them, and passes on the
+ * broken code too. Its early return sits above the first use of the receiver, so
+ * the bug never reached anything there — shops with search off were genuinely
+ * unaffected, and the test exists to say that they stay unaffected. It still
+ * discriminates the retry's existence: delete the `setTimeout` and it fails.
+ *
+ * They are still written to assert the deferred pass's *effect on the instance
+ * and the DOM* rather than `expect(...).not.toThrow()`, for two reasons. An
+ * effect assertion says what the code must achieve, so it keeps its meaning if
+ * the timer implementation ever stops manufacturing that TypeError, whereas a
+ * not-throw assertion would silently become vacuous. And it forces each test to
+ * name a specific consequence of the retry, which is what caught the first
+ * draft of this file asserting things the synchronous pass alone satisfied.
+ */
+
+"use strict";
+
+const harness = require("./wc-harness");
+
+describe("deferred company-search initialisation", () => {
+  let ctx;
+  let ajax;
+
+  beforeEach(() => {
+    // Fake timers here are not the usual "stop initialize()'s timers escaping
+    // the test" guard the rest of the suite installs them for — advancing them
+    // is the subject. Every advance below stops AT 800ms, which is what keeps
+    // the other timers initialize() installs out of the picture: a 1000ms
+    // setTimeout (saveCheckoutInputs / getCompanyData / renderCompanySummary /
+    // getApproval) and a 3s setInterval. Both would fire against this DOM if a
+    // test ever advanced further, so a test that needs to should expect to deal
+    // with them rather than assume 800 is the only timer in play.
+    jest.useFakeTimers();
+    ctx = harness.loadTwoinc({ supported_buyer_countries: ["GB"] });
+    harness.buildCheckoutForm({ country: "GB" });
+    // The checkout-page gate initialize() returns on, plus the gateway radio
+    // the payment-method checks look for.
+    ctx.$("form[name='checkout']").after('<div id="order_review"></div>');
+    ctx
+      .$("form[name='checkout']")
+      .append(
+        "<input type='radio' id='payment_method_woocommerce-gateway-tillit'" +
+          " name='payment_method' value='woocommerce-gateway-tillit' />"
+      );
+    // enableCompanySearch builds a real selectWoo widget whose ajax transport
+    // would otherwise reach for the network on the first keystroke. No test
+    // here types, but the stub keeps a leaked request from failing elsewhere.
+    ajax = harness.stubAjax(ctx.$);
+  });
+
+  afterEach(() => {
+    ajax.restore();
+    harness.releaseWidgets(ctx.$);
+    // Load-bearing, not tidying — initialize() binds delegated handlers on
+    // document.body and jsdom's document outlives the test, so wiping innerHTML
+    // removes the elements but leaves the bindings live for the next test.
+    ctx.$(document.body).off();
+    document.body.innerHTML = "";
+    window.sessionStorage.clear();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  /**
+   * Is a selectWoo widget currently attached to the company field?
+   *
+   * Read from the DOM rather than from `billingCompanySelect`: that property is
+   * assigned the result of `.selectWoo()` on a jQuery set that may have been
+   * EMPTY, which is a truthy empty set and so says nothing about whether a
+   * widget exists. `data("select2")` is set by the widget on the element it
+   * actually initialised.
+   *
+   * @returns {boolean}
+   */
+  function pickerAttached() {
+    return Boolean(ctx.$("#billing_company_display").data("select2"));
+  }
+
+  /**
+   * How many widget containers the company field's own wrapper holds.
+   *
+   * The duplicate-attach failure this guards is a SECOND rendered container
+   * next to the first, not a replaced instance, so it has to be counted in the
+   * DOM rather than inferred from the element's `data`. Scoped to the field's
+   * `<p>` rather than counted document-wide: a document-wide count would depend
+   * on no other field in the fixture ever being given a widget, so it would
+   * start failing here for a reason that has nothing to do with this timer.
+   *
+   * @returns {number}
+   */
+  function containerCount() {
+    return ctx.$("#billing_company_display_field .select2-container").length;
+  }
+
+  /**
+   * Witness that `enableCompanySearch` was called, synchronous pass included.
+   *
+   * Needed because most of what the retry does is idempotent: re-attaching to a
+   * field that already has a picker leaves the DOM as it was, so a test that
+   * only checks the end state passes whether the timer fired or not. Removing
+   * the `setTimeout` from `initialize()` must fail such a test, and without a
+   * witness it does not.
+   *
+   * Two things about the shape of this, both deliberate, because the obvious
+   * version is a trap.
+   *
+   * It spies on the PROTOTYPE, and it must be installed BEFORE `initialize()`.
+   * An own-property spy installed after `initialize()` returns would also work
+   * against the fix as written — `self.enableCompanySearch()` is a property
+   * lookup at invocation time, so it would resolve to the spy — but it would
+   * work *only* against that shape. `setTimeout(this.enableCompanySearch.bind(this), 800)`
+   * is an equally correct fix, and it resolves the method when the timer is
+   * SCHEDULED, before any post-initialize spy exists; such a test would fail on
+   * a correct implementation. Spying the prototype up front is invariant to all
+   * three shapes — bare reference, `.bind()`, or a wrapper — because every one
+   * of them ultimately reaches the prototype method.
+   *
+   * The cost of that is that the synchronous pass is recorded too, so callers
+   * assert a call count of 1 before advancing and 2 after, rather than 1 after.
+   *
+   * @param {Function} Twoinc the class from the harness's fresh evaluation
+   * @returns {Object} jest spy on the prototype's enableCompanySearch
+   */
+  function witnessEnableCalls(Twoinc) {
+    return jest.spyOn(Twoinc.prototype, "enableCompanySearch");
+  }
+
+  /**
+   * How many handlers are bound for one event on the company field.
+   *
+   * Read out of jQuery's own event store, because the duplication being counted
+   * is invisible from the DOM and from the widget: the extra handler is a second
+   * entry against the same element and event name.
+   *
+   * @param {string} eventName jQuery/select2 event name
+   * @returns {number}
+   */
+  function handlerCount(eventName) {
+    const el = ctx.$("#billing_company_display")[0];
+    if (!el) return 0;
+    const store = ctx.$._data(el, "events");
+    if (!store || !store[eventName]) return 0;
+    return store[eventName].length;
+  }
+
+  test("the deferred pass stores its widget on the instance", () => {
+    const instance = ctx.Twoinc.getInstance();
+    instance.initialize(false);
+
+    // Discard what the SYNCHRONOUS pass stored. Without this the assertions
+    // below pass on the synchronous pass's own work — deleting the `setTimeout`
+    // from initialize() altogether would leave them green, which is exactly the
+    // vacuity that made the first draft of this test worthless.
+    instance.billingCompanySelect = null;
+
+    jest.advanceTimersByTime(800);
+
+    // Only the deferred pass can have put this back.
+    expect(instance.billingCompanySelect).not.toBeNull();
+    expect(instance.billingCompanySelect.length).toBe(1);
+    expect(instance.billingCompanySelect[0]).toBe(ctx.$("#billing_company_display")[0]);
+
+    // Deliberately NOT asserted: that `window.billingCompanySelect` is
+    // undefined. Pre-fix this harness throws at the assignment before any write
+    // reaches the global, so such an assertion could never fail and would be
+    // decorative. The global leak is real but browser-only observable — see the
+    // Chromium evidence in the file docblock.
+  });
+
+  test("the deferred pass attaches a picker the first pass could not find", () => {
+    // The late-render case the timer exists for: #order_review is present, so
+    // initialize() runs in full, but the billing fragment is not there yet.
+    const markup = ctx.$("#billing_company_display_field").prop("outerHTML");
+    ctx.$("#billing_company_display_field").remove();
+
+    const instance = ctx.Twoinc.getInstance();
+    instance.initialize(false);
+
+    // The synchronous pass found nothing to attach to. This is the state a real
+    // late-rendering theme left the checkout in permanently.
+    expect(pickerAttached()).toBe(false);
+
+    // And note what it stored, because it is NOT null: `.selectWoo()` on an
+    // empty jQuery set returns that same empty set. The property holds a truthy
+    // widget-shaped object wrapping no element, which is worse than null for
+    // any caller testing it for presence — the stale value the fix stops the
+    // deferred pass from leaving behind.
+    expect(instance.billingCompanySelect).not.toBeNull();
+    expect(instance.billingCompanySelect.length).toBe(0);
+
+    // WooCommerce renders the billing fragment.
+    ctx.$("form[name='checkout']").append(markup);
+    expect(pickerAttached()).toBe(false);
+
+    jest.advanceTimersByTime(800);
+
+    // ...and the retry catches it. The picker attaching is what the buyer sees;
+    // the instance holding the real reference is what the misdirected write
+    // cost.
+    expect(pickerAttached()).toBe(true);
+    expect(containerCount()).toBe(1);
+    expect(instance.billingCompanySelect.length).toBe(1);
+  });
+
+  test("the deferred pass renders no second widget on the ordinary path", () => {
+    // Field present all along, so the retry re-runs against a widget that is
+    // already live. That is not new — the retry did the same thing before the
+    // fix, since the wrong receiver only changed where the reference was
+    // stored and `selectWoo()` ran on the same element either way — so this
+    // pins existing behaviour rather than behaviour the fix introduces.
+    const enableCalls = witnessEnableCalls(ctx.Twoinc);
+    const instance = ctx.Twoinc.getInstance();
+    instance.initialize(false);
+
+    expect(enableCalls).toHaveBeenCalledTimes(1);
+    expect(pickerAttached()).toBe(true);
+    expect(containerCount()).toBe(1);
+
+    jest.advanceTimersByTime(800);
+
+    // Without this the test is vacuous: re-attaching changes nothing observable
+    // on this path, so the two assertions below hold even with no timer at all.
+    expect(enableCalls).toHaveBeenCalledTimes(2);
+
+    // selectWoo's re-init destroys the previous instance, so no second
+    // container is rendered and the buyer sees one picker.
+    expect(pickerAttached()).toBe(true);
+    expect(containerCount()).toBe(1);
+  });
+
+  test("CHARACTERISATION: the deferred pass leaves the select handler bound twice", () => {
+    // Records a real pre-existing defect rather than endorsing it (TWO-25338).
+    //
+    // Container count above is reassuring about the wrong thing. selectWoo's
+    // `destroy()` unbinds with `.off(".select2")`, but the plugin binds its own
+    // `select2:select` / `select2:open` handlers UNNAMESPACED and with no
+    // preceding `.off()`, so a namespaced unbind cannot match them and they
+    // survive the destroy. Every ordinary page load with company search on
+    // therefore ends up with the handler bound twice, and one pick then runs
+    // getApproval(), addressLookup() and renderCompanySummary() twice over.
+    //
+    // What the duplication costs, per handler. From `select2:select`:
+    // `renderCompanySummary()` and `togglePaySubtitleDesc()` genuinely run
+    // twice, and `addressLookup()` does too when address lookup is enabled; the
+    // DOM and `customerCompany` writes are idempotent; and `getApproval()` costs
+    // nothing, because the second entry finds `orderIntentCheck.interval` set,
+    // flags `pendingCheck` and returns — and that flag cannot buy a later round
+    // either, since every site that nulls the interval clears it in the same
+    // block. The duplicated `select2:open` costs almost nothing, and explicitly
+    // NOT a pair of racing focus pollers: `addSelectWooFocusFixHandler` guards
+    // itself, and the `waitToFocus("billing_company_display", null, null)` call
+    // defeats that helper's own defaults — it guards them with `isNaN`, and
+    // `isNaN(null)` is false, so `attemptsLeft` becomes `null * 8` and the
+    // interval clears on its first tick. Two single-shot focus nudges.
+    //
+    // Unchanged by TWO-25337 — the retry ran on the live widget before it too.
+    // Left alone here deliberately: fixing it means touching how every handler
+    // in enableCompanySearch is bound, which is wider than this ticket. When
+    // TWO-25338 fixes it, both expectations below become 1 and this test flips
+    // from characterisation to guarantee.
+    ctx.Twoinc.getInstance().initialize(false);
+
+    expect(handlerCount("select2:select")).toBe(1);
+    expect(handlerCount("select2:open")).toBe(1);
+
+    jest.advanceTimersByTime(800);
+
+    expect(handlerCount("select2:select")).toBe(2);
+    expect(handlerCount("select2:open")).toBe(2);
+  });
+
+  test("the deferred pass early-returns with company search off", () => {
+    // The `enable_company_search !== "yes"` early return sits ABOVE the first
+    // use of the receiver, so the unbound call never dereferenced anything on
+    // shops with search off. They were unaffected by the bug and must stay
+    // unaffected by the fix — no widget may appear on the timer. `ctx.twoinc`
+    // and `window.twoinc` are the same object, so setting it once is enough.
+    window.twoinc.enable_company_search = "no";
+
+    const enableCalls = witnessEnableCalls(ctx.Twoinc);
+    const instance = ctx.Twoinc.getInstance();
+    instance.initialize(false);
+
+    expect(enableCalls).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(800);
+
+    // The witness is what makes this about the DEFERRED early return rather than
+    // the synchronous one. Both assertions below already hold straight out of
+    // the constructor, so without proof the timer fired they say nothing.
+    expect(enableCalls).toHaveBeenCalledTimes(2);
+
+    expect(pickerAttached()).toBe(false);
+    // The one path that really does leave the property null: the early return
+    // is above the assignment.
+    expect(instance.billingCompanySelect).toBeNull();
+  });
+});

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -15,10 +15,12 @@ module.exports = {
   rootDir: "../..",
   testMatch: ["<rootDir>/tests/js/**/*.test.js"],
   testEnvironment: "jsdom",
-  // The suite uses no jest mocks today — it stubs jQuery.ajax by hand and
-  // restores it in afterEach. These are the net for the first test that
-  // reaches for jest.spyOn, since a leaked spy on a shared helper object fails
-  // somewhere other than where it was created.
+  // Most of the suite stubs jQuery.ajax by hand and restores it in afterEach.
+  // These two are the net under the tests that do reach for jest.spyOn — the
+  // deferred-init suite spies on `Twoinc.prototype.enableCompanySearch` — since
+  // a leaked spy on a shared prototype or helper object fails somewhere other
+  // than where it was created. Both fire before each test, so a spy created
+  // inside a test body still calls through.
   restoreMocks: true,
   resetMocks: true
 };


### PR DESCRIPTION
## What

`initialize()` retries `enableCompanySearch()` on an 800ms timer, to catch a billing fragment that WooCommerce had not rendered yet when `initialize()` ran. It passed the method by reference — `setTimeout(this.enableCompanySearch, 800)` — so the retry ran with the wrong receiver.

Fixed by wrapping the call, reusing the `self` that `initialize()` already declares. A `function` wrapper rather than an arrow because the file contains zero arrow functions.

## The ticket's premise was wrong, and that is the interesting part

TWO-25337 described this as a TypeError firing on every real checkout page load with company search on — a live production error. **It is not.** Measured in real Chromium before writing the fix:

```
receiver:     "window"
threw:        false
instanceProp: null
windowProp:   "ATTACHED"
console/pageerrors: []
```

`setTimeout` invokes a bare method reference with the **global** as its receiver: the timer steps supply `window` as the callback's this-value, and a strict-mode class body does not change that, because the global is only substituted for a null/undefined receiver in sloppy mode and here a receiver was passed.

The TypeError is **Sinon's**. Jest's fake timers invoke the callback with `null` where a browser passes the global, so the harness manufactures a crash no browser produces. `tests/js/README.md` had written that up as production behaviour; this PR corrects it.

The ticket has been downgraded off High accordingly.

## What the defect actually was

A misdirected write, not a crash:

- the retry set `billingCompanySelect` on `window` instead of on the singleton;
- **the widget still attached** — nothing outside `enableCompanySearch` reads that property — so the late-render retry has been working in production all along;
- what remained was a live selectWoo object leaked onto the global, plus an instance property still holding whatever the synchronous pass wrote.

That last value is **not** `null`, which is worth stating because the first draft of this PR got it wrong: `.selectWoo()` on an empty jQuery set returns that same empty set, so in the late-render case the property held a truthy widget-shaped object wrapping no element — worse than `null` for any caller testing it for presence. `null` survives only with company search off, where the early return sits above the assignment.

Behavioural delta is therefore narrow by construction: every widget-wiring call in `enableCompanySearch` either used `self` only for that one property or went through the DOM / `Twoinc.getInstance()`, so the only thing that moves is which object holds the reference.

## Tests

New `tests/js/company-search-deferred-init.test.js`, 5 tests.

| Test | Pins |
|---|---|
| stores its widget on the instance | the fix itself — discards what the synchronous pass stored, so only the retry can satisfy it |
| attaches a picker the first pass could not find | the effect the 800ms delay exists for, via a late-rendered billing fragment; also pins the truthy-empty-set value above |
| renders no second widget on the ordinary path | no duplicate container, with a witness that the retry actually ran |
| CHARACTERISATION: select handler bound twice | a real pre-existing defect (TWO-25338), recorded rather than endorsed |
| early-returns with company search off | the `enable_company_search` guard sits above the first receiver use, so those shops were and stay unaffected |

Two traps are handled explicitly, both found by review rather than by me:

**No `not.toThrow()` assertions.** All of that assertion's discriminating power here would be Sinon's, so it would go quietly vacuous the moment the timer implementation stopped manufacturing the TypeError. The tests assert the retry's effect on the instance and the DOM instead. Relatedly, the harness **cannot** reproduce the browser's `this`-binding at all — the docblock and README now say so plainly rather than letting a green run be mistaken for browser evidence.

**Witnesses against idempotence.** Most of what the retry does is idempotent: re-attaching to a field that already has a picker leaves the DOM as it was, so an end-state assertion passes whether the timer fired or not. Deleting the `setTimeout` outright left two tests green in an earlier revision, so each such test now carries a call witness.

That witness spies `Twoinc.prototype.enableCompanySearch` **before** `initialize()`, not the instance after it — which matters more than it sounds. An instance spy installed afterwards works against the wrapper shape used here (a late property lookup) but would **reject** `setTimeout(this.enableCompanySearch.bind(this), 800)`, an equally correct fix that resolves the method when the timer is scheduled. Every binding shape reaches the prototype, so the prototype spy is invariant to all of them; the cost is that the synchronous pass is counted too, hence "1 call before advancing, 2 after".

**Mutation-verified, three mutations, tree confirmed changed each time:**

| Mutation | Expected | Result |
|---|---|---|
| delete the retry entirely | all fail | 5 fail |
| revert the receiver (`setTimeout(this.enableCompanySearch, 800)`) | fail those that can see it | 4 fail |
| `setTimeout(this.enableCompanySearch.bind(this), 800)` — a *correct* alternative | all **pass** | 5 pass |

The third is the one that stops these tests from encoding my implementation choice as the only right answer. The company-search-off test passing under the receiver revert is also by design: its early return sits above the first use of the receiver, so those shops were genuinely never affected, and the test exists to say they stay that way.

**Full JS suite green: 304 tests, 9 suites.** Style gate (prettier 3.1.0) clean; `tests/js/README.md` was prettier-clean on base, so its diff stays scoped to the corrected passage.

## Out of scope, and filed: TWO-25338

Review found a real pre-existing defect that the container-count assertion was quietly reassuring about. The plugin binds its `select2:select` / `select2:open` handlers unnamespaced with no preceding `.off()`, and selectWoo's `destroy()` unbinds with `.off(".select2")` — which cannot match them — so the retry leaves both handlers bound twice on every ordinary page load.

Cost priced per handler, after review corrected me twice on it. `select2:select` is the only copy that costs anything meaningful: `renderCompanySummary()` and `togglePaySubtitleDesc()` double, `addressLookup()` doubles when address lookup is enabled (two registry round trips for one pick), the DOM and `customerCompany` writes are idempotent, and the duplicate `getApproval()` is dropped outright at the `orderIntentCheck.interval` guard — the `pendingCheck` flag it sets cannot buy a later round either, because every site that nulls the interval clears the flag in the same block.

The duplicated `select2:open` costs almost nothing, which is the opposite of what an earlier revision of this PR claimed. It looks like it should start two racing 300ms focus pollers, but the call site passes `waitToFocus("billing_company_display", null, null)` and that helper guards its defaults with `isNaN` — and `isNaN(null)` is false, so `attemptsLeft` becomes `null * 8`, i.e. 0, and the interval clears on its first tick. Two single-shot focus nudges, each already a no-op when the input is focused.

Unchanged by this PR: the retry ran on a live widget before it too. Fixing it means changing how every handler in `enableCompanySearch` is bound, which is wider than this ticket, so it is filed as TWO-25338 with the characterisation test as its regression gate.

## Verification status, honestly

**No live checkout load.** The Chrome bridge was down for this session, so the browser evidence is headless Chromium driven through the repo's own Playwright install, not a real WooCommerce checkout. That settles the `this`-binding question it was used for; the rest is the jsdom suite against the real jQuery and the real selectWoo widget.

**`e2e-tests` is red, and not from this diff.** The failure is `admin login failed: 404` in `two-api.ts` during `triggerFulfilBatch` — an auth/routing failure in the e2e harness, on a spec (order flow: place → fulfil → refund) that this JS-only change cannot reach. Every one of the last 25 `e2e-tests` runs on this repo is `failure` or `cancelled`, across unrelated PRs, so it is a systemic/environmental breakage on the shared base rather than something this branch introduced. Flagging rather than fixing: it needs whoever owns that endpoint, and this PR should not be the only copy of a fix for it. All other 17 checks pass.

Closes TWO-25337.

<sub>by Claude</sub>
