### PR TITLE
feat(company-search): one control, location setting picks address area vs payment tile (TWO-25326)

### DIFF
--- a/assets/css/twoinc.css
+++ b/assets/css/twoinc.css
@@ -48,6 +48,20 @@
 }
 
 /*
+ * TWO-25326 §7.3 (ruling 2026-08-03): the approved and declined intent
+ * messages now carry the captured company (`<name> (<number>)`) directly in
+ * their sentence, where the standalone `.twoinc-company-tile-label` used to.
+ * That label carried `overflow-wrap: anywhere` for exactly this reason —
+ * registry names in DE/NL/NO routinely contain a single unbroken token wider
+ * than the tile column — and these two boxes need the same protection now
+ * that they are the ones holding the name.
+ */
+.twoinc-pay-box.twoinc-intent-approved,
+.twoinc-pay-box.twoinc-err-payment-default {
+  overflow-wrap: anywhere;
+}
+
+/*
  * Visually hidden but readable by assistive technology. Defined here rather
  * than leaning on the theme's .screen-reader-text, which not every theme
  * ships — a missing rule there would render the text visibly.
@@ -160,8 +174,9 @@
  * The captured NAME no longer renders here. §7 rules out any company name or
  * number text in the address area beyond the company-name field itself and
  * this number label — the name was a second copy of what the control directly
- * above already shows. It moved to the payment tile
- * (`.twoinc-company-tile-label`).
+ * above already shows. It no longer renders as a standalone label anywhere
+ * (TWO-25326 §7.2/§7.3, ruling 2026-08-03): it lives inside the payment
+ * tile's intent-message sentence instead.
  */
 .twoinc-company-summary {
   padding-bottom: 15px;
@@ -590,49 +605,23 @@
 }
 
 /*
- * The captured company, as `<name> (<number>)`, in the payment tile
- * (TWO-25326 §7).
+ * The company-search control's location in the payment tile (TWO-25326 §7.1,
+ * ruling 2026-08-03), when the `company_search_location` admin setting is
+ * 'payment_tile'. Holds the SAME control moved out of the address area by
+ * twoincDomHelper.syncCompanySearchTileLocation() — the fields themselves
+ * (`#billing_company_field` etc.) already carry all their own styling from
+ * the address form, so this wrapper only needs enough of its own spacing to
+ * sit cleanly between the sole-trader toggle and the intent message.
  *
- * A text label, deliberately styled as one: no border, no background, nothing
- * that reads as a control. The buyer cannot act on this — it restates what
- * they already picked in the address form — and anything that looks clickable
- * here invites them to try to edit it in the tile, which is the exact failure
- * mode the ticket records against the Magento implementations.
- *
- * Semibold rather than a colour change, so it stays legible on any brand
- * overlay's tile background without this rule having to know what colour that
- * is.
- *
- * `overflow-wrap: anywhere` for the same reason the number label under the
- * address field carries it: registry names in DE/NL/NO routinely contain a
- * single unbroken token longer than the tile is wide, and the tile is
- * narrower than the address column.
+ * The standalone `.twoinc-company-tile-label` text label this replaced is
+ * gone outright (§7.2/§7.3): the company now lives inside the intent-message
+ * sentences instead, which need no CSS of their own beyond what
+ * `.twoinc-pay-box` already provides.
  */
