### PR TITLE
fix(e2e): point admin login at the dev-only /test path (TWO-25341)

### DIFF
--- a/tests/e2e/two-api.ts
+++ b/tests/e2e/two-api.ts
@@ -71,7 +71,10 @@ export async function cancelOrder(orderId: string): Promise<void> {
 export async function triggerFulfilBatch(): Promise<void> {
   if (!TWO_ADMIN_PASSWORD) throw new Error("TWO_ADMIN_PASSWORD env var not set");
   const basic = Buffer.from(`${TWO_ADMIN_LOGIN}:${TWO_ADMIN_PASSWORD}`).toString("base64");
-  const loginRes = await fetch(`${API_BASE_URL}/admin/v1/login`, {
+  // The basic-auth admin login lives under the dev-only `/test/` family and only
+  // exists in lower environments. It was moved there upstream on 2026-07-31; the
+  // old path now 404s, which is what broke this job on every run since.
+  const loginRes = await fetch(`${API_BASE_URL}/test/admin/login`, {
     method: "POST",
     headers: { Authorization: `Basic ${basic}` }
   });


### PR DESCRIPTION
## Problem

The `e2e-tests` job has failed on every run since 2026-07-31 (25/25 across unrelated PRs) with:

```
Error: admin login failed: 404 <!DOCTYPE html> ... <p class="code">404</p>
```

thrown from `triggerFulfilBatch` in `tests/e2e/two-api.ts`. One test — `order-flow.spec.ts`
(`place → fulfil → refund`) — fails; the other three pass. Net effect: this repo has had **no
working e2e gate** all week, and every PR has merged past a red check.

## Root cause

Nothing to do with the WordPress/WooCommerce staging shop, and nothing to do with any PR's diff.

The harness authenticated against the Two API's **old** basic-auth admin login path. That path was
retired upstream on 2026-07-31 and replaced by a dev-only equivalent under the `/test/` family,
which exists in lower environments only. The harness was never updated, so it has been POSTing to a
path that no longer exists.

Verified against staging (unauthenticated POST, so status alone is the signal):

| Path | Status |
|---|---|
| old path | `404` |
| `/test/admin/login` | `401` — route present, credentials required |
| `/v1/batch/order_fulfillment_batch` | `401` — unchanged |

Credentials and secrets are fine: `STAGING_TWO_ADMIN_PASSWORD` / `admin@two.inc` are unchanged, and
the shared e2e-tests repo already uses the new path successfully with the same secret.

## Fix

One-line path change in `tests/e2e/two-api.ts`, plus a comment recording why the path is where it is
so the next reader doesn't "fix" it back.

## Scope: WC-only

Checked every other plugin repo on its default branch — none of them contain this admin-login code
path at all, so none are affected. The shared e2e harness repo was already migrated to the new path.
