### PR TITLE
fix(company-search): make payment-tile placement functional (TWO-25326)

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -748,7 +748,7 @@ let twoincSelectWooHelper = {
       if (this.tabIndex < 0) return;
       if (jQuery(this).closest(".select2-container--open, .select2-dropdown").length) return;
       if (twoincSelectWooHelper.isHiddenForTabbing(this)) return;
-      if (!((anchor.compareDocumentPosition(this) & 4) /* DOCUMENT_POSITION_FOLLOWING */)) return;
+      if (!(anchor.compareDocumentPosition(this) & 4 /* DOCUMENT_POSITION_FOLLOWING */)) return;
       found.push(this);
     });
 
@@ -1526,30 +1526,40 @@ let twoincDomHelper = {
 
         // #company_id_field is deliberately left OUT here when manual entry
         // (TWO-25288/#30.x.13) is what put us on this branch. This branch is
-        // shared with two other reasons `enable_company_search` can read
-        // "no" — the merchant simply never enabled company search at all,
-        // and sole-trader mode (twoincSoleTrader.setMode), which both
-        // legitimately want the id field: the plain fallback captures
-        // name+id like it always has, and sole-trader mode fills company_id
-        // itself with a synthetic identifier (Two's payment method cannot
-        // function without one). Manual entry is the one case in this org's
-        // three-mode company-capture model that captures name ONLY — Two's
-        // payment method still needs an id in the other two modes, but a
-        // buyer who says "my company isn't in the registry" has no id to
-        // give, and showing the field only invites one that was never
+        // shared with the one other reason `enable_company_search` can read
+        // "no" at runtime — sole-trader mode (twoincSoleTrader.setMode),
+        // which also legitimately wants the id field: the plain fallback
+        // captures name+id like it always has, and sole-trader mode fills
+        // company_id itself with a synthetic identifier (Two's payment
+        // method cannot function without one). Manual entry is the one case
+        // in this org's three-mode company-capture model that captures name
+        // ONLY — Two's payment method still needs an id in the other mode,
+        // but a buyer who says "my company isn't in the registry" has no id
+        // to give, and showing the field only invites one that was never
         // validated against anything. `manual_company_entry_active` is set
         // by enterManualCompanyEntry/exitManualCompanyEntry specifically so
-        // this branch can tell "manual entry" apart from the other two
-        // routes into it.
+        // this branch can tell "manual entry" apart from the other route
+        // into it.
         if (!window.twoinc.manual_company_entry_active) {
           visibleTargets.push("#company_id_field");
           requiredTargets.push("#company_id_field");
         }
       }
     } else {
+      // `enable_company_search_for_others`'s own admin description ties it
+      // to the checkbox being checked ("Requires the option above to be
+      // checked") — i.e. the ADMIN's address-area preference, not whatever
+      // `window.twoinc.enable_company_search` currently reads at runtime
+      // (that flag is "yes" whenever the search widget is the active input
+      // method, in BOTH placements — see the doc comment on
+      // syncCompanySearchTileLocation). Reading it here instead of
+      // `company_search_location` would light up address-area search for
+      // other payment methods even when the merchant chose payment-tile
+      // placement, where there is no tile to show it in at all (the tile
+      // only exists inside this gateway's own payment box).
       if (
         twoincDomHelper.isCountrySupported() &&
-        window.twoinc.enable_company_search === "yes" &&
+        window.twoinc.company_search_location === "address_area" &&
         window.twoinc.enable_company_search_for_others === "yes"
       ) {
         visibleTargets.push("#billing_company_display_field");
@@ -1733,30 +1743,32 @@ let twoincDomHelper = {
    * company name out of the address form entirely, which is exactly the bug
    * this comment documents.
    *
-   * `#company_id_field` is ALSO excluded (adversarial review finding, Vader,
-   * 2026-08-04): `WC_Twoinc_Checkout::update_company_fields()` only
-   * registers `billing_company_display` server-side when
-   * `get_enable_company_search() === 'yes'` — the ONLY state that ever
-   * reaches this function's 'payment_tile' branch is checkbox-unchecked, in
-   * which `#billing_company_display_field` never exists in the DOM at all.
-   * Moving `#company_id_field` alone into the tile in that state left a
-   * bare, unlabelled, REQUIRED "Company ID" box floating in the payment
-   * tile with no search widget behind it to populate it — confusing and
-   * checkout-blocking. Excluding it too means this branch is currently a
-   * true no-op for every reachable state (tracked as a follow-up: making
-   * search functionally live inside the tile, matching this field's own
-   * admin description, is materially bigger scope than this correction and
-   * needs its own design pass); both plain fields now simply stay in the
-   * address form together when the checkbox is off, exactly like the
-   * pre-PR-#436 fallback.
+   * `#company_id_field` is ALSO excluded, but for a different reason than
+   * `#billing_company_field` above: it is a plain hidden input
+   * (`class: hidden`, never shown to the buyer) that just carries the
+   * org-number value the search widget writes into it on selection — moving
+   * a hidden field has no visible effect, and it is still submitted with
+   * the rest of `form[name="checkout"]` regardless of where inside that
+   * form it physically sits. Leaving it in the address form alongside
+   * `#billing_company_field` (its manual-entry partner) is simplest and
+   * costs nothing.
+   *
+   * 2026-08-04 correction, round 2 (Doug, live-verified): an earlier version
+   * of this fix left `WC_Twoinc_Checkout::update_company_fields()` gating
+   * `billing_company_display`'s registration on
+   * `get_enable_company_search() === 'yes'` — the exact state that reaches
+   * this function's 'payment_tile' branch is checkbox-unchecked, so the
+   * field never existed server-side there, this function's move loop was a
+   * genuine no-op, and the tile rendered empty. That gate is gone now — the
+   * control is ALWAYS registered (see `update_company_fields()`) — so this
+   * branch has real work to do: a functional selectWoo search, live inside
+   * the tile, exactly matching this field's own admin description
+   * ("company search will be visible within the payment method").
    *
    * Default is 'address_area' (checkbox checked): this function is then a
    * no-op and the control renders exactly where WooCommerce always put it —
    * zero behavioural change for every merchant who leaves the checkbox at
-   * its default. A merchant with the checkbox UNCHECKED gets the plain
-   * `#billing_company_field` + `#company_id_field` fallback pair in the
-   * address area — unchanged from the pre-PR-#436 "off" behaviour — and no
-   * change to the (currently empty) payment tile.
+   * its default.
    *
    * 'payment_tile': the fields move into `.twoinc-company-search-tile-slot`,
    * the empty slot `get_pay_box_description()` server-renders between the
@@ -1830,11 +1842,10 @@ let twoincDomHelper = {
     // wrapper (bug found in adversarial review, Han, 2026-08-04, after
     // `#company_id_field` was excluded above): `getCompanySummaryNode()`
     // anchors the summary against `#company_id_field` wherever THAT field
-    // currently lives — the address form, in every state this branch is
-    // reachable in today, since `#billing_company_display_field` never
-    // exists server-side when the checkbox is unchecked (see the doc
-    // comment above). A version of this function that still calls
-    // `getCompanySummaryNode()` and appends its result into the wrapper
+    // currently lives — the address form, since `#company_id_field` is
+    // itself never relocated (see the doc comment above). A version of this
+    // function that still calls `getCompanySummaryNode()` and appends its
+    // result into the wrapper
     // fights that anchor on every call: `getCompanySummaryNode()` re-homes
     // the node next to `#company_id_field` (address form) as a side effect
     // of being called at all, then the append here immediately yanks it
@@ -1846,18 +1857,21 @@ let twoincDomHelper = {
     // `getCompanySummaryNode()` already put it — correctly, next to the
     // fields that are actually capturing the value.
     //
-    // Unhidden only when the wrapper actually gained a child (bug found in
-    // adversarial review round 2, Han, 2026-08-04): in the only state this
-    // branch is reachable in today (checkbox unchecked), the move above is
-    // itself a no-op — `#billing_company_display_field` never exists
-    // server-side in that state, per the same doc comment — so an
-    // unconditional unhide left every checkbox-off merchant with a bare,
-    // unexplained gap (`.twoinc-company-search-tile-slot`'s own
-    // `margin: 12px 0`, assets/css/twoinc.css) between the sole-trader
-    // toggle and the intent message on every checkout. Re-hiding when
-    // nothing moved in is the same "confusing empty box" failure mode the
-    // company_id_field exclusion above was fixing, just the inverse of it.
-    if ($wrapper.children().length) {
+    // Unhidden only when the wrapper actually gained a VISIBLE child (bug
+    // found in adversarial review round 2, Han, 2026-08-04; widened
+    // 2026-08-04 correction round 3 — the field now always exists
+    // server-side, so checking mere presence in the wrapper is no longer
+    // enough). Manual entry and sole-trader mode both hide
+    // `#billing_company_display_field` with the `hidden` class rather than
+    // removing it (see toggleBusinessFields) — it still gets moved into the
+    // wrapper by the loop above, so `$wrapper.children().length` alone
+    // would unhide the slot around a `display: none` field, leaving the
+    // buyer a bare, unexplained gap (`.twoinc-company-search-tile-slot`'s
+    // own `margin: 12px 0`, assets/css/twoinc.css) between the sole-trader
+    // toggle and the intent message — the exact "confusing empty box" state
+    // this guard exists to prevent. Checking for a child that is not itself
+    // `.hidden` closes that gap.
+    if ($wrapper.children(":not(.hidden)").length) {
       if ($slot.hasClass("hidden")) $slot.removeClass("hidden");
     } else if (!$slot.hasClass("hidden")) {
       $slot.addClass("hidden");
@@ -3832,7 +3846,10 @@ class Twoinc {
     // survive any future tightening of isTwoincVisible.)
     if (
       twoincDomHelper.isTwoincVisible() ||
-      (window.twoinc.enable_company_search === "yes" &&
+      // Admin's address-area preference, not the runtime
+      // `enable_company_search` flag — see the comment on the equivalent
+      // check in toggleBusinessFields (TWO-25326 §7.1).
+      (window.twoinc.company_search_location === "address_area" &&
         window.twoinc.enable_company_search_for_others === "yes")
     ) {
       // Toggle the business fields
@@ -4874,7 +4891,10 @@ jQuery(function () {
         // methods, wire it immediately — that setting exists precisely
         // for checkouts where this gateway isn't offered.
         if (
-          window.twoinc.enable_company_search === "yes" &&
+          // Admin's address-area preference, not the runtime
+          // `enable_company_search` flag — see the comment on the
+          // equivalent check in toggleBusinessFields (TWO-25326 §7.1).
+          window.twoinc.company_search_location === "address_area" &&
           window.twoinc.enable_company_search_for_others === "yes"
         ) {
           Twoinc.getInstance().initialize(true);

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -748,7 +748,7 @@ let twoincSelectWooHelper = {
       if (this.tabIndex < 0) return;
       if (jQuery(this).closest(".select2-container--open, .select2-dropdown").length) return;
       if (twoincSelectWooHelper.isHiddenForTabbing(this)) return;
-      if (!(anchor.compareDocumentPosition(this) & 4 /* DOCUMENT_POSITION_FOLLOWING */)) return;
+      if (!((anchor.compareDocumentPosition(this) & 4) /* DOCUMENT_POSITION_FOLLOWING */)) return;
       found.push(this);
     });
 

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -189,31 +189,42 @@ if (!class_exists('WC_Twoinc_Checkout')) {
             // priority needs its own ceiling).
             $company_name_priority = self::clamp_company_priority($fields['billing']['billing_company']['priority'] ?? 30);
 
-            if ($this->wc_twoinc->get_enable_company_search() === 'yes') {
-                $fields['billing']['billing_company_display'] = [
-                    'label' => __('Company name', 'twoinc-payment-gateway'),
-                    'autocomplete' => 'organization',
-                    'type' => 'select',
-                    /*'custom_attributes' => [
-                        'data-multiple' => true,
-                        'data-multi' => true
-                    ],*/
-                    // form-row-wide is what carries WooCommerce's
-                    // `clear: both` (and full width) for a checkout row.
-                    // Without it this row does not clear the
-                    // form-row-first/form-row-last float pair that the first-
-                    // and last-name rows form, so its label's line boxes get
-                    // squeezed into the gutter between those two 47% floats —
-                    // the label renders wrapped between the two name inputs
-                    // (TWO-25160).
-                    'class' => array('billing_company_selectwoo', 'form-row-wide', 'hidden'),
-                    'options' => [
-                        '' => '&nbsp;'
-                    ],
-                    'required' => false,
-                    'priority' => $company_name_priority
-                ];
-            }
+            // Always registered — TWO-25326 §7.1 correction 2026-08-04. This
+            // is the ONE company-search control; `get_enable_company_search()`
+            // only ever decides WHERE it renders (address area vs payment
+            // tile, via `company_search_location` — see
+            // derive_company_search_location() and
+            // twoincDomHelper.syncCompanySearchTileLocation() in twoinc.js),
+            // never whether it exists. A gate here that skipped registration
+            // when the checkbox was unchecked left the payment-tile branch
+            // with nothing to relocate — the tile rendered empty and the
+            // buyer saw only the plain, unenhanced fallback fields
+            // (`#billing_company_field` + `#company_id_field`) in the address
+            // area, with no working search anywhere on the page. Removing the
+            // gate is what gives the relocation JS a control to move.
+            $fields['billing']['billing_company_display'] = [
+                'label' => __('Company name', 'twoinc-payment-gateway'),
+                'autocomplete' => 'organization',
+                'type' => 'select',
+                /*'custom_attributes' => [
+                    'data-multiple' => true,
+                    'data-multi' => true
+                ],*/
+                // form-row-wide is what carries WooCommerce's
+                // `clear: both` (and full width) for a checkout row.
+                // Without it this row does not clear the
+                // form-row-first/form-row-last float pair that the first-
+                // and last-name rows form, so its label's line boxes get
+                // squeezed into the gutter between those two 47% floats —
+                // the label renders wrapped between the two name inputs
+                // (TWO-25160).
+                'class' => array('billing_company_selectwoo', 'form-row-wide', 'hidden'),
+                'options' => [
+                    '' => '&nbsp;'
+                ],
+                'required' => false,
+                'priority' => $company_name_priority
+            ];
 
             $fields['billing']['company_id'] = [
                 'label' => __('Company ID', 'twoinc-payment-gateway'),
@@ -423,12 +434,32 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                     'search_company' => __('Search for company', 'twoinc-payment-gateway'),
                 ],
                 'twoinc_checkout_host' => $this->wc_twoinc->get_twoinc_checkout_host(),
-                'enable_company_search' => $enable_company_search,
+                // Always 'yes' at load — TWO-25326 §7.1 correction
+                // 2026-08-04 (Doug's ruling: the search control is never
+                // "off", only relocated). `window.twoinc.enable_company_search`
+                // is a RUNTIME flag in twoinc.js — toggled to "no" only by
+                // enterManualCompanyEntry()/twoincSoleTrader.setMode() to
+                // mean "the search widget is not the active input method
+                // right now" — not the admin's raw checkbox value. Feeding
+                // the raw checkbox value in here used to make the two
+                // meanings collide: a merchant who unchecked the box (asking
+                // for payment-tile placement) also read as "search is
+                // suppressed" everywhere this flag gates the actual
+                // selectWoo widget (Twoinc.enableCompanySearch() and
+                // friends), so nothing in the tile ever became live. Where
+                // the control renders is `company_search_location`'s job,
+                // below — driven by the checkbox — never this flag's.
+                'enable_company_search' => 'yes',
                 'enable_company_search_for_others' => $this->wc_twoinc->get_option('enable_company_search_for_others'),
                 // TWO-25326 §7.1, correction 2026-08-04: where the one
                 // company-search control renders — driven by the
                 // `enable_company_search` checkbox itself (not a setting of
                 // its own; see get_enable_company_search()'s doc comment).
+                // Any JS check for the admin's own "checked" preference
+                // (e.g. gating `enable_company_search_for_others`, which its
+                // own description ties to the checkbox) must read THIS value
+                // against 'address_area', not the runtime
+                // `enable_company_search` flag above.
                 'company_search_location' => self::derive_company_search_location($enable_company_search),
                 'enable_address_lookup' => $this->wc_twoinc->get_option('enable_address_lookup'),
                 'enable_order_intent' => $this->wc_twoinc->get_option('enable_order_intent'),

--- a/tests/js/company-search-tile-location.test.js
+++ b/tests/js/company-search-tile-location.test.js
@@ -120,16 +120,16 @@ describe("company-search tile location (TWO-25326 §7.1)", () => {
      * 2026-08-04: neither WooCommerce's OWN native `#billing_company_field`
      * NOR `#company_id_field` are part of this plugin's search control, and
      * neither may be relocated into the tile. `#billing_company_field` is
-     * the plain, unenhanced fallback the buyer types into when the
-     * checkbox is off (Hyvä companyName.phtml parity: degrade to a plain
-     * field for the same entity attribute, never remove it).
-     * `#company_id_field` moving ALONE (its search-widget partner,
-     * `#billing_company_display_field`, never even exists server-side when
-     * the checkbox is off — see WC_Twoinc_Checkout::update_company_fields())
-     * left a bare, unlabelled, REQUIRED "Company ID" box floating in the
-     * payment tile with no search behind it to fill it from — checkout-
-     * blocking confusion. A version of this function that folds either
-     * field back into its move-set fails this test loudly.
+     * the plain, unenhanced fallback the buyer types into when manual entry
+     * or sole-trader mode takes over (Hyvä companyName.phtml parity:
+     * degrade to a plain field for the same entity attribute, never remove
+     * it). `#company_id_field` is a plain hidden input with no visible home
+     * to move to — it is submitted with the rest of the form regardless of
+     * where inside it it physically sits, and moving it ALONE, without the
+     * search widget behind it, would leave a bare, unlabelled, REQUIRED
+     * "Company ID" box floating in the payment tile — checkout-blocking
+     * confusion. A version of this function that folds either field back
+     * into its move-set fails this test loudly.
      */
     test("never relocates #billing_company_field or #company_id_field — both stay in the address form, visible and editable", () => {
       dom.syncCompanySearchTileLocation();
@@ -157,24 +157,70 @@ describe("company-search tile location (TWO-25326 §7.1)", () => {
     });
 
     /**
-     * Bug found in adversarial review round 2 (Han, 2026-08-04): in the
-     * only state this branch is reachable in today (checkbox unchecked),
-     * `#billing_company_display_field` never exists server-side at all
-     * (WC_Twoinc_Checkout::update_company_fields() only registers it when
-     * `enable_company_search === 'yes'`) — so the move loop is a no-op and
-     * the wrapper stays empty. A version of this function that unhides the
-     * slot unconditionally leaves every checkbox-off merchant with a bare,
-     * unexplained gap (the slot's own `margin: 12px 0`) between the sole-
-     * trader toggle and the intent message on every checkout. This test
-     * removes the display field from the fixture to reproduce that exact
-     * real-world DOM shape and asserts the slot stays hidden.
+     * Bug found in adversarial review round 2 (Han, 2026-08-04), widened in
+     * the 2026-08-04 correction round 3: the field now always exists
+     * server-side (`WC_Twoinc_Checkout::update_company_fields()` no longer
+     * gates its registration on the checkbox), but manual entry and
+     * sole-trader mode still hide it with the `hidden` class rather than
+     * removing it from the DOM (see toggleBusinessFields). The move loop
+     * moves it into the wrapper regardless of that class, so checking mere
+     * presence would unhide the slot around a `display: none` field —
+     * leaving the buyer a bare, unexplained gap
+     * (`.twoinc-company-search-tile-slot`'s own `margin: 12px 0`) between
+     * the sole-trader toggle and the intent message. This test hides the
+     * display field the way toggleBusinessFields does in that state and
+     * asserts the slot stays hidden even though the field itself did move.
      */
-    test("stays hidden when nothing is left to move — the field doesn't exist server-side when the checkbox is off", () => {
-      $("#billing_company_display_field").remove();
+    test("stays hidden when the only thing moved in is a hidden field (manual entry / sole-trader mode)", () => {
+      $("#billing_company_display_field").addClass("hidden");
 
       dom.syncCompanySearchTileLocation();
 
+      expect(
+        $("#billing_company_display_field").closest(".twoinc-company-search-tile-slot").length
+      ).toBe(1);
       expect(tileSlot().hasClass("hidden")).toBe(true);
+    });
+
+    /**
+     * TWO-25326 §7.1, correction 2026-08-04 round 3 (Doug's ruling): the
+     * whole point of this correction is that the search control is
+     * FUNCTIONAL once relocated, not just present in the DOM — the earlier
+     * bug this ticket closes shipped the relocation mechanism with nothing
+     * for it to move, because `update_company_fields()` skipped registering
+     * the field whenever the checkbox was unchecked. Drives the real
+     * checkout-page wiring (`Twoinc.initialize()`, not the helper directly)
+     * so a regression that reintroduces that gate, or that leaves
+     * `enableCompanySearch()` gated on the admin's raw checkbox value again,
+     * fails here rather than only in a narrower unit test.
+     */
+    test("the relocated control is a live, initialized selectWoo widget — not just a moved DOM node", () => {
+      // isCountrySupported() (called from toggleBusinessFields, which
+      // initialize() reaches) reads this — absent from the fixture above,
+      // which never exercises that branch itself.
+      ctx.twoinc.supported_buyer_countries = ["GB"];
+
+      ctx.$("form[name='checkout']").after('<div id="order_review"></div>');
+      ctx
+        .$("form[name='checkout']")
+        .append(
+          "<input type='radio' id='payment_method_" +
+            GATEWAY_ID +
+            "' name='payment_method' value='" +
+            GATEWAY_ID +
+            "' checked />"
+        );
+
+      ctx.Twoinc.getInstance().initialize(false);
+
+      expect(
+        $("#billing_company_display_field").closest(".twoinc-company-search-tile-slot").length
+      ).toBe(1);
+      expect(tileSlot().hasClass("hidden")).toBe(false);
+      expect($("#billing_company_display").data("select2")).toBeTruthy();
+
+      harness.releaseWidgets($);
+      $(document.body).off();
     });
 
     test("detach-to-safety is also idempotent — a second call in a row does not re-move an already-parked wrapper (round 2 review — Vader)", () => {

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -34,6 +34,7 @@ final class BrandConfigSpec
             'testCheckoutFieldsHookFires',
             'testInvoiceEmailFieldHasNoPlaceholder',
             'testFieldPrioritiesMatchDesiredCheckoutOrder',
+            'testBillingCompanyDisplayAlwaysRegisteredRegardlessOfCheckbox',
             'testCompanyPriorityClampPreventsInversionAboveOptionals',
             'testLocaleDefaultCountryPriorityStaysBelowCompany',
             'testConfirmationUrlHookReceivesUrlAndOrderId',
@@ -474,6 +475,54 @@ final class BrandConfigSpec
         TinyAssert::true($p('invoice_email') < $p('purchase_order_number'));
         TinyAssert::true($p('purchase_order_number') < $p('project'));
         TinyAssert::true($p('project') < $p('department'));
+    }
+
+    /**
+     * TWO-25326 §7.1, correction 2026-08-04 round 3 (Doug's ruling). The ONE
+     * company-search control must always be registered by
+     * update_company_fields() — the checkbox this ticket is about
+     * ("Enable Company Search In Address Entry") only ever decides WHERE it
+     * renders (address area vs payment tile, via `company_search_location`
+     * — see derive_company_search_location() and
+     * twoincDomHelper.syncCompanySearchTileLocation() in twoinc.js), never
+     * whether it exists. A gate here that skips registration when the
+     * checkbox is unchecked is exactly the bug this correction closes: the
+     * payment-tile relocation JS then has nothing to move, and the buyer
+     * sees no working search anywhere on the page. Checked in both
+     * directions so a regression that reintroduces the gate in either
+     * direction fails here rather than only live.
+     */
+    private static function testBillingCompanyDisplayAlwaysRegisteredRegardlessOfCheckbox(): void
+    {
+        foreach (['yes', 'no', null, ''] as $enableCompanySearch) {
+            $gateway = new class ($enableCompanySearch) extends WC_Twoinc {
+                private $enable_company_search;
+
+                public function __construct($enable_company_search)
+                {
+                    $this->id = WC_Twoinc_Brand::get('gateway_id');
+                    $this->enable_company_search = $enable_company_search;
+                }
+
+                public function get_option($key, $empty_value = null)
+                {
+                    return '';
+                }
+
+                public function get_enable_company_search()
+                {
+                    return $this->enable_company_search;
+                }
+            };
+
+            $checkout = new WC_Twoinc_Checkout($gateway);
+            $fields = $checkout->update_company_fields(['billing' => []]);
+
+            TinyAssert::true(
+                isset($fields['billing']['billing_company_display']),
+                'billing_company_display must be registered when get_enable_company_search() returns ' . var_export($enableCompanySearch, true)
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
## What

Fixes TWO-25326 item §7.1/#64.1: unchecking "Enable Company Search In Address Entry" is supposed to relocate the ONE company-search control into the payment tile, never turn it off. `WC_Twoinc_Checkout::update_company_fields()` still gated the control's registration on that checkbox, so unchecking it left the tile's relocation JS (`syncCompanySearchTileLocation()`) with nothing to move — the tile rendered empty and buyers saw only the plain, unenhanced fallback fields with no working search anywhere on the page.

## Change

- `update_company_fields()` now registers `billing_company_display` unconditionally. Only its mount location (address area vs payment tile) is still driven by the checkbox, via the existing `company_search_location` derivation.
- Decouples `window.twoinc.enable_company_search`'s two prior meanings:
  - the admin's raw checkbox preference — now read via `company_search_location` wherever that's what's meant (the three `enable_company_search_for_others` gates, which the setting's own description ties to address-area placement)
  - the JS runtime "is the search widget the active input method right now" flag — now always `"yes"` at page load, since the control is never fully off; still toggled to `"no"` by manual-entry and sole-trader mode exactly as before.
- Widens `syncCompanySearchTileLocation()`'s unhide guard from "wrapper has a child" to "wrapper has a *visible* child" — manual-entry/sole-trader mode now leaves a real (but `hidden`-classed) field in the wrapper instead of no field existing at all, and the old guard would have unhidden an empty-looking tile around it.
- Corrected several doc comments across `WC_Twoinc_Checkout.php`, `twoinc.js` and the Jest suite that had documented the old gate as permanent, intended behaviour.

No block-checkout code path exists in this plugin to update — `WC_Twoinc_Checkout` hooks the classic `woocommerce_checkout_fields` filter only; there's no WooCommerce Blocks integration in this repo.

## Testing

- `php tests/unit/run.php` — full suite green, plus a new test asserting `billing_company_display` is registered regardless of `get_enable_company_search()`'s return value (`yes`/`no`/`null`/`''`).
- `npm run test:js` — 320/320 green. Extended `company-search-tile-location.test.js` with:
  - a test driving the real `Twoinc.initialize()` wiring and asserting the relocated control is a live, initialized selectWoo widget (`$(...).data("select2")` truthy) while sitting inside the tile slot — not just a moved DOM node
  - an updated hidden-field guard test reflecting the field's new always-present, sometimes-`hidden` DOM shape

Confirmed exactly one company-search control definition in the codebase (`billing_company_display` / `#billing_company_display_field`) — no second parallel implementation was added for the tile.

Not merging — leaving for review per standing process.