### PR TITLE
fix(checkout): declined intent notice must never be brand-overridable

### DIFF
--- a/brands/two.php
+++ b/brands/two.php
@@ -109,4 +109,10 @@ return [
     // the brand product_name and %2$s the buyer's company name.
     // WC_Twoinc::get_intent_approved_notice is the only reader.
     'intent_approved_notice' => null,
+    // Deliberately no 'intent_declined_notice' key here (removed
+    // 2026-08-04 ruling, TWO-25326): the "order intent NOT approved"
+    // notice is never brand-overridable. WC_Twoinc::
+    // get_intent_declined_notice_template() no longer reads any brand
+    // key for this — do not add one back, and do not add one to an
+    // overlay's own brand file either; it would be silently ignored.
 ];

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -919,22 +919,22 @@ if (!class_exists('WC_Twoinc')) {
          *
          * Same token mechanism as get_intent_approved_notice(): %1$s is the
          * brand product name, %2$s is the company token twoinc.js substitutes
-         * with the same "<name> (<number>)" (or bare name) string. A brand
-         * may override the template via 'intent_declined_notice', mirroring
-         * 'intent_approved_notice' — absent/empty means the platform default.
+         * with the same "<name> (<number>)" (or bare name) string.
+         *
+         * Deliberately NOT brand-overridable (2026-08-04 ruling, TWO-25326):
+         * unlike get_intent_approved_notice() above, there is no
+         * 'intent_declined_notice' brand key and there must never be one —
+         * every brand renders this exact platform default copy.
          *
          * @return string sprintf template with %1$s and the company TOKEN,
          *                 ready for esc_attr() into data-company-template.
          */
         private function get_intent_declined_notice_template(): string
         {
-            $template = WC_Twoinc_Brand::get('intent_declined_notice');
-            if (!is_string($template) || trim($template) === '') {
-                // TWO-25326 §7.3 literal wording: "<product> is not available
-                // for this order by <name> (<number>)".
-                /* translators: %1$s: brand product name (e.g. "Two"); %2$s: the buyer's captured company name and number, substituted client-side */
-                $template = __('%1$s is not available for this order by %2$s', 'twoinc-payment-gateway');
-            }
+            // TWO-25326 §7.3 literal wording: "<product> is not available
+            // for this order by <name> (<number>)".
+            /* translators: %1$s: brand product name (e.g. "Two"); %2$s: the buyer's captured company name and number, substituted client-side */
+            $template = __('%1$s is not available for this order by %2$s', 'twoinc-payment-gateway');
 
             $product_name = WC_Twoinc_Brand::get('product_name');
             return sprintf($template, $product_name, self::INTENT_NOTICE_COMPANY_TOKEN);

--- a/tests/unit/fixtures/decidedoverridebrand.php
+++ b/tests/unit/fixtures/decidedoverridebrand.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Brand fixture proving 'intent_declined_notice' is NOT a supported
+ * override (2026-08-04 ruling, TWO-25326): the "order intent NOT approved"
+ * notice must render the exact same platform default copy for every
+ * brand. WC_Twoinc no longer reads this key at all, so an overlay
+ * declaring it (whether by habit, copy-paste from the approved-notice
+ * fixture, or a stale doc) must be silently ignored, not honoured.
+ */
+
+return [
+    'code' => 'decidedoverridebrand',
+    'product_name' => 'Decidedoverridebrand',
+    'gateway_id' => 'woocommerce-gateway-decidedoverridebrand',
+    'meta_prefix' => 'decidedoverridebrand',
+    'intent_declined_notice' => 'This override must never render: %1$s / %2$s.',
+];

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -178,6 +178,7 @@ final class BrandConfigSpec
             'testPaymentBoxOrdersTaglineChipsThenSoleTrader',
             'testPaymentBoxRendersCompanySearchTileSlotBetweenSoleTraderAndIntentMessage',
             'testDeclinedBoxCarriesCompanyTemplate',
+            'testDeclinedNoticeIgnoresABrandOverrideKey',
             'testSelectedTermInputPrecedesChipsContainer',
             'testBrandWithoutTaglineEmitsNoTaglineBlock',
             'testTaglineSentenceIsPlatformCopyWithBrandFaqLink',
@@ -5416,6 +5417,36 @@ final class BrandConfigSpec
         TinyAssert::true(
             strpos($html, 'Invoice purchase with Taglinebrand is not available for this order.') !== false,
             'the no-company fallback sentence must be unchanged'
+        );
+    }
+
+    /**
+     * 2026-08-04 ruling (TWO-25326): the declined/"not available" notice is
+     * never brand-overridable. WC_Twoinc no longer reads an
+     * 'intent_declined_notice' brand key at all, so a brand file declaring
+     * one (fixtures/decidedoverridebrand.php) must be silently ignored —
+     * the platform default copy renders regardless, with only the brand's
+     * product_name substituted the normal way.
+     */
+    private static function testDeclinedNoticeIgnoresABrandOverrideKey(): void
+    {
+        add_filter('twoinc_brand_file', static function ($file) {
+            return __DIR__ . '/fixtures/decidedoverridebrand.php';
+        });
+
+        $html = self::gateway()->build_payment_description();
+
+        TinyAssert::true(
+            strpos(
+                $html,
+                'twoinc-pay-box twoinc-err-payment-default hidden" data-company-template="Decidedoverridebrand'
+                . ' is not available for this order by {company}"'
+            ) !== false,
+            'the declined box must render the platform default copy, ignoring the brand override key'
+        );
+        TinyAssert::true(
+            strpos($html, 'This override must never render') === false,
+            'a brand-declared intent_declined_notice must never reach rendered output'
         );
     }
 


### PR DESCRIPTION
## Summary
Per the 2026-08-04 TWO-25326 ruling, the buyer-facing "order intent NOT approved" checkout tile notice must render identical platform-default copy for every brand — only the approved/success notice is meant to be brand-overridable.

`get_intent_declined_notice_template()` previously read `WC_Twoinc_Brand::get('intent_declined_notice')`, mirroring the approved notice's copy-override mechanism. No shipped brand file used the key, but the seam was live and reachable end-to-end (same defect shape found and fixed in `two-inc/magento-plugin` PR #322).

- `class/WC_Twoinc.php`: `get_intent_declined_notice_template()` always renders the literal default copy; no brand-key read.
- `brands/two.php`: documents the deliberate omission so it doesn't get "helpfully" re-added.
- New fixture `tests/unit/fixtures/decidedoverridebrand.php` + test `testDeclinedNoticeIgnoresABrandOverrideKey` lock in that a brand file declaring the key is silently ignored.

The approved-notice override (`intent_approved_notice`) is unchanged — the companion ABN-overlay fix (`two-inc/woocommerce-abn-plugin`) turns that ON with ABN copy instead of leaving it suppressed.

## Test plan
- [x] `make test-unit` — full suite green, including the new test.
- [x] `php -l` on every touched file.