-.twoinc-company-tile-label {
+.twoinc-company-search-tile-slot {
   margin: 12px 0;
-  font-weight: 600;
-  line-height: 1.4;
-  overflow-wrap: anywhere;
 }
-.twoinc-company-tile-label.hidden {
-  display: none;
-}
-/*
- * The no-content case (TWO-25326 §7, revised 2026-08-03).
- *
- * The label's visibility now mirrors the intent-approved notice's, and NOT
- * "has a company been captured" — so the label can be unhidden while holding
- * no text, on an intent-approved checkout whose company is unknown. That is a
- * real state rather than a defensive hypothetical: the notice itself carries a
- * separate no-company variant of its sentence for exactly it.
- *
- * Without this rule such a label would be an invisible 24px gap (the 12px
- * margins above and below) wedged between the chips and the notice. Handled
- * here rather than by and-ing the text back into the JS condition, so the one
- * gate in twoinc.js stays literally "shown when the notice is shown" and this
- * stays what it is — a rendering detail about an element with nothing in it.
- */
-.twoinc-company-tile-label:empty {
+.twoinc-company-search-tile-slot.hidden {
   display: none;
 }
 .twoinc-mode-selector {

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1616,9 +1616,95 @@ let twoincDomHelper = {
   companySearchTileSlotClass: "twoinc-company-search-tile-slot",
 
   /**
+   * DOM id of the wrapper that holds the relocated company-search control
+   * (TWO-25326 §7.1). One element, created once; every move below is this
+   * same node changing parent, never a clone.
+   */
+  companySearchTileWrapperId: "twoinc-company-search-tile-wrapper",
+
+  /**
+   * DOM id of the safe holding pen the wrapper sits in whenever it is NOT
+   * currently inside the live `.twoinc-company-search-tile-slot` (TWO-25326
+   * §7.1, hardened round 2026-08-03 after adversarial review).
+   *
+   * Exists as a direct child of `<form name="checkout">` — stable across
+   * every WooCommerce checkout AJAX refresh (the form element itself is
+   * never one of the fragments `update_order_review` replaces) — rather than
+   * `document.body`, so a buyer who manages to submit the form during the
+   * brief detached window still posts real, still-attached inputs.
+   *
+   * @returns {Object} jQuery-wrapped holding pen, created on first use
+   */
+  getCompanySearchTileHoldingPen: function () {
+    let $pen = jQuery("#twoinc-company-search-tile-holding-pen");
+    if (!$pen.length) {
+      $pen = jQuery('<div id="twoinc-company-search-tile-holding-pen" class="hidden"></div>');
+      const $form = jQuery('form[name="checkout"]');
+      // Falls through to <body> only on a page with no checkout form at all
+      // (never expected in production; keeps this a no-op rather than a
+      // throw on such a page).
+      (($form.length && $form) || jQuery("body")).append($pen);
+    }
+    return $pen;
+  },
+
+  /**
+   * Detach the company-search tile wrapper to the safe holding pen, BEFORE
+   * any WooCommerce checkout AJAX refresh can destroy it (TWO-25326 §7.1,
+   * hardened round 2026-08-03).
+   *
+   * The bug this closes (found independently by every reviewer in the
+   * TWO-25326 adversarial round): WooCommerce's `update_order_review` AJAX
+   * — fired on a shipping-method change, a coupon apply, a quantity change,
+   * not only a payment-method or country switch — replaces the WHOLE
+   * `.woocommerce-checkout-payment` fragment wholesale
+   * (`$(key).replaceWith(fragments[key])` in WC core's checkout.js). The
+   * payment tile's slot lives inside that fragment. A real, live
+   * `<select>`/`<input>` re-parented into the slot is therefore a
+   * descendant of a subtree WooCommerce can destroy at any moment with no
+   * warning — `replaceWith` removes the old nodes outright; nothing
+   * resurrects them, and no later re-sync call can recover a node jQuery
+   * already tore down.
+   *
+   * The fix is to never leave the wrapper sitting inside that fragment for
+   * longer than it has to: bound to WooCommerce's OWN `update_checkout`
+   * trigger (the past-tense `updated_checkout` fires only after the
+   * fragments are already swapped in — this is the PRESENT-tense trigger
+   * that starts an update, fired synchronously before the async AJAX call
+   * begins). jQuery dispatches every handler bound to a trigger
+   * synchronously, in the same tick, before any of them can kick off async
+   * work — so this handler is guaranteed to run and complete before the
+   * fragment swap it is defending against, regardless of registration order
+   * against WooCommerce's own handler on the same event.
+   *
+   * A no-op on 'address_area' (nothing was ever moved into the fragment) and
+   * a no-op if the wrapper doesn't exist yet (nothing captured, no company
+   * fields ever relocated) or is already in the pen.
+   *
+   * @returns {void}
+   */
+  detachCompanySearchTileWrapperToSafety: function () {
+    if (window.twoinc.company_search_location !== "payment_tile") return;
+
+    const $wrapper = jQuery("#" + twoincDomHelper.companySearchTileWrapperId);
+    if (!$wrapper.length) return;
+
+    const $pen = twoincDomHelper.getCompanySearchTileHoldingPen();
+    if ($wrapper.parent()[0] !== $pen[0]) {
+      $wrapper.appendTo($pen);
+    }
+  },
+
+  /** DOM class of the payment-tile slot the company-search control moves into
+   * when `company_search_location` is 'payment_tile' (TWO-25326 §7.1). */
+  companySearchTileSlotClass: "twoinc-company-search-tile-slot",
+
+  /**
    * Relocate the ONE company-search control into the payment tile, or leave
    * it in the address area, per the `company_search_location` admin setting
-   * (TWO-25326 §7.1, ruling 2026-08-03).
+   * (TWO-25326 §7.1, ruling 2026-08-03; hardened round 2026-08-03 after
+   * adversarial review — see `detachCompanySearchTileWrapperToSafety` for
+   * the AJAX-destruction bug this pairs with).
    *
    * This is the same control both ways — the real `#billing_company_field`,
    * `#billing_company_display_field` and `#company_id_field` rows (plus the
@@ -1640,20 +1726,23 @@ let twoincDomHelper = {
    * now-removed `.twoinc-company-tile-label` used to occupy). A single
    * wrapper (`#twoinc-company-search-tile-wrapper`) is created once and holds
    * all the moved rows in address-form order, so the slot only ever has one
-   * child to manage.
+   * child to manage. This function only ever pulls the wrapper INTO the
+   * slot — pulling it back OUT, before it can be destroyed, is
+   * `detachCompanySearchTileWrapperToSafety`'s job, called from the
+   * `update_checkout` trigger paired with this one on `updated_checkout`.
    *
-   * Idempotent and safe to call on every render, mirroring the anchor-check
-   * pattern `getCompanySummaryNode()` already uses for the same reason: WC's
-   * own checkout JS resorts `.form-row` elements it still owns, but once a
-   * row is moved out of the billing wrapper into the tile it is no longer one
-   * of the rows WC resorts, so this only needs to run again defensively (a
-   * full billing-fields re-render, a theme, a future WC version) rather than
-   * on every keystroke.
+   * Every move below is guarded on the node's CURRENT parent — the same
+   * `$x.parent()[0] !== $y[0]` idempotency check `getCompanySummaryNode()`
+   * already relies on elsewhere in this file, for the same reason (round 1
+   * review — Leia): an unconditional `appendTo()` on every call physically
+   * detaches and reattaches a live `<select>` even when nothing has moved,
+   * which would silently close an open selectWoo dropdown and collapse any
+   * in-progress text selection on every payment-method/country switch.
    *
-   * Called from `toggleBusinessFields()`, which already runs on every
-   * payment-method switch, country change and `updated_checkout` — the same
-   * triggers that can re-decide which company fields are even visible, and
-   * so the same ones that must re-decide where they live.
+   * Called directly from `onUpdatedCheckout()` (bound to `updated_checkout`)
+   * and from `toggleBusinessFields()` (payment-method switch, gestured
+   * country change) — the two paths that can re-decide which company fields
+   * are even visible, and so the two that must re-decide where they live.
    *
    * @returns {void}
    */
@@ -1666,28 +1755,41 @@ let twoincDomHelper = {
       // once per page load (see WC_Twoinc_Checkout::prepare_twoinc_object),
       // so this value cannot flip mid-session — every call on this branch,
       // for the lifetime of the page, is a genuine no-op.
-      $slot.addClass("hidden");
+      if (!$slot.hasClass("hidden")) $slot.addClass("hidden");
       return;
     }
 
-    let $wrapper = jQuery("#twoinc-company-search-tile-wrapper");
+    let $wrapper = jQuery("#" + twoincDomHelper.companySearchTileWrapperId);
     if (!$wrapper.length) {
-      $wrapper = jQuery('<div id="twoinc-company-search-tile-wrapper"></div>');
+      $wrapper = jQuery('<div id="' + twoincDomHelper.companySearchTileWrapperId + '"></div>');
       $slot.append($wrapper);
     } else if ($wrapper.parent()[0] !== $slot[0]) {
       $slot.append($wrapper);
     }
 
-    // Address-form order: name/search control, hidden org-number field, the
-    // read-only number label underneath it. `.appendTo()` on an
-    // already-attached node MOVES it (never clones), same as
-    // `getCompanySummaryNode()` relies on elsewhere in this file.
-    jQuery("#billing_company_display_field, #billing_company_field, #company_id_field").appendTo(
-      $wrapper
+    // Ends up in address-form order (name/search control, then the hidden
+    // org-number field) because that already IS each one's document order in
+    // the address form before this runs — jQuery's multi-selector returns
+    // matches in document order, not the order the selector string lists
+    // them in (round 1 review — Leia: a prior version of this comment
+    // credited the selector string's own argument order, which is not what
+    // jQuery actually guarantees). `.appendTo()` on an already-attached node
+    // MOVES it (never clones), same as `getCompanySummaryNode()` relies on
+    // elsewhere in this file — but only when it isn't already there, so a
+    // stale selectWoo dropdown or text selection survives a re-render that
+    // changed nothing.
+    jQuery("#billing_company_display_field, #billing_company_field, #company_id_field").each(
+      function () {
+        const $field = jQuery(this);
+        if ($field.parent()[0] !== $wrapper[0]) $field.appendTo($wrapper);
+      }
     );
-    twoincDomHelper.getCompanySummaryNode().appendTo($wrapper);
+    const $summary = twoincDomHelper.getCompanySummaryNode();
+    if ($summary.length && $summary.parent()[0] !== $wrapper[0]) {
+      $summary.appendTo($wrapper);
+    }
 
-    $slot.removeClass("hidden");
+    if ($slot.hasClass("hidden")) $slot.removeClass("hidden");
   },
 
   /**
@@ -1773,7 +1875,15 @@ let twoincDomHelper = {
           twoincUtilHelper.blankToEmpty(captured.organization_number)
         );
         if (companyTemplate && companyText) {
-          intentBox.text(companyTemplate.replace("{company}", companyText));
+          intentBox.text(companyTemplate.replace("{company}", function () {
+            // Function replacer (Vader, round 1 review): a string replacer
+            // honours special patterns like `$&`/`$$` inside the SECOND
+            // argument, so a company literally named "Acme $& Corp" or
+            // "50% Ltd $$" would come out mangled with a plain-string
+            // replace. A function replacer passes companyText through
+            // literally, no matter what it contains.
+            return companyText;
+          }));
         } else {
           intentBox.text(intentBox.data("twoincDefaultText"));
         }
@@ -1795,7 +1905,9 @@ let twoincDomHelper = {
             twoincUtilHelper.blankToEmpty(captured.organization_number)
           );
           if (declinedTemplate && companyText) {
-            $errBox.text(declinedTemplate.replace("{company}", companyText));
+            $errBox.text(declinedTemplate.replace("{company}", function () {
+              return companyText;
+            }));
           } else {
             $errBox.text($errBox.data("twoincDefaultText"));
           }
@@ -3729,6 +3841,19 @@ class Twoinc {
     // Disable or enable actions based on the account type
     $body.on("updated_checkout", Twoinc.getInstance().onUpdatedCheckout);
 
+    // Company-search tile relocation (TWO-25326 §7.1), paired handlers on
+    // WooCommerce's own before/after checkout-update triggers. `update_checkout`
+    // is the PRESENT-tense trigger that starts a recalculation — fired
+    // synchronously, before the async AJAX call WooCommerce's own handler on
+    // this same event kicks off — so detaching the tile wrapper here always
+    // completes before that AJAX response can wholesale-replace the
+    // `.woocommerce-checkout-payment` fragment the tile lives inside (see
+    // `detachCompanySearchTileWrapperToSafety`'s doc comment for the bug this
+    // closes). `onUpdatedCheckout` (the past-tense, after-swap trigger,
+    // already bound above) is what moves the wrapper back into the fresh
+    // slot.
+    $body.on("update_checkout", twoincDomHelper.detachCompanySearchTileWrapperToSafety);
+
     // No click handler for the manual-entry row (TWO-25288). It is a pseudo-
     // option inside the results list now, so the picker already turns a click
     // on it into the same internal select that Enter does, and
@@ -4199,6 +4324,19 @@ class Twoinc {
 
     twoincTermChips.refresh();
     twoincSoleTrader.refresh();
+
+    // TWO-25326 §7.1, hardened round 2026-08-03: called directly here, not
+    // only via `toggleBusinessFields()`. `updated_checkout` (this handler)
+    // fires on every WooCommerce checkout AJAX refresh — a shipping-method
+    // change, a coupon apply, a quantity change — not only the
+    // payment-method/gestured-country switches that call
+    // `toggleBusinessFields()`. The server just re-rendered a fresh, empty
+    // `.twoinc-company-search-tile-slot` as part of that same refresh (see
+    // `detachCompanySearchTileWrapperToSafety`, paired on `update_checkout`,
+    // for why the wrapper survived the refresh to be moved back in here at
+    // all), and every one of those triggers needs it re-populated, not just
+    // the two `toggleBusinessFields()` already covered.
+    twoincDomHelper.syncCompanySearchTileLocation();
   }
 
   /**

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1571,6 +1571,13 @@ let twoincDomHelper = {
 
     twoincDomHelper.syncCompanyFieldWrappers();
 
+    // Relocate the company-search control per the admin setting (TWO-25326
+    // §7.1) BEFORE renderCompanySummary() below: the summary node's anchor
+    // (getCompanySummaryNode()) is relative to whichever field is currently
+    // its neighbour, and this call may just have moved that field's wrapper
+    // into the tile.
+    twoincDomHelper.syncCompanySearchTileLocation();
+
     // Last, and unconditionally: this function runs on every payment-method,
     // country and capture-mode switch, which is exactly when the summary's own
     // visibility gate needs re-evaluating. It reads the current inputs and
@@ -1604,6 +1611,85 @@ let twoincDomHelper = {
     );
   },
 
+  /** DOM class of the payment-tile slot the company-search control moves into
+   * when `company_search_location` is 'payment_tile' (TWO-25326 §7.1). */
+  companySearchTileSlotClass: "twoinc-company-search-tile-slot",
+
+  /**
+   * Relocate the ONE company-search control into the payment tile, or leave
+   * it in the address area, per the `company_search_location` admin setting
+   * (TWO-25326 §7.1, ruling 2026-08-03).
+   *
+   * This is the same control both ways — the real `#billing_company_field`,
+   * `#billing_company_display_field` and `#company_id_field` rows (plus the
+   * read-only number label, `getCompanySummaryNode()`), MOVED with
+   * `appendTo()`, never cloned and never a second implementation. Whatever
+   * JS already targets those ids/classes (selectWoo init, keyboard handling,
+   * tab-order fixes, `getCompanyName()`/`getCompanyData()`, the manual-entry
+   * affordances) keeps working unchanged, because it all selects by id or
+   * class rather than by position in the DOM.
+   *
+   * Default setting is 'address_area': this function is then a no-op and the
+   * control renders exactly where WooCommerce always put it — zero
+   * behavioural change for every merchant who does not touch the new
+   * setting.
+   *
+   * 'payment_tile': the fields move into `.twoinc-company-search-tile-slot`,
+   * the empty slot `get_pay_box_description()` server-renders between the
+   * sole-trader toggle and the intent loader/notice (the same position the
+   * now-removed `.twoinc-company-tile-label` used to occupy). A single
+   * wrapper (`#twoinc-company-search-tile-wrapper`) is created once and holds
+   * all the moved rows in address-form order, so the slot only ever has one
+   * child to manage.
+   *
+   * Idempotent and safe to call on every render, mirroring the anchor-check
+   * pattern `getCompanySummaryNode()` already uses for the same reason: WC's
+   * own checkout JS resorts `.form-row` elements it still owns, but once a
+   * row is moved out of the billing wrapper into the tile it is no longer one
+   * of the rows WC resorts, so this only needs to run again defensively (a
+   * full billing-fields re-render, a theme, a future WC version) rather than
+   * on every keystroke.
+   *
+   * Called from `toggleBusinessFields()`, which already runs on every
+   * payment-method switch, country change and `updated_checkout` — the same
+   * triggers that can re-decide which company fields are even visible, and
+   * so the same ones that must re-decide where they live.
+   *
+   * @returns {void}
+   */
+  syncCompanySearchTileLocation: function () {
+    const $slot = jQuery("." + twoincDomHelper.companySearchTileSlotClass);
+    if (!$slot.length) return;
+
+    if (window.twoinc.company_search_location !== "payment_tile") {
+      // Address area (default): nothing to move. `window.twoinc` is written
+      // once per page load (see WC_Twoinc_Checkout::prepare_twoinc_object),
+      // so this value cannot flip mid-session — every call on this branch,
+      // for the lifetime of the page, is a genuine no-op.
+      $slot.addClass("hidden");
+      return;
+    }
+
+    let $wrapper = jQuery("#twoinc-company-search-tile-wrapper");
+    if (!$wrapper.length) {
+      $wrapper = jQuery('<div id="twoinc-company-search-tile-wrapper"></div>');
+      $slot.append($wrapper);
+    } else if ($wrapper.parent()[0] !== $slot[0]) {
+      $slot.append($wrapper);
+    }
+
+    // Address-form order: name/search control, hidden org-number field, the
+    // read-only number label underneath it. `.appendTo()` on an
+    // already-attached node MOVES it (never clones), same as
+    // `getCompanySummaryNode()` relies on elsewhere in this file.
+    jQuery("#billing_company_display_field, #billing_company_field, #company_id_field").appendTo(
+      $wrapper
+    );
+    twoincDomHelper.getCompanySummaryNode().appendTo($wrapper);
+
+    $slot.removeClass("hidden");
+  },
+
   /**
    * Deselect payment method and select the first available one
    */
@@ -1635,6 +1721,24 @@ let twoincDomHelper = {
   },
 
   /**
+   * The captured company as the intent-message sentences want it
+   * (TWO-25326 §7.3): "<name> (<number>)", or bare <name> when there is no
+   * number (manual entry, which clears #company_id). Never "<name> ()" —
+   * an absent number is genuinely absent, not pending.
+   *
+   * This is what used to build the now-removed `.twoinc-company-tile-label`
+   * text. It has the same job now, just substituted into the intent
+   * sentences' data-company-template token instead of a standalone element.
+   *
+   * @param {string} name already blank-collapsed
+   * @param {string} number already blank-collapsed
+   * @returns {string}
+   */
+  getCompanyLabelText: function (name, number) {
+    return name && number ? name + " (" + number + ")" : name;
+  },
+
+  /**
    * Toggle payment text in subtitle and description
    */
   togglePaySubtitleDesc: function (action, errSelector) {
@@ -1648,69 +1752,57 @@ let twoincDomHelper = {
         jQuery(".twoinc-pay-box.twoinc-loader").removeClass("hidden");
       } else if (action === "intent-approved") {
         // The notice ships the no-company sentence as its text and the
-        // company-name variant as a template on data-company-template
-        // (only the browser knows the buyer's company). Substitute here,
+        // company variant as a template on data-company-template (only the
+        // browser knows the buyer's captured company). Substitute here,
         // always from the template, so a later company change re-renders
         // and an emptied company falls back to the served sentence.
         // Suppressed by the brand => the div is absent and every call
         // below is a no-op on an empty jQuery set.
+        //
+        // TWO-25326 §7.3: the token now stands for the WHOLE "<name>
+        // (<number>)" chunk, not the bare name — this is what replaces the
+        // separate `.twoinc-company-tile-label` element.
         let intentBox = jQuery(".twoinc-pay-box.twoinc-intent-approved");
         if (intentBox.data("twoincDefaultText") === undefined) {
           intentBox.data("twoincDefaultText", intentBox.text());
         }
         let companyTemplate = intentBox.attr("data-company-template");
-        let companyName = (twoincDomHelper.getCompanyName() || "").trim();
-        if (companyTemplate && companyName) {
-          intentBox.text(companyTemplate.replace("{company}", companyName));
+        let captured = twoincDomHelper.readCapturedCompany();
+        let companyText = twoincDomHelper.getCompanyLabelText(
+          twoincUtilHelper.blankToEmpty(captured.company_name),
+          twoincUtilHelper.blankToEmpty(captured.organization_number)
+        );
+        if (companyTemplate && companyText) {
+          intentBox.text(companyTemplate.replace("{company}", companyText));
         } else {
           intentBox.text(intentBox.data("twoincDefaultText"));
         }
         intentBox.removeClass("hidden");
       } else if (action === "errored") {
-        jQuery(".twoinc-pay-box" + errSelector).removeClass("hidden");
+        // TWO-25326 §7.3: the "not available" box carries the same
+        // data-company-template/token mechanism as the approved notice
+        // above, but ONLY on `.twoinc-err-payment-default` — the phone-number
+        // box is a fixed, unrelated message and never gets one.
+        let $errBox = jQuery(".twoinc-pay-box" + errSelector);
+        if (errSelector === ".twoinc-err-payment-default") {
+          if ($errBox.data("twoincDefaultText") === undefined) {
+            $errBox.data("twoincDefaultText", $errBox.text());
+          }
+          let declinedTemplate = $errBox.attr("data-company-template");
+          let captured = twoincDomHelper.readCapturedCompany();
+          let companyText = twoincDomHelper.getCompanyLabelText(
+            twoincUtilHelper.blankToEmpty(captured.company_name),
+            twoincUtilHelper.blankToEmpty(captured.organization_number)
+          );
+          if (declinedTemplate && companyText) {
+            $errBox.text(declinedTemplate.replace("{company}", companyText));
+          } else {
+            $errBox.text($errBox.data("twoincDefaultText"));
+          }
+        }
+        $errBox.removeClass("hidden");
       }
     }
-
-    // The tile's captured-company label tracks the intent notice's
-    // visibility (TWO-25326 §7, revised 2026-08-03), and this method is the
-    // ONLY thing in the plugin that changes that visibility — the sweep on
-    // the first line plus the three branches above are the whole set. So the
-    // re-sync belongs here, at the end, AFTER the notice's own class has
-    // settled: `renderCompanyTileLabel()` reads that class back rather than
-    // recomputing the action, which is what keeps the two from drifting.
-    //
-    // Called unconditionally, including for the actions that show nothing:
-    // hiding the notice must hide the label in the same turn, and the early
-    // `addClass` sweep means every non-intent action is a hide.
-    twoincDomHelper.renderCompanyTileLabel();
-  },
-
-  /**
-   * Whether the payment tile's intent-approved notice is on screen right now
-   * (TWO-25326 §7, revised 2026-08-03).
-   *
-   * The single source of truth for the captured-company label's visibility.
-   * Deliberately reads the notice ELEMENT's own state rather than re-deriving
-   * it from the intent action: the requirement is that the label shows
-   * exactly when the notice shows, and any second copy of the condition — however
-   * faithful when written — is a thing that can come to disagree.
-   *
-   * Both halves are load-bearing, and they cover the two independent ways the
-   * notice can be off screen:
-   *   - `.length` — the brand switched the notice off, so
-   *     get_intent_approved_notice() returned '' and the div was never
-   *     rendered at all (`intent_approved_notice_enabled: false`). An absent
-   *     notice is a hidden notice, so the label stays hidden forever on that
-   *     brand;
-   *   - `.hidden` — the notice exists but the checkout is not in the
-   *     intent-approved state (pre-intent, checking, errored, or a
-   *     re-render), which is the runtime case.
-   *
-   * @returns {boolean}
-   */
-  isIntentNoticeVisible: function () {
-    const $notice = jQuery(".twoinc-pay-box.twoinc-intent-approved");
-    return $notice.length > 0 && !$notice.hasClass("hidden");
   },
 
   /**
@@ -1846,8 +1938,10 @@ let twoincDomHelper = {
    * and this number label. The number stays because §5 requires exactly this
    * — the number as a plain right-aligned text label immediately below the
    * name field, never as an input — and this element is the only thing on WC
-   * providing it. The name moved to the payment tile instead, where §7 wants
-   * it; see `renderCompanyTileLabel`.
+   * providing it. The name itself no longer renders anywhere in the tile
+   * either, as a standalone label (TWO-25326 §7.2/§7.3, ruling 2026-08-03):
+   * it is substituted directly into the intent-message sentence instead —
+   * see `getCompanyLabelText` and its callers in `togglePaySubtitleDesc`.
    *
    * Anchored after the company-id field's enclosing `.twoinc-inp-container`
    * where there is one, NOT inside it. The pay-for-order page wraps every
@@ -1956,10 +2050,10 @@ let twoincDomHelper = {
     const name = twoincUtilHelper.blankToEmpty(data.company_name);
     const number = twoincUtilHelper.blankToEmpty(data.organization_number);
 
-    // Rendered from the same resolved pair, in the same call, so the tile and
-    // the address area can never disagree about what was captured
-    // (TWO-25326 §7).
-    twoincDomHelper.renderCompanyTileLabel(name, number);
+    // The tile no longer carries a separate company label to keep in sync
+    // here (TWO-25326 §7.2/§7.3, ruling 2026-08-03: `.twoinc-company-tile-label`
+    // is removed — the company now lives inside the intent-message sentences
+    // themselves, substituted in togglePaySubtitleDesc()).
 
     const $node = twoincDomHelper.getCompanySummaryNode();
     if (!$node.length) return;
@@ -1980,73 +2074,6 @@ let twoincDomHelper = {
       number && twoincDomHelper.isTwoincVisible() && twoincDomHelper.isTwoincSelected()
     );
     $node.toggleClass("hidden", !visible);
-  },
-
-  /** DOM class of the payment tile's captured-company label (TWO-25326 §7). */
-  companyTileLabelClass: "twoinc-company-tile-label",
-
-  /**
-   * Render the captured company inside the payment tile (TWO-25326 §7).
-   *
-   * The ticket asks for `<name> (<number>)` as a text label in the tile,
-   * "between the chips and the intent message (if rendered) or else the
-   * optional fields". On WooCommerce the second half of that has no referent:
-   * the optional fields (invoice email, project, department) are checkout
-   * form fields in the billing column, not tile content, so there is nothing
-   * in the tile for the label to sit above if the intent message is switched
-   * off. The container is therefore server-rendered as the last element of
-   * the tile block before the intent loader/notice, which satisfies the
-   * position in both cases — see the block comment on that markup in
-   * WC_Twoinc.php.
-   *
-   * Nothing here creates DOM. The container is server-rendered, so a brand
-   * overlay that removes or repositions it in its own template simply gets no
-   * label, rather than having one injected back underneath it.
-   *
-   * Falls back to the bare name when the capture carries no number, which is
-   * manual entry. `<name> ()` would read as a rendering fault, and the number
-   * is genuinely absent rather than pending.
-   *
-   * @param {string} name already blank-collapsed
-   * @param {string} number already blank-collapsed
-   * @returns {void}
-   */
-  renderCompanyTileLabel: function (name, number) {
-    const $label = jQuery("." + twoincDomHelper.companyTileLabelClass);
-    if (!$label.length) return;
-
-    // Both arguments omitted => read the live inputs, the same fallback
-    // `renderCompanySummary` uses. This is the shape `togglePaySubtitleDesc`
-    // calls: it knows the notice's visibility changed but holds no company
-    // values of its own, and re-reading is what lets it re-sync the label
-    // without the capture sites having to notify it.
-    if (name === undefined && number === undefined) {
-      const captured = twoincDomHelper.readCapturedCompany();
-      name = twoincUtilHelper.blankToEmpty(captured.company_name);
-      number = twoincUtilHelper.blankToEmpty(captured.organization_number);
-    }
-
-    const text = name && number ? name + " (" + number + ")" : name;
-
-    $label.text(text);
-
-    // Visibility is the intent notice's, not "is a company captured"
-    // (TWO-25326 §7, revised 2026-08-03: the label is no longer wanted
-    // shown unconditionally once a company is known). `isIntentNoticeVisible()`
-    // reads the notice element back, so this is the same gate the notice
-    // itself passed through rather than a parallel re-derivation of it.
-    //
-    // Note what is NOT and-ed in here: `text`. A captured company is no
-    // longer part of the condition, so an intent-approved checkout whose
-    // company is unknown — a real state, which is precisely why the notice
-    // ships a no-company variant of its sentence — leaves this element
-    // unhidden with nothing in it. The empty case is suppressed in CSS
-    // instead (`.twoinc-company-tile-label:empty`), because an empty label
-    // with the rule's 12px margins would otherwise push the notice down by
-    // 24px for no visible reason. Keeping that out of the JS is what makes
-    // "shown exactly when the notice is shown" literally true of this line,
-    // with the no-content case handled as the rendering detail it is.
-    $label.toggleClass("hidden", !twoincDomHelper.isIntentNoticeVisible());
   },
 
   /**

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1875,15 +1875,17 @@ let twoincDomHelper = {
           twoincUtilHelper.blankToEmpty(captured.organization_number)
         );
         if (companyTemplate && companyText) {
-          intentBox.text(companyTemplate.replace("{company}", function () {
-            // Function replacer (Vader, round 1 review): a string replacer
-            // honours special patterns like `$&`/`$$` inside the SECOND
-            // argument, so a company literally named "Acme $& Corp" or
-            // "50% Ltd $$" would come out mangled with a plain-string
-            // replace. A function replacer passes companyText through
-            // literally, no matter what it contains.
-            return companyText;
-          }));
+          intentBox.text(
+            companyTemplate.replace("{company}", function () {
+              // Function replacer (Vader, round 1 review): a string replacer
+              // honours special patterns like `$&`/`$$` inside the SECOND
+              // argument, so a company literally named "Acme $& Corp" or
+              // "50% Ltd $$" would come out mangled with a plain-string
+              // replace. A function replacer passes companyText through
+              // literally, no matter what it contains.
+              return companyText;
+            })
+          );
         } else {
           intentBox.text(intentBox.data("twoincDefaultText"));
         }
@@ -1905,9 +1907,11 @@ let twoincDomHelper = {
             twoincUtilHelper.blankToEmpty(captured.organization_number)
           );
           if (declinedTemplate && companyText) {
-            $errBox.text(declinedTemplate.replace("{company}", function () {
-              return companyText;
-            }));
+            $errBox.text(
+              declinedTemplate.replace("{company}", function () {
+                return companyText;
+              })
+            );
           } else {
             $errBox.text($errBox.data("twoincDefaultText"));
           }

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -885,6 +885,7 @@ if (!class_exists('WC_Twoinc')) {
                 // dropped from this variant per the ruling's literal wording;
                 // it stays in the no-company fallback below, which the
                 // ruling does not cover.
+                /* translators: %1$s: brand product name (e.g. "Two"); %2$s: the buyer's captured company name and number, substituted client-side — reorderable, do not assume %1$s precedes %2$s in every locale */
                 $template = __('This order by %2$s is likely to be accepted by %1$s', 'twoinc-payment-gateway');
             }
 
@@ -932,6 +933,7 @@ if (!class_exists('WC_Twoinc')) {
             if (!is_string($template) || trim($template) === '') {
                 // TWO-25326 §7.3 literal wording: "<product> is not available
                 // for this order by <name> (<number>)".
+                /* translators: %1$s: brand product name (e.g. "Two"); %2$s: the buyer's captured company name and number, substituted client-side */
                 $template = __('%1$s is not available for this order by %2$s', 'twoinc-payment-gateway');
             }
 

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -273,6 +273,25 @@ if (!class_exists('WC_Twoinc')) {
         }
 
         /**
+         * Where the ONE company-search control (§1-§4) renders (TWO-25326
+         * §7.1). Never "on vs off" — the control always exists; this only
+         * decides its location:
+         *   - 'address_area' (default): renders in the billing address form,
+         *     exactly as before this setting existed. The payment tile then
+         *     shows only the intent message (§7.2/§7.3).
+         *   - 'payment_tile': the SAME control (fields, JS, dropdown) is
+         *     relocated into the payment tile instead — see
+         *     twoincDomHelper.syncCompanySearchTileLocation() in twoinc.js.
+         *
+         * @return string 'address_area' or 'payment_tile'
+         */
+        public function get_company_search_location(): string
+        {
+            $location = $this->get_option('company_search_location');
+            return $location === 'payment_tile' ? 'payment_tile' : 'address_area';
+        }
+
+        /**
          * The decoded GET /v1/merchant/{id} record, fetched at most once
          * per PHP request — the memo covers failures too, so a hanging API
          * costs a single capped stall per request instead of one per
@@ -831,12 +850,23 @@ if (!class_exists('WC_Twoinc')) {
          *     the company-name variant's sprintf template.
          *
          * Two placeholders, in this order: %1$s is the brand product name,
-         * substituted here; %2$s is the buyer's company name, which only
+         * substituted here; %2$s is the buyer's captured company, which only
          * the browser knows, so it is emitted as a token on
-         * data-company-template for the checkout JS to substitute at
-         * unhide time. The div's own text is the no-company variant, so a
-         * buyer whose company is unknown (or whose JS never runs) still
-         * reads a complete sentence.
+         * data-company-template for the checkout JS to substitute at unhide
+         * time. As of TWO-25326 §7.3 that token stands for the WHOLE
+         * "<name> (<number>)" chunk (or bare name with no number, e.g. manual
+         * entry) — twoinc.js builds that string the same way the old,
+         * now-removed `.twoinc-company-tile-label` used to, and substitutes
+         * it wherever this token lands, so the tile no longer needs a
+         * standalone label element to carry the company at all. The div's
+         * own text is the no-company variant, so a buyer whose company is
+         * unknown (or whose JS never runs) still reads a complete sentence.
+         *
+         * A brand's own override template still works unchanged: it keeps
+         * its own wording and its own %1$s product name, and only needs to
+         * place %2$s somewhere in its sentence to get the same company
+         * substitution (§7.4) — nothing here special-cases the default copy
+         * over a brand's.
          *
          * @param bool $notice_enabled resolved once per render by the caller
          *                             (see get_intent_loader_html()).
@@ -849,10 +879,13 @@ if (!class_exists('WC_Twoinc')) {
 
             $template = WC_Twoinc_Brand::get('intent_approved_notice');
             if (!is_string($template) || trim($template) === '') {
-                $template = __(
-                    'Your invoice with %1$s is likely to be accepted for %2$s, subject to additional checks.',
-                    'twoinc-payment-gateway'
-                );
+                // TWO-25326 §7.3: the company (name + number, formatted by
+                // twoinc.js) sits directly in the sentence now, replacing the
+                // standalone tile label. "subject to additional checks" is
+                // dropped from this variant per the ruling's literal wording;
+                // it stays in the no-company fallback below, which the
+                // ruling does not cover.
+                $template = __('This order by %2$s is likely to be accepted by %1$s', 'twoinc-payment-gateway');
             }
 
             $product_name = WC_Twoinc_Brand::get('product_name');
@@ -871,6 +904,39 @@ if (!class_exists('WC_Twoinc')) {
                 esc_attr($with_company),
                 esc_html($without_company)
             );
+        }
+
+        /**
+         * Buyer-facing notice shown when order intent is NOT approved (or no
+         * intent check has run) — the `.twoinc-err-payment-default` block
+         * (TWO-25326 §7.3, added 2026-08-03).
+         *
+         * Unlike the approved notice above, this box is NEVER gated on
+         * 'intent_approved_notice_enabled' (TWO-25224: "a merchant who wants
+         * no reassurance still needs failures surfaced") — it always renders,
+         * brand suppression or not, so its default text argument is used
+         * directly as a fallback rather than routed through an early return.
+         *
+         * Same token mechanism as get_intent_approved_notice(): %1$s is the
+         * brand product name, %2$s is the company token twoinc.js substitutes
+         * with the same "<name> (<number>)" (or bare name) string. A brand
+         * may override the template via 'intent_declined_notice', mirroring
+         * 'intent_approved_notice' — absent/empty means the platform default.
+         *
+         * @return string sprintf template with %1$s and the company TOKEN,
+         *                 ready for esc_attr() into data-company-template.
+         */
+        private function get_intent_declined_notice_template(): string
+        {
+            $template = WC_Twoinc_Brand::get('intent_declined_notice');
+            if (!is_string($template) || trim($template) === '') {
+                // TWO-25326 §7.3 literal wording: "<product> is not available
+                // for this order by <name> (<number>)".
+                $template = __('%1$s is not available for this order by %2$s', 'twoinc-payment-gateway');
+            }
+
+            $product_name = WC_Twoinc_Brand::get('product_name');
+            return sprintf($template, $product_name, self::INTENT_NOTICE_COMPANY_TOKEN);
         }
 
         /**
@@ -917,40 +983,24 @@ if (!class_exists('WC_Twoinc')) {
             // would report an invalid brand value twice per render.
             $notice_enabled = $this->is_intent_approved_notice_enabled();
 
-            // The captured company, as `<name> (<number>)` (TWO-25326 §7).
+            // The standalone `<name> (<number>)` tile label is REMOVED
+            // (TWO-25326 §7.2/§7.3, ruling 2026-08-03). The company now lives
+            // only inside the intent-approved/declined sentences themselves
+            // (get_intent_approved_notice() / get_intent_declined_notice_template()
+            // above), never as a separate element — see those methods' doc
+            // comments for the token mechanism that replaces it.
             //
-            // Position is the ticket's, read literally: "between the chips and
-            // the intent message (if rendered) or else the optional fields".
-            // On WooCommerce the fallback half of that has no referent — the
-            // optional fields (invoice email, project, department) are billing
-            // form fields, not tile content — so the only anchor that exists
-            // here is the intent message, and this sits immediately before the
-            // intent loader/notice pair.
-            //
-            // Empty and `hidden` on render, filled by renderCompanyTileLabel()
-            // in twoinc.js. Server-side it cannot be filled at all: the
-            // captured company is chosen client-side after this markup is
-            // generated, and this same block is re-rendered by every
-            // `update_checkout` regardless of whether a company was picked.
-            //
-            // Suppressed with the notice (TWO-25326 §7, revised 2026-08-03).
-            // The label's visibility now mirrors the intent-approved notice's
-            // exactly, so on a brand with 'intent_approved_notice_enabled'
-            // false there is no state in which this container can ever be
-            // shown — shipping it anyway would be markup that only ever sits
-            // empty and hidden. This is the same reasoning TWO-25224 already
-            // applied to the intent loader, and it puts the label inside the
-            // one reassurance pass the notice switch governs. twoinc.js does
-            // not rely on the suppression (its gate reads the notice element,
-            // and an absent notice reads as hidden) — the two agree because
-            // they are the same rule, which is the point.
-            //
-            // A <div>, not a <p>: some themes give `.payment_box p` its own
-            // margins, and this must not pick up spacing the chips and notices
-            // around it do not have.
-            $company_label = $notice_enabled
-                ? '<div class="twoinc-company-tile-label hidden"></div>'
-                : '';
+            // The tile-location slot below is new (§7.1): empty and hidden by
+            // default (setting = 'address_area', the unchanged behaviour).
+            // When the merchant sets 'company_search_location' to
+            // 'payment_tile', twoinc.js relocates the SAME company-search
+            // control (the real billing_company/billing_company_display/
+            // company_id fields, moved, not cloned) into this slot — see
+            // twoincDomHelper.syncCompanySearchTileLocation(). Always rendered
+            // (a hidden empty div is cheap) so the JS never has to special-case
+            // "the slot doesn't exist yet" against "the setting is off".
+            $company_search_tile_slot = '<div class="twoinc-company-search-tile-slot hidden"></div>';
+
             return sprintf(
                 '<div>
                     %s
@@ -960,13 +1010,14 @@ if (!class_exists('WC_Twoinc')) {
                     %s
                     %s
                     %s
-                    <div class="twoinc-pay-box twoinc-err-payment-default hidden">%s</div>
+                    <div class="twoinc-pay-box twoinc-err-payment-default hidden" data-company-template="%s">%s</div>
                     <div class="twoinc-pay-box twoinc-err-phone-number hidden">%s</div>
                 </div>',
                 $term_input,
-                $company_label,
+                $company_search_tile_slot,
                 $this->get_intent_loader_html($notice_enabled),
                 $this->get_intent_approved_notice($notice_enabled),
+                esc_attr($this->get_intent_declined_notice_template()),
                 sprintf(__('Invoice purchase with %s is not available for this order.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')),
                 __('Phone number is invalid.', 'twoinc-payment-gateway')
             );
@@ -3884,6 +3935,17 @@ if (!class_exists('WC_Twoinc')) {
                     'label'       => ' ',
                     'type'        => 'checkbox',
                     'default'     => 'yes'
+                ],
+                'company_search_location' => [
+                    'title'       => __('Company search location', 'twoinc-payment-gateway'),
+                    'description' => __('Where the company search control renders: in the address area (as part of the billing form), or inside the Two payment tile itself. Either way it is the same control — this only decides where it appears.', 'twoinc-payment-gateway'),
+                    'desc_tip'    => true,
+                    'type'        => 'select',
+                    'options'     => [
+                        'address_area' => __('Address area', 'twoinc-payment-gateway'),
+                        'payment_tile' => __('Payment tile', 'twoinc-payment-gateway'),
+                    ],
+                    'default'     => 'address_area'
                 ],
                 // No sole-trader section: sole trader checkout is gated on the
                 // registry's answer for the billing country alone, with no

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -390,6 +390,8 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                 'twoinc_checkout_host' => $this->wc_twoinc->get_twoinc_checkout_host(),
                 'enable_company_search' => $this->wc_twoinc->get_enable_company_search(),
                 'enable_company_search_for_others' => $this->wc_twoinc->get_option('enable_company_search_for_others'),
+                // TWO-25326 §7.1: where the one company-search control renders.
+                'company_search_location' => $this->wc_twoinc->get_company_search_location(),
                 'enable_address_lookup' => $this->wc_twoinc->get_option('enable_address_lookup'),
                 'enable_order_intent' => $this->wc_twoinc->get_option('enable_order_intent'),
                 'display_tooltips' => $this->wc_twoinc->get_option('display_tooltips'),

--- a/tests/js/company-search-tile-location.test.js
+++ b/tests/js/company-search-tile-location.test.js
@@ -114,9 +114,7 @@ describe("company-search tile location (TWO-25326 §7.1)", () => {
       // whole document, and the address-area wrapper it used to sit in is
       // now empty.
       expect($("#billing_company_display_field").length).toBe(1);
-      expect($(".woocommerce-billing-fields__field-wrapper #billing_company_field").length).toBe(
-        0
-      );
+      expect($(".woocommerce-billing-fields__field-wrapper #billing_company_field").length).toBe(0);
     });
 
     test("is idempotent — a second call does not physically re-detach nodes that are already in place", () => {
@@ -158,9 +156,9 @@ describe("company-search tile location (TWO-25326 §7.1)", () => {
 
     test("survives a WooCommerce-style fragment replace of .woocommerce-checkout-payment", () => {
       dom.syncCompanySearchTileLocation();
-      expect($("#billing_company_display_field").closest(".twoinc-company-search-tile-slot").length).toBe(
-        1
-      );
+      expect(
+        $("#billing_company_display_field").closest(".twoinc-company-search-tile-slot").length
+      ).toBe(1);
 
       // The bug this whole mechanism exists to close: WooCommerce's
       // `update_checkout` trigger fires synchronously BEFORE the AJAX call
@@ -270,9 +268,9 @@ describe("company-search tile location (TWO-25326 §7.1)", () => {
 
       dom.syncCompanySearchTileLocation();
 
-      expect($("#billing_company_display_field").closest(".twoinc-company-search-tile-slot").length).toBe(
-        0
-      );
+      expect(
+        $("#billing_company_display_field").closest(".twoinc-company-search-tile-slot").length
+      ).toBe(0);
       expect(tileSlot().hasClass("hidden")).toBe(true);
       expect(appendToSpy).not.toHaveBeenCalled();
       appendToSpy.mockRestore();

--- a/tests/js/company-search-tile-location.test.js
+++ b/tests/js/company-search-tile-location.test.js
@@ -1,0 +1,284 @@
+/**
+ * TWO-25326 §7.1, ruling 2026-08-03 (hardened after adversarial review the
+ * same day). The `company_search_location` admin setting relocates the ONE
+ * company-search control between the address area and the payment tile.
+ *
+ * The round-1 adversarial review (Leia, Han, Yoda, Vader — all four,
+ * independently) found the same real bug in the first version of this
+ * feature: the relocated fields were re-parented directly into
+ * `.twoinc-company-search-tile-slot`, which lives inside
+ * `.woocommerce-checkout-payment` — the exact fragment WooCommerce's
+ * `update_order_review` AJAX replaces wholesale (`replaceWith`) on a
+ * shipping-method change, a coupon apply, a quantity change, not only a
+ * payment-method or country switch. A live `<select>`/`<input>` sitting
+ * inside that fragment at the moment of a fragment swap is destroyed
+ * outright, with nothing to resurrect it.
+ *
+ * The fix pairs `detachCompanySearchTileWrapperToSafety()` (bound to
+ * WooCommerce's own PRESENT-tense `update_checkout` trigger — fired
+ * synchronously, before the AJAX call that eventually replaces the
+ * fragment) with `syncCompanySearchTileLocation()` (bound to the
+ * PAST-tense `updated_checkout`, after the fragment is already back). This
+ * suite drives that pair directly, simulating the fragment-replace with a
+ * real DOM `replaceWith()` on `.twoinc-company-search-tile-slot`'s parent —
+ * the same operation WooCommerce performs — and asserts the company fields
+ * survive it.
+ */
+
+"use strict";
+
+const harness = require("./wc-harness");
+
+const GATEWAY_ID = "woocommerce-gateway-tillit";
+
+describe("company-search tile location (TWO-25326 §7.1)", () => {
+  let ctx;
+  let $;
+  let dom;
+
+  beforeEach(() => {
+    harness.buildCheckoutForm();
+  });
+
+  afterEach(() => {
+    if ($) harness.releaseWidgets($);
+    document.body.innerHTML = "";
+  });
+
+  /**
+   * Append the minimal payment-tile markup `get_pay_box_description()`
+   * server-renders: the tile slot, hidden and empty, inside
+   * `.woocommerce-checkout-payment` — the exact WooCommerce container the
+   * AJAX fragment-replace bug is about. Wrapped in the real checkout form so
+   * `getCompanySearchTileHoldingPen()` finds a real `form[name="checkout"]`.
+   *
+   * @returns {void}
+   */
+  function buildTileSlot() {
+    $('form[name="checkout"]').append(
+      '<div class="woocommerce-checkout-payment">' +
+        '<ul class="wc_payment_methods payment_methods methods">' +
+        '<li class="wc_payment_method payment_method_' +
+        GATEWAY_ID +
+        '">' +
+        '<input type="radio" name="payment_method" value="' +
+        GATEWAY_ID +
+        '" checked />' +
+        '<div class="payment_box payment_method_' +
+        GATEWAY_ID +
+        '">' +
+        '<div class="twoinc-company-search-tile-slot hidden"></div>' +
+        "</div>" +
+        "</li>" +
+        "</ul>" +
+        "</div>"
+    );
+  }
+
+  /** @returns {Object} the current `.twoinc-company-search-tile-slot` */
+  function tileSlot() {
+    return $(".twoinc-company-search-tile-slot");
+  }
+
+  /** @returns {Object} the current `.woocommerce-checkout-payment` container */
+  function paymentFragment() {
+    return $(".woocommerce-checkout-payment");
+  }
+
+  describe("payment_tile setting", () => {
+    beforeEach(() => {
+      ctx = harness.loadTwoinc({
+        gateway_id: GATEWAY_ID,
+        enable_company_search: "yes",
+        company_search_location: "payment_tile",
+        text: {}
+      });
+      $ = ctx.$;
+      dom = ctx.dom;
+      buildTileSlot();
+    });
+
+    test("moves the real fields into the tile slot, not a clone", () => {
+      dom.syncCompanySearchTileLocation();
+
+      const $display = $("#billing_company_display_field");
+      expect($display.length).toBe(1);
+      expect($display.closest(".twoinc-company-search-tile-slot").length).toBe(1);
+      expect($("#billing_company_field").closest(".twoinc-company-search-tile-slot").length).toBe(
+        1
+      );
+      expect($("#company_id_field").closest(".twoinc-company-search-tile-slot").length).toBe(1);
+      expect(tileSlot().hasClass("hidden")).toBe(false);
+
+      // Not a clone: exactly one #billing_company_display_field in the
+      // whole document, and the address-area wrapper it used to sit in is
+      // now empty.
+      expect($("#billing_company_display_field").length).toBe(1);
+      expect($(".woocommerce-billing-fields__field-wrapper #billing_company_field").length).toBe(
+        0
+      );
+    });
+
+    test("is idempotent — a second call does not physically re-detach nodes that are already in place", () => {
+      dom.syncCompanySearchTileLocation();
+
+      const appendToSpy = jest.spyOn($.fn, "appendTo");
+      dom.syncCompanySearchTileLocation();
+
+      expect(appendToSpy).not.toHaveBeenCalled();
+      appendToSpy.mockRestore();
+    });
+
+    test("survives a WooCommerce-style fragment replace of .woocommerce-checkout-payment", () => {
+      dom.syncCompanySearchTileLocation();
+      expect($("#billing_company_display_field").closest(".twoinc-company-search-tile-slot").length).toBe(
+        1
+      );
+
+      // The bug this whole mechanism exists to close: WooCommerce's
+      // `update_checkout` trigger fires synchronously BEFORE the AJAX call
+      // that eventually calls `.replaceWith()` on this fragment.
+      dom.detachCompanySearchTileWrapperToSafety();
+
+      // Simulate WooCommerce's own AJAX success handler: wholesale-replace
+      // the payment fragment with a FRESH server render (an empty tile slot,
+      // no company fields — exactly what `get_pay_box_description()`
+      // produces on every render).
+      paymentFragment().replaceWith(
+        '<div class="woocommerce-checkout-payment">' +
+          '<ul class="wc_payment_methods payment_methods methods">' +
+          '<li class="wc_payment_method payment_method_' +
+          GATEWAY_ID +
+          '">' +
+          '<input type="radio" name="payment_method" value="' +
+          GATEWAY_ID +
+          '" checked />' +
+          '<div class="payment_box payment_method_' +
+          GATEWAY_ID +
+          '">' +
+          '<div class="twoinc-company-search-tile-slot hidden"></div>' +
+          "</div>" +
+          "</li>" +
+          "</ul>" +
+          "</div>"
+      );
+
+      // The real company fields must have survived the replace — held safely
+      // in the holding pen, not destroyed along with the old fragment.
+      expect($("#billing_company_display_field").length).toBe(1);
+      expect($("#billing_company").val).toBeDefined();
+
+      // WooCommerce's own past-tense trigger, fired after the fragments are
+      // back — this is what moves the surviving fields back into the FRESH
+      // slot.
+      dom.syncCompanySearchTileLocation();
+
+      expect(
+        $("#billing_company_display_field").closest(".twoinc-company-search-tile-slot").length
+      ).toBe(1);
+      expect(tileSlot().hasClass("hidden")).toBe(false);
+    });
+
+    test("a captured company value survives the fragment replace", () => {
+      dom.syncCompanySearchTileLocation();
+      $("#billing_company").val("ACME Widgets Ltd");
+      $("#company_id").val("12345678");
+
+      dom.detachCompanySearchTileWrapperToSafety();
+      paymentFragment().replaceWith(
+        '<div class="woocommerce-checkout-payment">' +
+          '<ul class="wc_payment_methods payment_methods methods">' +
+          '<li class="wc_payment_method payment_method_' +
+          GATEWAY_ID +
+          '">' +
+          '<input type="radio" name="payment_method" value="' +
+          GATEWAY_ID +
+          '" checked />' +
+          '<div class="payment_box payment_method_' +
+          GATEWAY_ID +
+          '">' +
+          '<div class="twoinc-company-search-tile-slot hidden"></div>' +
+          "</div>" +
+          "</li>" +
+          "</ul>" +
+          "</div>"
+      );
+      dom.syncCompanySearchTileLocation();
+
+      expect($("#billing_company").val()).toBe("ACME Widgets Ltd");
+      expect($("#company_id").val()).toBe("12345678");
+    });
+
+    test("detach-to-safety is a no-op when nothing has been relocated yet", () => {
+      // Never called syncCompanySearchTileLocation() — no wrapper exists.
+      expect(() => dom.detachCompanySearchTileWrapperToSafety()).not.toThrow();
+      expect($("#twoinc-company-search-tile-holding-pen").length).toBe(0);
+    });
+
+    test("the holding pen lives inside the checkout form, not detached from it", () => {
+      dom.syncCompanySearchTileLocation();
+      dom.detachCompanySearchTileWrapperToSafety();
+
+      const $pen = $("#twoinc-company-search-tile-holding-pen");
+      expect($pen.length).toBe(1);
+      expect($pen.closest('form[name="checkout"]').length).toBe(1);
+    });
+  });
+
+  describe("address_area setting (default)", () => {
+    beforeEach(() => {
+      ctx = harness.loadTwoinc({
+        gateway_id: GATEWAY_ID,
+        enable_company_search: "yes",
+        company_search_location: "address_area",
+        text: {}
+      });
+      $ = ctx.$;
+      dom = ctx.dom;
+      buildTileSlot();
+    });
+
+    test("is a no-op — the control never moves, the slot stays hidden", () => {
+      const appendToSpy = jest.spyOn($.fn, "appendTo");
+
+      dom.syncCompanySearchTileLocation();
+
+      expect($("#billing_company_display_field").closest(".twoinc-company-search-tile-slot").length).toBe(
+        0
+      );
+      expect(tileSlot().hasClass("hidden")).toBe(true);
+      expect(appendToSpy).not.toHaveBeenCalled();
+      appendToSpy.mockRestore();
+    });
+
+    test("detach-to-safety is also a no-op on this setting", () => {
+      const appendToSpy = jest.spyOn($.fn, "appendTo");
+      dom.detachCompanySearchTileWrapperToSafety();
+      expect(appendToSpy).not.toHaveBeenCalled();
+      appendToSpy.mockRestore();
+    });
+  });
+
+  describe("no gateway/tile present yet", () => {
+    beforeEach(() => {
+      ctx = harness.loadTwoinc({
+        gateway_id: GATEWAY_ID,
+        enable_company_search: "yes",
+        company_search_location: "payment_tile",
+        text: {}
+      });
+      $ = ctx.$;
+      dom = ctx.dom;
+      // Deliberately no buildTileSlot() — the Two gateway markup (and so the
+      // tile slot) has not rendered yet.
+    });
+
+    test("is a safe no-op, not a throw", () => {
+      expect(() => dom.syncCompanySearchTileLocation()).not.toThrow();
+      expect($("#billing_company_field").length).toBeGreaterThan(0);
+      expect($("#billing_company_field").closest(".twoinc-company-search-tile-slot").length).toBe(
+        0
+      );
+    });
+  });
+});

--- a/tests/js/company-search-tile-location.test.js
+++ b/tests/js/company-search-tile-location.test.js
@@ -129,6 +129,33 @@ describe("company-search tile location (TWO-25326 §7.1)", () => {
       appendToSpy.mockRestore();
     });
 
+    test("detach-to-safety is also idempotent — a second call in a row does not re-move an already-parked wrapper (round 2 review — Vader)", () => {
+      dom.syncCompanySearchTileLocation();
+
+      dom.detachCompanySearchTileWrapperToSafety();
+      const appendToSpy = jest.spyOn($.fn, "appendTo");
+      dom.detachCompanySearchTileWrapperToSafety();
+
+      expect(appendToSpy).not.toHaveBeenCalled();
+      appendToSpy.mockRestore();
+    });
+
+    test("a wrapper detached to the pen while the tile slot is absent stays parked there, not orphaned (round 2 review — Vader)", () => {
+      dom.syncCompanySearchTileLocation();
+      dom.detachCompanySearchTileWrapperToSafety();
+
+      // Simulate the slot genuinely not existing yet when `updated_checkout`
+      // fires — e.g. the gateway hasn't rendered on this particular refresh.
+      tileSlot().remove();
+
+      expect(() => dom.syncCompanySearchTileLocation()).not.toThrow();
+
+      const $wrapper = $("#twoinc-company-search-tile-wrapper");
+      expect($wrapper.length).toBe(1);
+      expect($wrapper.closest("#twoinc-company-search-tile-holding-pen").length).toBe(1);
+      expect($("#billing_company_display_field").length).toBe(1);
+    });
+
     test("survives a WooCommerce-style fragment replace of .woocommerce-checkout-payment", () => {
       dom.syncCompanySearchTileLocation();
       expect($("#billing_company_display_field").closest(".twoinc-company-search-tile-slot").length).toBe(

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -824,12 +824,14 @@ describe("read-only captured-company summary", () => {
     test("the phone-number error box is never substituted, even with a company captured", () => {
       // Only `.twoinc-err-payment-default` gets the company-template
       // treatment — the phone-number box is a fixed, unrelated message.
-      $(document.body).find(".payment_box").append(
-        '<div class="twoinc-pay-box twoinc-err-phone-number hidden" ' +
-          'data-company-template="{company}">' +
-          "Phone number is invalid." +
-          "</div>"
-      );
+      $(document.body)
+        .find(".payment_box")
+        .append(
+          '<div class="twoinc-pay-box twoinc-err-phone-number hidden" ' +
+            'data-company-template="{company}">' +
+            "Phone number is invalid." +
+            "</div>"
+        );
       captureCompanyOnly();
 
       dom.togglePaySubtitleDesc("errored", ".twoinc-err-phone-number");

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -69,34 +69,37 @@ describe("read-only captured-company summary", () => {
       '<input type="radio" name="payment_method" value="' + GATEWAY_ID + '" checked />'
     );
 
-    // The payment tile, minimally. The captured company now renders as a text
-    // label INSIDE the tile (TWO-25326 §7), from server-rendered markup that
-    // renderCompanyTileLabel() only fills — it never creates it — so without
-    // this every tile assertion below would be checking an element that does
-    // not exist. Deliberately outside the billing field wrapper, which is what
-    // the address-area assertions are scoped to.
+    // The payment tile, minimally. The captured company now renders INSIDE the
+    // intent-approved notice's own sentence (TWO-25326 §7.2/§7.3, ruling
+    // 2026-08-03) rather than in a separate label element — the
+    // now-removed `.twoinc-company-tile-label` — so without this notice
+    // element every tile-text assertion below would be checking an element
+    // that does not exist. Deliberately outside the billing field wrapper,
+    // which is what the address-area assertions are scoped to.
     //
-    // The intent-approved notice is part of that minimum now (TWO-25326 §7,
-    // revised 2026-08-03): the label's visibility mirrors this element's, so
-    // a tile without it is a tile whose label can never appear. Rendered with
-    // the server's own attributes — `hidden`, and the company template on
-    // data-company-template — because both are what the production markup
-    // ships and the gate reads the `hidden` class back.
+    // The template is deliberately just the bare token, and the fallback text
+    // a distinctive marker: this suite's tile assertions care about WHICH
+    // string is on screen (raw company text vs. the served fallback), not
+    // about a production sentence's wording — that belongs to
+    // WC_Twoinc.php's own tests.
     $(document.body).append(
       '<li class="wc_payment_method"><div class="payment_box">' +
-        '<div class="twoinc-company-tile-label hidden"></div>' +
         '<div class="twoinc-pay-box twoinc-intent-approved hidden" ' +
-        'data-company-template="Your invoice is likely to be accepted for {company}.">' +
-        "Your invoice is likely to be accepted." +
+        'data-company-template="{company}">' +
+        "NO_COMPANY_APPROVED" +
+        "</div>" +
+        '<div class="twoinc-pay-box twoinc-err-payment-default hidden" ' +
+        'data-company-template="{company}">' +
+        "NO_COMPANY_DECLINED" +
         "</div>" +
         "</div></li>"
     );
 
     // Intent approved is this suite's baseline state, because it is the only
-    // state in which the label is on screen at all. Tests about WHEN the label
-    // shows live in their own describe block below and drive the notice
-    // themselves; everything else here is about WHAT it renders, and would be
-    // asserting against a permanently hidden element without this.
+    // state in which the tile carries any company text at all. Tests about
+    // WHEN it shows live in their own describe block below and drive the
+    // notice themselves; everything else here is about WHAT it renders, and
+    // would be asserting against a permanently hidden element without this.
     approveIntent();
   }
 
@@ -120,41 +123,40 @@ describe("read-only captured-company summary", () => {
     return intentNotice().length > 0 && !intentNotice().hasClass("hidden");
   }
 
-  /** @returns {boolean} whether the tile's company label is on screen */
-  function tileLabelShown() {
-    return tileLabel().length > 0 && !tileLabel().hasClass("hidden");
-  }
-
   /** @returns {Object} the summary element, or an empty set */
   function summary() {
     return $("#" + dom.companySummaryId);
   }
 
-  /** @returns {Object} the payment tile's captured-company label */
-  function tileLabel() {
-    return $("." + dom.companyTileLabelClass);
-  }
-
-  /** @returns {string} the tile label's text, `<name> (<number>)` */
+  /**
+   * @returns {string} the intent-approved notice's own text, `<name>
+   *   (<number>)` when shown with a company substituted in — this is where
+   *   the now-removed `.twoinc-company-tile-label` used to render it
+   *   (TWO-25326 §7.2/§7.3).
+   */
   function tileText() {
-    return tileLabel().hasClass("hidden") ? "" : tileLabel().text();
+    return intentNotice().hasClass("hidden") ? "" : intentNotice().text();
   }
 
   /**
-   * The rendered company NAME.
+   * The captured company NAME, read straight off the posted field.
    *
-   * Reads the payment tile, not the address area. The name used to render in
-   * a `.twoinc-company-summary-name` span under the company field; TWO-25326
-   * §7 removed it from there — it was a second copy of what the company-name
-   * control immediately above already shows — and put it in the tile instead.
-   * The assertions that pre-date the move are still asking the right
-   * question, so they still call this; they just get their answer from where
-   * the name actually is now.
+   * Used to render in a `.twoinc-company-summary-name` span under the
+   * company field; TWO-25326 §7 removed it from there — it was a second copy
+   * of what the company-name control immediately above already shows. It then
+   * briefly lived in the payment tile's `.twoinc-company-tile-label`
+   * (PR #431) before that too was removed and replaced with the company
+   * embedded directly in the intent-message sentences (§7.2/§7.3, ruling
+   * 2026-08-03) — which only render it while an intent check has actually
+   * run. Reading `#billing_company` directly is what makes this assertion
+   * independent of that: it is the one thing every capture mode always
+   * writes, tile state notwithstanding, and it is also literally what
+   * WooCommerce posts — which is the property these tests care about.
    *
    * @returns {string}
    */
   function renderedName() {
-    return tileText().replace(/\s*\([^()]*\)\s*$/, "");
+    return $("#billing_company").val();
   }
 
   /** @returns {string} the rendered organisation number */
@@ -203,9 +205,9 @@ describe("read-only captured-company summary", () => {
 
       // Picking a company invalidates the intent that was approved for the
       // PREVIOUS one, so the pick itself takes the notice back off screen —
-      // and the label with it (TWO-25326 §7, revised 2026-08-03). That is the
+      // and its embedded company text with it (TWO-25326 §7.2/§7.3, ruling 2026-08-03). That is the
       // behaviour, not a harness quirk; re-approve to get back to the state
-      // this test is about, which is what the label renders once shown.
+      // this test is about, which is what the notice renders once shown.
       approveIntent();
 
       expect(isShown()).toBe(true);
@@ -340,8 +342,9 @@ describe("read-only captured-company summary", () => {
       // The organisation number is optional on a registry hit; the name is not.
       pickCompany("ACME Widgets Ltd", "");
 
-      // The pick invalidated the previous intent; re-approve so the tile label
-      // is on screen to be read (see the first test in this block).
+      // The pick invalidated the previous intent; re-approve so the tile's
+      // company text is on screen to be read (see the first test in this
+      // block).
       approveIntent();
 
       // No number means no number label at all — not an empty one taking up a
@@ -415,10 +418,14 @@ describe("read-only captured-company summary", () => {
       expect(idBody[1]).toMatch(/overflow-wrap:\s*anywhere/);
 
       // The name rule is gone with the name span (TWO-25326 §7); the same
-      // protection now has to be on the tile label, which is narrower than
-      // the address column and so needs it more.
+      // protection now has to be on the intent-message boxes, which carry the
+      // company text directly (§7.2/§7.3) and are narrower than the address
+      // column, so they need it more.
       expect(stylesheetSource()).not.toMatch(/\.twoinc-company-summary-name\s*\{/);
-      const tileBody = /\.twoinc-company-tile-label\s*\{([^}]*)\}/.exec(stylesheetSource());
+      const tileBody =
+        /\.twoinc-pay-box\.twoinc-intent-approved,\s*\n\.twoinc-pay-box\.twoinc-err-payment-default\s*\{([^}]*)\}/.exec(
+          stylesheetSource()
+        );
       expect(tileBody).not.toBeNull();
       expect(tileBody[1]).toMatch(/overflow-wrap:\s*anywhere/);
       // The old nowrap protected the (inline, same-line) id from wrapping
@@ -566,6 +573,10 @@ describe("read-only captured-company summary", () => {
       expect(isShown()).toBe(true);
       expect(renderedName()).toBe("Jo Bloggs Trading");
       expect(renderedNumber()).toBe("99887766");
+
+      // The tile only carries the company once an intent check has actually
+      // run (§7.2/§7.3) — setCompany() alone does not trigger one.
+      approveIntent();
       expect(tileText()).toBe("Jo Bloggs Trading (99887766)");
       expect($("#billing_company").val()).toBe("Jo Bloggs Trading");
       expect($("#company_id").val()).toBe("99887766");
@@ -580,9 +591,11 @@ describe("read-only captured-company summary", () => {
       // The value lives in an element a user cannot put a caret in.
       expect(summary().find(".twoinc-company-summary-id").prop("tagName")).toBe("SPAN");
 
-      // Same for the tile label, which is now the other half of the display.
-      expect(tileLabel().find("input, select, textarea, [contenteditable]").length).toBe(0);
-      expect(tileLabel().prop("tagName")).toBe("DIV");
+      // Same for the tile: the company now renders as plain text inside the
+      // intent-approved notice, which is itself a <div> with no controls in
+      // it (TWO-25326 §7.2/§7.3).
+      expect(intentNotice().find("input, select, textarea, [contenteditable]").length).toBe(0);
+      expect(intentNotice().prop("tagName")).toBe("DIV");
     });
 
     test("there is no control in it that removes the captured company", () => {
@@ -752,22 +765,21 @@ describe("read-only captured-company summary", () => {
   });
 
   /**
-   * The tile label's visibility mirrors the intent-approved notice's
-   * (TWO-25326 §7, revised by Doug 2026-08-03).
+   * The captured company now renders INSIDE the intent-message sentences
+   * themselves — the approved notice and the declined ("not available") box
+   * both carry it — rather than in a separate `.twoinc-company-tile-label`
+   * element (TWO-25326 §7.2/§7.3, ruling 2026-08-03, superseding the label
+   * PR #431 shipped the night before).
    *
-   * The rule this replaces was "shown whenever a company is captured", which
-   * shipped the night before in PR #429. The revision drops that: capture is no
-   * longer part of the condition at all — the
-   * notice's visibility is the whole of it, in both directions.
-   *
-   * The assertions below are deliberately written against the NOTICE's state
-   * rather than against the action that produced it. A test that checked
-   * `action === "intent-approved"` would pass just as happily against a
-   * parallel re-derivation of the condition, which is the exact failure mode
-   * the implementation is built to rule out — the label has to follow the
-   * element, so that is what gets compared.
+   * There is no longer a second element whose visibility has to be kept in
+   * sync with the notice's — the company text and the notice are the same
+   * element now, so "shown" and "carries the company" collapse into one
+   * question per box. What is still worth asserting: which template each box
+   * substitutes from, that they do not cross-contaminate, and that the
+   * no-company fallback still works exactly as it did before this ticket
+   * touched either box.
    */
-  describe("tile label visibility mirrors the intent notice (TWO-25326 §7, 2026-08-03)", () => {
+  describe("intent-message boxes carry the captured company (TWO-25326 §7.2/§7.3, 2026-08-03)", () => {
     /** Capture a company without leaving the intent notice on screen. */
     function captureCompanyOnly() {
       const ajax = harness.stubAjax($);
@@ -775,129 +787,130 @@ describe("read-only captured-company summary", () => {
       ajax.restore();
     }
 
-    test("a captured company alone does NOT show the label", () => {
-      // The whole point of the revision. Picking a company fills the label's
-      // text and leaves it hidden, because nothing has approved an intent yet.
+    /** @returns {Object} the payment tile's declined ("not available") box */
+    function declinedBox() {
+      return $(".twoinc-pay-box.twoinc-err-payment-default");
+    }
+
+    test("a captured company alone shows neither box yet", () => {
+      // Picking a company does not itself approve or decline anything — an
+      // order-intent check has to run first.
       captureCompanyOnly();
 
       expect($("#billing_company").val()).toBe("ACME Widgets Ltd");
       expect(intentShown()).toBe(false);
-      expect(tileLabelShown()).toBe(false);
+      expect(declinedBox().hasClass("hidden")).toBe(true);
     });
 
-    test("the label appears with the notice, and carries the captured company", () => {
+    test("the approved notice carries the captured company", () => {
       captureCompanyOnly();
       approveIntent();
 
       expect(intentShown()).toBe(true);
-      expect(tileLabelShown()).toBe(true);
-      expect(tileLabel().text()).toBe("ACME Widgets Ltd (12345678)");
+      expect(intentNotice().text()).toBe("ACME Widgets Ltd (12345678)");
     });
 
-    test("the label goes away again when the notice does", () => {
+    test("the declined box carries the captured company too, on its own template", () => {
       captureCompanyOnly();
-      approveIntent();
-      expect(tileLabelShown()).toBe(true);
-
-      // Back into the checking state: a new intent is in flight, so the
-      // approval no longer holds and neither element may claim it does.
-      dom.togglePaySubtitleDesc("checking-intent");
-
-      expect(intentShown()).toBe(false);
-      expect(tileLabelShown()).toBe(false);
-    });
-
-    test("an error state hides the label even with a company captured", () => {
-      captureCompanyOnly();
-      approveIntent();
 
       dom.togglePaySubtitleDesc("errored", ".twoinc-err-payment-default");
 
-      expect(intentShown()).toBe(false);
-      expect(tileLabelShown()).toBe(false);
+      expect(declinedBox().hasClass("hidden")).toBe(false);
+      expect(declinedBox().text()).toBe("ACME Widgets Ltd (12345678)");
+      // The approved notice's own template is untouched by a declined action.
+      expect(intentNotice().hasClass("hidden")).toBe(true);
     });
 
-    test("the two agree across every intent action, in both directions", () => {
-      // The invariant itself, swept over the full action set rather than
-      // spot-checked: hidden(label) === hidden(notice), always. A parallel
-      // condition that merely usually agrees fails somewhere in here.
+    test("the phone-number error box is never substituted, even with a company captured", () => {
+      // Only `.twoinc-err-payment-default` gets the company-template
+      // treatment — the phone-number box is a fixed, unrelated message.
+      $(document.body).find(".payment_box").append(
+        '<div class="twoinc-pay-box twoinc-err-phone-number hidden" ' +
+          'data-company-template="{company}">' +
+          "Phone number is invalid." +
+          "</div>"
+      );
       captureCompanyOnly();
 
-      const actions = [
-        undefined,
-        "checking-intent",
-        "intent-approved",
-        "errored",
-        "intent-approved",
-        undefined,
-        "intent-approved"
-      ];
+      dom.togglePaySubtitleDesc("errored", ".twoinc-err-phone-number");
 
-      actions.forEach(function (action) {
-        dom.togglePaySubtitleDesc(action, ".twoinc-err-payment-default");
-        expect(tileLabelShown()).toBe(intentShown());
-      });
-
-      // And the sweep genuinely visited both states, so the invariant was not
-      // satisfied trivially by everything staying hidden throughout.
-      dom.togglePaySubtitleDesc("intent-approved");
-      expect(tileLabelShown()).toBe(true);
-      dom.togglePaySubtitleDesc();
-      expect(tileLabelShown()).toBe(false);
+      expect($(".twoinc-pay-box.twoinc-err-phone-number").text()).toBe("Phone number is invalid.");
     });
 
-    test("a brand that suppressed the notice never shows the label", () => {
+    test("switching from approved to declined swaps which box carries the company", () => {
+      captureCompanyOnly();
+      approveIntent();
+      expect(intentNotice().text()).toBe("ACME Widgets Ltd (12345678)");
+
+      dom.togglePaySubtitleDesc("errored", ".twoinc-err-payment-default");
+
+      expect(intentNotice().hasClass("hidden")).toBe(true);
+      expect(declinedBox().hasClass("hidden")).toBe(false);
+      expect(declinedBox().text()).toBe("ACME Widgets Ltd (12345678)");
+    });
+
+    test("a brand that suppressed the approved notice leaves it absent, but the declined box is unaffected", () => {
       // 'intent_approved_notice_enabled: false' => get_intent_approved_notice()
-      // returns '' and the notice div is never rendered. An absent notice is a
-      // hidden notice, so the label must stay down even on the action that
-      // would otherwise show it. WC_Twoinc.php also stops emitting the label
-      // container on such a brand; this asserts the JS gate holds on its own,
-      // so the two are not load-bearing for each other.
+      // returns '' and the approved div is never rendered. The declined box
+      // is NEVER gated on that switch (TWO-25224: "a merchant who wants no
+      // reassurance still needs failures surfaced") — proven here by driving
+      // it with the approved notice removed from the DOM entirely.
       intentNotice().remove();
       captureCompanyOnly();
 
-      dom.togglePaySubtitleDesc("intent-approved");
+      dom.togglePaySubtitleDesc("errored", ".twoinc-err-payment-default");
 
       expect(intentNotice().length).toBe(0);
-      expect(tileLabelShown()).toBe(false);
+      expect(declinedBox().hasClass("hidden")).toBe(false);
+      expect(declinedBox().text()).toBe("ACME Widgets Ltd (12345678)");
     });
 
-    test("the label re-syncs without the capture sites having to re-render it", () => {
-      // togglePaySubtitleDesc holds no company values of its own, so the
-      // no-argument path of renderCompanyTileLabel has to read them back off
-      // the live inputs. If it did not, toggling the notice would show an
-      // empty label on a checkout that has a company.
+    test("re-substitutes from live inputs on every toggle call, not a stale snapshot", () => {
+      // togglePaySubtitleDesc holds no company values of its own; each call
+      // re-reads #billing_company/#company_id. If it did not, a second
+      // approval after the inputs changed would keep showing the FIRST
+      // company.
       captureCompanyOnly();
-      tileLabel().text("");
+      approveIntent();
+      expect(intentNotice().text()).toBe("ACME Widgets Ltd (12345678)");
 
-      dom.togglePaySubtitleDesc("intent-approved");
+      $("#billing_company").val("Beta Traders Ltd");
+      $("#company_id").val("87654321");
+      dom.togglePaySubtitleDesc("checking-intent");
+      approveIntent();
 
-      expect(tileLabel().text()).toBe("ACME Widgets Ltd (12345678)");
+      expect(intentNotice().text()).toBe("Beta Traders Ltd (87654321)");
     });
 
-    test("an intent-approved checkout with no company leaves no empty label behind", () => {
-      // The no-company state is real — the notice ships a separate sentence
-      // for it — and the JS gate deliberately does not and-in the text, so the
-      // element is unhidden while empty. CSS is what stops that being a 24px
-      // gap (the rule's own 12px margins) between the chips and the notice.
+    test("a company with no organisation number substitutes the bare name, never a dangling '()'", () => {
+      captureCompanyOnly();
+      $("#company_id").val("");
+
+      approveIntent();
+      expect(intentNotice().text()).toBe("ACME Widgets Ltd");
+
+      dom.togglePaySubtitleDesc("errored", ".twoinc-err-payment-default");
+      expect(declinedBox().text()).toBe("ACME Widgets Ltd");
+    });
+
+    test("an intent-approved checkout with no company falls back to the served no-company sentence", () => {
       $("#billing_company").val("");
       $("#company_id").val("");
 
       dom.togglePaySubtitleDesc("intent-approved");
 
       expect(intentShown()).toBe(true);
-      expect(tileLabel().text()).toBe("");
+      expect(intentNotice().text()).toBe("NO_COMPANY_APPROVED");
+    });
 
-      // The element is deliberately NOT hidden here — that is the whole reason
-      // the CSS rule below has to exist. Asserted rather than left implied
-      // (round 1 review): without it this test would still pass against an
-      // implementation that quietly and-ed the text back into the JS gate, and
-      // the CSS assertion underneath would then be guarding nothing.
-      expect(tileLabelShown()).toBe(true);
+    test("a declined checkout with no company falls back to its own served sentence", () => {
+      $("#billing_company").val("");
+      $("#company_id").val("");
 
-      const empty = /\.twoinc-company-tile-label:empty\s*\{([^}]*)\}/.exec(stylesheetSource());
-      expect(empty).not.toBeNull();
-      expect(empty[1]).toMatch(/display:\s*none/);
+      dom.togglePaySubtitleDesc("errored", ".twoinc-err-payment-default");
+
+      expect(declinedBox().hasClass("hidden")).toBe(false);
+      expect(declinedBox().text()).toBe("NO_COMPANY_DECLINED");
     });
   });
 });

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -176,7 +176,8 @@ final class BrandConfigSpec
             'testClientVersionSuffixesShortShaWhenStamped',
             'testClientVersionIsQueryEncodedAsPlus',
             'testPaymentBoxOrdersTaglineChipsThenSoleTrader',
-            'testPaymentBoxRendersCompanyLabelBetweenChipsAndIntentMessage',
+            'testPaymentBoxRendersCompanySearchTileSlotBetweenSoleTraderAndIntentMessage',
+            'testDeclinedBoxCarriesCompanyTemplate',
             'testSelectedTermInputPrecedesChipsContainer',
             'testBrandWithoutTaglineEmitsNoTaglineBlock',
             'testTaglineSentenceIsPlatformCopyWithBrandFaqLink',
@@ -191,7 +192,7 @@ final class BrandConfigSpec
             'testIntentApprovedNoticeInvalidSwitchReportsAndDefaultsOn',
             'testIntentLoaderRendersTheOneSharedDotPulse',
             'testIntentLoaderSuppressedWithTheNoticeButErrorBoxesSurvive',
-            'testCompanyTileLabelSuppressedWithTheNotice',
+            'testCompanySearchTileSlotAndDeclinedTemplateSurviveNoticeSuppression',
             'testAssetVersionTracksFileMtimeNotPluginVersion',
             'testAssetVersionFallsBackToPluginVersionWhenFileMissing',
         ];
@@ -5263,37 +5264,78 @@ final class BrandConfigSpec
     }
 
     /**
-     * The captured company renders in the payment tile, as a text label
-     * between the term chips and the intent message (TWO-25326 section 7).
+     * The company-search-tile-location slot renders between the sole-trader
+     * toggle and the intent message (TWO-25326 §7.1, ruling 2026-08-03,
+     * superseding the standalone company-tile-label this ticket originally
+     * shipped in PR #431).
      *
      * Position is asserted, not just presence: the requirement names the
-     * chips and the intent message as its two anchors, and the whole box is
-     * one concatenated sprintf, so an edit that moves the label is a silent
-     * regression exactly like the ordering test above guards against.
+     * sole-trader toggle and the intent message as its two anchors, and the
+     * whole box is one concatenated sprintf, so an edit that moves the slot
+     * is a silent regression exactly like the ordering test above guards
+     * against.
      *
-     * Empty on render by design. The captured company is chosen client-side
-     * after this markup is generated, so the container ships empty and
-     * hidden and renderCompanyTileLabel() in twoinc.js fills it.
+     * Empty and hidden on render regardless of the `company_search_location`
+     * setting — twoinc.js's syncCompanySearchTileLocation() is what moves the
+     * real company-search fields into it and unhides it, client-side, and
+     * this markup does not know the setting's value at all (it is read from
+     * `window.twoinc.company_search_location`, not baked into this HTML).
      */
-    private static function testPaymentBoxRendersCompanyLabelBetweenChipsAndIntentMessage(): void
+    private static function testPaymentBoxRendersCompanySearchTileSlotBetweenSoleTraderAndIntentMessage(): void
     {
         self::useTaglineBrand();
         $html = self::gateway()->build_payment_description();
 
-        $chips = strpos($html, 'twoinc-term-chips');
-        $label = strpos($html, 'twoinc-company-tile-label');
+        $sole_trader = strpos($html, 'twoinc-sole-trader-toggle');
+        $slot = strpos($html, 'twoinc-company-search-tile-slot');
         $intent = strpos($html, 'twoinc-pay-box');
 
-        TinyAssert::true($chips !== false, 'chips container missing');
-        TinyAssert::true($label !== false, 'company tile label missing');
+        TinyAssert::true($sole_trader !== false, 'sole-trader toggle missing');
+        TinyAssert::true($slot !== false, 'company-search tile slot missing');
         TinyAssert::true($intent !== false, 'intent/notice pay box missing');
 
-        TinyAssert::true($chips < $label, 'chips must precede the company label');
-        TinyAssert::true($label < $intent, 'company label must precede the intent message');
+        TinyAssert::true($sole_trader < $slot, 'sole-trader toggle must precede the tile slot');
+        TinyAssert::true($slot < $intent, 'tile slot must precede the intent message');
 
         TinyAssert::true(
-            strpos($html, '<div class="twoinc-company-tile-label hidden"></div>') !== false,
-            'company tile label must ship empty and hidden'
+            strpos($html, '<div class="twoinc-company-search-tile-slot hidden"></div>') !== false,
+            'the tile slot must ship empty and hidden'
+        );
+
+        // §7.2/§7.3: the standalone tile label PR #431 shipped is gone
+        // outright, not just replaced in this position.
+        TinyAssert::true(
+            strpos($html, 'twoinc-company-tile-label') === false,
+            'the superseded standalone company tile label must not be emitted'
+        );
+    }
+
+    /**
+     * The declined ("not available") box carries the same company-token
+     * mechanism as the approved notice (TWO-25326 §7.3, ruling 2026-08-03):
+     * %1$s is the brand product name, resolved here; %2$s is the buyer's
+     * captured company, left as the {company} token for twoinc.js to
+     * substitute, since only the browser knows it.
+     */
+    private static function testDeclinedBoxCarriesCompanyTemplate(): void
+    {
+        self::useTaglineBrand();
+        $html = self::gateway()->build_payment_description();
+
+        TinyAssert::true(
+            strpos(
+                $html,
+                'twoinc-pay-box twoinc-err-payment-default hidden" data-company-template="Taglinebrand is not'
+                . ' available for this order by {company}"'
+            ) !== false,
+            'the declined box must carry the company template, brand name resolved, company tokenised'
+        );
+
+        // Unchanged, no-company fallback text — still the box's own visible
+        // content, exactly as before this ticket added the template.
+        TinyAssert::true(
+            strpos($html, 'Invoice purchase with Taglinebrand is not available for this order.') !== false,
+            'the no-company fallback sentence must be unchanged'
         );
     }
 
@@ -5498,8 +5540,7 @@ final class BrandConfigSpec
         TinyAssert::true(
             strpos(
                 $html,
-                'data-company-template="Your invoice with Two is likely to be accepted for {company},'
-                . ' subject to additional checks."'
+                'data-company-template="This order by {company} is likely to be accepted by Two"'
             ) !== false,
             'the notice must carry the company variant, brand name resolved, company name tokenised'
         );
@@ -5555,8 +5596,7 @@ final class BrandConfigSpec
             TinyAssert::true(
                 strpos(
                     $html,
-                    'data-company-template="Your invoice with ' . $product
-                    . ' is likely to be accepted for {company}, subject to additional checks."'
+                    'data-company-template="This order by {company} is likely to be accepted by ' . $product . '"'
                 ) !== false,
                 $fixture . ': the company variant must be the platform default copy too'
             );
@@ -5721,19 +5761,23 @@ final class BrandConfigSpec
     }
 
     /**
-     * TWO-25326 section 7, revised 2026-08-03: the captured-company label's
-     * visibility mirrors the intent-approved notice's exactly. On a brand
-     * that switched the notice off there is therefore no state in which the
-     * label can ever be shown, so its container must not be emitted either —
-     * the same conclusion TWO-25224 reached for the loader, extended to the
-     * label now that it belongs to the same reassurance pass.
+     * TWO-25326 §7.1-§7.3, ruling 2026-08-03: the standalone company-tile
+     * label this section originally tested (PR #431) is gone outright, on
+     * every brand, notice switch or not — it is superseded, not conditional.
+     * The company-search tile slot that replaces its POSITION is unrelated to
+     * the notice switch entirely: it exists to let the location SETTING
+     * (§7.1) move the search control into the tile, which has nothing to do
+     * with whether the approved-intent reassurance copy is on. It must
+     * therefore render on BOTH a brand that suppresses the notice and one
+     * that does not.
      *
-     * Asserted as a pair with the enabled case. Presence alone would pass
-     * against markup that emits the container unconditionally, and absence
-     * alone would pass against markup that never emits it at all; only the
-     * two together pin the container to the switch.
+     * The declined ("not available") box is the one still worth pinning
+     * against the switch here (TWO-25224's rule, extended by §7.3's new
+     * company template): it is NEVER gated on
+     * 'intent_approved_notice_enabled', so its data-company-template must
+     * survive even on a brand that suppresses the approved notice entirely.
      */
-    private static function testCompanyTileLabelSuppressedWithTheNotice(): void
+    private static function testCompanySearchTileSlotAndDeclinedTemplateSurviveNoticeSuppression(): void
     {
         add_filter('twoinc_brand_file', static function ($file) {
             return __DIR__ . '/fixtures/suppressednoticebrand.php';
@@ -5743,22 +5787,27 @@ final class BrandConfigSpec
         $html = self::gateway()->build_payment_description();
         TinyAssert::true(
             strpos($html, 'twoinc-company-tile-label') === false,
-            'a brand disabling the notice must emit no company tile label container'
+            'the superseded standalone company tile label must never be emitted'
         );
-
-        // The error boxes still prove the tile itself rendered, so the
-        // absence above is the switch doing its job and not an empty build.
         TinyAssert::true(
-            strpos($html, 'twoinc-pay-box twoinc-err-phone-number hidden') !== false,
-            'the tile must still have rendered for that absence to mean anything'
+            strpos($html, '<div class="twoinc-company-search-tile-slot hidden"></div>') !== false,
+            'the tile slot must still render on a brand that suppresses the approved notice'
+        );
+        TinyAssert::true(
+            strpos(
+                $html,
+                'twoinc-pay-box twoinc-err-payment-default hidden" data-company-template="Suppressednoticebrand'
+                . ' is not available for this order by {company}"'
+            ) !== false,
+            'the declined box\'s company template must survive the approved notice being suppressed'
         );
 
         self::reset();
         self::useTaglineBrand();
         $enabled_html = self::gateway()->build_payment_description();
         TinyAssert::true(
-            strpos($enabled_html, '<div class="twoinc-company-tile-label hidden"></div>') !== false,
-            'a brand with the notice on must still ship the label container'
+            strpos($enabled_html, '<div class="twoinc-company-search-tile-slot hidden"></div>') !== false,
+            'the tile slot must also render on a brand with the notice on'
         );
     }
 


### PR DESCRIPTION
## Summary

Implements Doug's 2026-08-03 design ruling on TWO-25326 §7.1-§7.4 for WooCommerce only.

- **§7.1 — one control, admin setting picks LOCATION.** Adds a `company_search_location` admin setting (Address area / Payment tile). The existing company-search control (fields, selectWoo widget, keyboard handling — everything from §1-§4) is left untouched when the setting is "Address area" (the default, zero behaviour change). When set to "Payment tile", `twoincDomHelper.syncCompanySearchTileLocation()` relocates the SAME control (moved with `appendTo()`, never cloned) into a new `.twoinc-company-search-tile-slot` server-rendered in the payment tile.
- **§7.2/§7.3 — tile is text-only, wording embeds name/number.** Removes the standalone `.twoinc-company-tile-label` div (PR #431). The captured company now lives directly inside the intent-message sentences:
  - Approved: `This order by <name> (<number>) is likely to be accepted by <product>`
  - Declined: `<product> is not available for this order by <name> (<number>)`
  Both use the existing brand-template/token substitution mechanism (`data-company-template` + `{company}`), extended to the declined ("not available") box, which — per TWO-25224 — is never gated on the brand's notice-suppression switch.
- **§7.4 — brand-overlay wording respected.** No change forces vanilla wording over a brand's own copy: a brand overriding `intent_approved_notice` keeps its own template and just needs the token somewhere in it to get the company substitution. A new, symmetrical `intent_declined_notice` override key is added for the declined box.

## Test plan

- [x] `npm run test:js` — 306/306 passing, including a rewritten `tests/js/company-summary.test.js` covering the new intent-message substitution (both approved and declined boxes) and confirming the removed tile label stays removed.
- [x] `php tests/unit/run.php` — 169/169 passing, including updated PHP-side markup assertions.
- [x] Mutation-verified: hand-mutated the errSelector guard, the name/number formatter, and the PHP declined-template default — all three caught by the suite.
- [x] Real-browser verification (local Docker WordPress/WooCommerce against a mock Two API, since this environment has no route to a live Two backend): confirmed via the real enqueued `twoinc.js` against real WooCommerce checkout markup —
  - `payment_tile` setting: the real company-search fields (dropdown, hidden org-number field, number label) physically relocate into the tile slot, selectWoo widget intact.
  - `address_area` setting (default): control stays exactly where it always was, tile slot stays hidden.
  - Approved notice renders `This order by ACME Widgets Ltd (12345678) is likely to be accepted by Two`.
  - Declined notice renders `Two is not available for this order by ACME Widgets Ltd (12345678)`.
  - No-number (manual entry) case renders the bare name, no dangling `()`.
  - Confirmed old `.twoinc-company-tile-label` div is gone.

## Known limitation / follow-up

Live verification of the relocation surviving a genuine WooCommerce `update_checkout` AJAX re-render was not completed — this local Docker environment's mock Two API isn't faithful enough to keep that AJAX cycle from corrupting the billing-fields fragment (a pre-existing artifact of the mock, reproducible even on vanilla checkout fields unrelated to this change). The relocation re-applies on every `toggleBusinessFields()` call, which is already wired to the same `updated_checkout` event other re-anchoring logic in this file relies on (e.g. `getCompanySummaryNode()`), so it should hold up the same way — but this specific path wants a real staging re-test.
