### PR TITLE
fix(company-search): re-decide tile visibility on payment-method switch (TWO-25326)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ cat > docker/config/staging.json <<EOF
   "show_abt_link": "yes",
   "section_auto_complete_settings": "",
   "enable_company_search": "yes",
-  "enable_company_search_for_others": "yes",
   "enable_address_lookup": "yes"
 }
 EOF

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -43,10 +43,6 @@ jQuery(function ($) {
     function (e) {
       toggleChildrenFields(
         $(this),
-        $("#woocommerce_" + twoinc_admin.gateway_id + "_enable_company_search_for_others")
-      );
-      toggleChildrenFields(
-        $(this),
         $("#woocommerce_" + twoinc_admin.gateway_id + "_enable_address_lookup")
       );
     }
@@ -72,10 +68,6 @@ jQuery(function ($) {
 
   jQuery("h3.wc-settings-sub-title").next().hide();
 
-  toggleChildrenFields(
-    $("#woocommerce_" + twoinc_admin.gateway_id + "_enable_company_search"),
-    $("#woocommerce_" + twoinc_admin.gateway_id + "_enable_company_search_for_others")
-  );
   toggleChildrenFields(
     $("#woocommerce_" + twoinc_admin.gateway_id + "_enable_company_search"),
     $("#woocommerce_" + twoinc_admin.gateway_id + "_enable_address_lookup")

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -2573,10 +2573,18 @@ let twoincDomHelper = {
         }
       }
     } else {
+      // Whether company search is available for OTHER payment methods is no
+      // longer a setting of its own (TWO-25326, Doug's ruling: a separate
+      // `enable_company_search_for_others` toggle was one control too many —
+      // there is no scenario where a merchant wants this to disagree with
+      // "Enable Company Search In Address Entry"). It now follows that same
+      // admin checkbox directly, via `company_search_location`
+      // ('address_area' means checked): checked shows the search field for
+      // other payment methods too, unchecked does not.
       if (
         twoincDomHelper.isCountrySupported() &&
         window.twoinc.enable_company_search === "yes" &&
-        window.twoinc.enable_company_search_for_others === "yes"
+        window.twoinc.company_search_location === "address_area"
       ) {
         visibleTargets.push("#billing_company_display_field");
       } else {
@@ -3900,9 +3908,11 @@ class Twoinc {
       twoincDomHelper.isTwoincVisible() ||
       // Admin's address-area preference, not the runtime
       // `enable_company_search` flag — see the comment on the equivalent
-      // check in toggleBusinessFields (TWO-25326 §7.1).
-      (window.twoinc.company_search_location === "address_area" &&
-        window.twoinc.enable_company_search_for_others === "yes")
+      // check in toggleBusinessFields (TWO-25326 §7.1). No longer ANDed with
+      // a separate "for other payment methods" toggle (removed, TWO-25326 —
+      // that setting is now just this same checkbox, so the AND collapsed
+      // to a no-op).
+      window.twoinc.company_search_location === "address_area"
     ) {
       // Toggle the business fields
       twoincDomHelper.toggleBusinessFields();
@@ -4018,6 +4028,39 @@ class Twoinc {
     // already bound above) is what moves the wrapper back into the fresh
     // slot.
     $body.on("update_checkout", twoincSelectWooHelper.detachCompanySearchTileWrapperToSafety);
+
+    // A payment-method switch must re-DECIDE company-field visibility, not
+    // just relocate whatever is already there (TWO-25326 bugfix, Doug
+    // live-verified: the search control never appeared in the payment tile
+    // at all). `onUpdatedCheckout()` below only calls
+    // `syncCompanySearchTileLocation()` — it never revisits which field
+    // `toggleBusinessFields()` decided to show, so a buyer who starts on a
+    // DIFFERENT gateway (the ordinary case: WooCommerce checks the first
+    // available gateway by default) and switches TO this one saw an empty
+    // tile: `#billing_company_display_field`'s hidden/visible decision was
+    // made once, at page load, while some other gateway was selected — the
+    // "other payment methods" branch of `toggleBusinessFields()`, gated on
+    // `enable_company_search_for_others` — and nothing re-ran that decision
+    // on the switch. `syncCompanySearchTileLocation()`'s own "unhide only if
+    // a VISIBLE child moved in" guard (see its doc comment) then correctly
+    // kept the slot hidden around a still-hidden field, which is the exact
+    // symptom reported live.
+    //
+    // The `change` listener `onUpdatedCheckout()` itself re-registers on
+    // every `updated_checkout` (below) cannot be relied on for this: it is
+    // bound too late to catch the FIRST payment-method switch of a session,
+    // since nothing forces `updated_checkout` to have fired even once before
+    // a buyer picks a payment method, and — unbound with no matching `.off`
+    // — it accumulates a duplicate on every cycle besides. Namespaced and
+    // delegated here instead, alongside this function's other one-time
+    // bindings, so it exists before the buyer's first click and never
+    // duplicates across repeated `initialize()` calls (guarded by
+    // `isInitialized` above, same as every other binding in this function).
+    $body
+      .off("change.twoincPaymentMethod", 'input[name="payment_method"]')
+      .on("change.twoincPaymentMethod", 'input[name="payment_method"]', function () {
+        twoincDomHelper.toggleBusinessFields();
+      });
 
     // No click handler for the manual-entry row (TWO-25288). It is a pseudo-
     // option inside the results list now, so the picker already turns a click
@@ -4481,9 +4524,11 @@ class Twoinc {
 
     Twoinc.getInstance().updateElements();
 
-    jQuery('input[name="payment_method"]').on("change", function () {
-      twoincDomHelper.toggleBusinessFields();
-    });
+    // Payment-method-switch handling moved to a single namespaced, delegated
+    // binding in `initialize()` (TWO-25326 bugfix) — bound once, before the
+    // buyer's first click, rather than re-registered (with no `.off()`, so it
+    // duplicated) on every `updated_checkout`. See that binding's own doc
+    // comment for the live bug this closes.
 
     twoincDomHelper.rearrangeDescription();
 
@@ -4940,14 +4985,15 @@ jQuery(function () {
         // country change). The old one-shot check left company search
         // unwired for the whole session. Re-check on every
         // updated_checkout; and when company search is enabled for other
-        // methods, wire it immediately — that setting exists precisely
-        // for checkouts where this gateway isn't offered.
+        // methods — the same "Enable Company Search In Address Entry"
+        // checkbox, no separate setting any more (TWO-25326) — wire it
+        // immediately: that state exists precisely for checkouts where this
+        // gateway isn't offered.
         if (
           // Admin's address-area preference, not the runtime
           // `enable_company_search` flag — see the comment on the
           // equivalent check in toggleBusinessFields (TWO-25326 §7.1).
-          window.twoinc.company_search_location === "address_area" &&
-          window.twoinc.enable_company_search_for_others === "yes"
+          window.twoinc.company_search_location === "address_area"
         ) {
           Twoinc.getInstance().initialize(true);
         } else {

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -683,7 +683,16 @@ if (!class_exists('WC_Twoinc')) {
             // sitting inert in their settings row (adversarial review
             // finding, Yoda). Same mechanism as `enable_sole_trader`
             // (TWO-25163).
-            $removed = ['enable_sole_trader', 'company_search_location'];
+            //
+            // 'enable_company_search_for_others' (TWO-25326, Doug's ruling):
+            // a second, independent toggle for whether company search shows
+            // on OTHER payment methods was one control too many — there is
+            // no scenario where a merchant wants that to disagree with
+            // "Enable Company Search In Address Entry" itself, so the
+            // behaviour now follows that same checkbox directly (see
+            // `WC_Twoinc_Checkout::prepare_twoinc_object()` and
+            // `twoincDomHelper.toggleBusinessFields()` in twoinc.js).
+            $removed = ['enable_sole_trader', 'company_search_location', 'enable_company_search_for_others'];
             $present = [];
             foreach ($removed as $key) {
                 if (is_array($this->settings) && array_key_exists($key, $this->settings)) {
@@ -994,21 +1003,19 @@ if (!class_exists('WC_Twoinc')) {
             // The tile-location slot below is new (§7.1): empty and hidden by
             // default (enable_company_search checked, the unchanged
             // behaviour). When the merchant UNCHECKS "Enable Company Search
-            // In Address Entry", twoincDomHelper.syncCompanySearchTileLocation()
+            // In Address Entry", twoincSelectWooHelper.syncCompanySearchTileLocation()
             // in twoinc.js relocates `#billing_company_display_field` (the
-            // ONLY field still eligible to move here as of the 2026-08-04
-            // correction — `#billing_company_field` and `#company_id_field`
-            // deliberately stay in the address form; see that function's own
-            // doc comment) into this slot, and unhides the slot only if
-            // something actually moved in. In practice today that field
-            // never exists server-side when the checkbox is unchecked (see
-            // update_company_fields() in WC_Twoinc_Checkout), so this slot
-            // currently stays empty and hidden in every reachable state —
-            // tracked as a known gap, not a bug: making search functionally
-            // live inside the tile is bigger scope than this correction.
-            // Always rendered (a hidden empty div is cheap) so the JS never
-            // has to special-case "the slot doesn't exist yet" against "the
-            // setting is off".
+            // ONLY field still eligible to move here — `#billing_company_field`
+            // and `#company_id_field` deliberately stay in the address form;
+            // see that function's own doc comment) into this slot, and
+            // unhides the slot only if something actually moved in. The
+            // field is always registered server-side now (see
+            // update_company_fields() in WC_Twoinc_Checkout — the earlier
+            // gate that skipped registration on an unchecked box is
+            // removed), so this branch is live: a functional selectWoo
+            // search inside the tile, not an empty box. Always rendered (a
+            // hidden empty div is cheap) so the JS never has to special-case
+            // "the slot doesn't exist yet" against "the setting is off".
             $company_search_tile_slot = '<div class="twoinc-company-search-tile-slot hidden"></div>';
 
             return sprintf(
@@ -3925,14 +3932,6 @@ if (!class_exists('WC_Twoinc')) {
                 'enable_company_search' => [
                     'title'       => __('Enable Company Search In Address Entry', 'twoinc-payment-gateway'),
                     'description' => __('When enabled, the buyer may search for their company within the address entry section of the checkout. Otherwise, company search will be visible within the payment method.', 'twoinc-payment-gateway'),
-                    'desc_tip'    => true,
-                    'label'       => ' ',
-                    'type'        => 'checkbox',
-                    'default'     => 'yes'
-                ],
-                'enable_company_search_for_others' => [
-                    'title'       => __('Enable company name search for other payment options', 'twoinc-payment-gateway'),
-                    'description' => __('Enables searching for company name even when other payment options are selected. Requires the option above to be checked.', 'twoinc-payment-gateway'),
                     'desc_tip'    => true,
                     'label'       => ' ',
                     'type'        => 'checkbox',

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -451,16 +451,17 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                 // the control renders is `company_search_location`'s job,
                 // below — driven by the checkbox — never this flag's.
                 'enable_company_search' => 'yes',
-                'enable_company_search_for_others' => $this->wc_twoinc->get_option('enable_company_search_for_others'),
                 // TWO-25326 §7.1, correction 2026-08-04: where the one
                 // company-search control renders — driven by the
                 // `enable_company_search` checkbox itself (not a setting of
                 // its own; see get_enable_company_search()'s doc comment).
-                // Any JS check for the admin's own "checked" preference
-                // (e.g. gating `enable_company_search_for_others`, which its
-                // own description ties to the checkbox) must read THIS value
-                // against 'address_area', not the runtime
-                // `enable_company_search` flag above.
+                // Any JS check for the admin's own "checked" preference —
+                // including whether company search shows for OTHER payment
+                // methods, which is this same checkbox now too (the
+                // standalone `enable_company_search_for_others` setting was
+                // removed, Doug's ruling) — must read THIS value against
+                // 'address_area', not the runtime `enable_company_search`
+                // flag above.
                 'company_search_location' => self::derive_company_search_location($enable_company_search),
                 'enable_address_lookup' => $this->wc_twoinc->get_option('enable_address_lookup'),
                 'enable_order_intent' => $this->wc_twoinc->get_option('enable_order_intent'),

--- a/tests/js/company-search-focus-trap.test.js
+++ b/tests/js/company-search-focus-trap.test.js
@@ -38,7 +38,6 @@ describe("company-search focus trap", () => {
       text: TEXT,
       supported_buyer_countries: ["GB"],
       enable_company_search: "yes",
-      enable_company_search_for_others: "yes",
       enable_address_lookup: "no"
     });
     $ = ctx.$;

--- a/tests/js/company-search-manual-entry.test.js
+++ b/tests/js/company-search-manual-entry.test.js
@@ -49,7 +49,6 @@ describe("company-search manual-entry affordance", () => {
       text: TEXT,
       supported_buyer_countries: ["GB"],
       enable_company_search: "yes",
-      enable_company_search_for_others: "yes",
       enable_address_lookup: "no"
     });
     $ = ctx.$;

--- a/tests/js/company-search-payment-method-switch.test.js
+++ b/tests/js/company-search-payment-method-switch.test.js
@@ -1,0 +1,190 @@
+"use strict";
+
+/**
+ * TWO-25326: switching payment method TO the Two gateway, from a different
+ * gateway checked by default, must re-decide company-field visibility — not
+ * just relocate whatever `toggleBusinessFields()` already decided at page
+ * load.
+ *
+ * Live bug (Doug, 2026-08-04): with "Enable Company Search In Address
+ * Entry" unchecked (`company_search_location: 'payment_tile'`), the search
+ * control never appeared in the payment tile at all. Root cause:
+ * `onUpdatedCheckout()` calls `syncCompanySearchTileLocation()` directly on
+ * every `updated_checkout`, but nothing reliably called
+ * `toggleBusinessFields()` — the function that actually decides whether
+ * `#billing_company_display_field` is shown — when the buyer SWITCHED to
+ * this gateway from a different one. WooCommerce checks the first available
+ * gateway by default, so this is the ordinary case, not an edge one. The
+ * only rebind that existed lived inside `onUpdatedCheckout()` itself
+ * (`jQuery('input[name="payment_method"]').on("change", ...)`, no matching
+ * `.off()`), which is bound too late to catch the FIRST switch of a session
+ * — nothing forces `updated_checkout` to have fired even once before a buyer
+ * picks a payment method — and accumulates a duplicate on every cycle
+ * besides. `syncCompanySearchTileLocation()`'s own "unhide only if a VISIBLE
+ * child moved in" guard then correctly kept the tile slot hidden around a
+ * still-hidden field, which is the exact symptom reported live.
+ *
+ * The fix moves this to a single namespaced, delegated binding in
+ * `initialize()` — bound once, before the buyer's first click. This suite
+ * drives the real bootstrap IIFE (the trailing `jQuery(function () { ... })`
+ * block) rather than the helper methods directly, because that block is what
+ * wires (or fails to wire) the payment-method listener in the first place;
+ * `wc-harness.js` deliberately loads with `window.twoinc` ABSENT so that
+ * block no-ops (see its own doc comment), which is why no other suite caught
+ * this.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const SOURCE_PATH = "assets/js/twoinc.js";
+
+const GATEWAY_ID = "woocommerce-gateway-tillit";
+const OTHER_GATEWAY_ID = "cod";
+
+/**
+ * @returns {Function} the jQuery instance bound to the current jsdom window
+ */
+function installJQuery() {
+  const jQuery = require("jquery");
+  global.$ = jQuery;
+  global.jQuery = jQuery;
+  global.window.$ = jQuery;
+  global.window.jQuery = jQuery;
+  require("selectwoo/dist/js/selectWoo.full.js")(global.window, jQuery);
+  return jQuery;
+}
+
+/** @returns {void} */
+function installWcParams() {
+  const params = {
+    i18n_input_too_short_1: "Please enter 1 or more characters",
+    i18n_input_too_short_n: "Please enter %qty% or more characters",
+    i18n_no_matches: "No matches found",
+    i18n_searching: "Searching…"
+  };
+  global.wc_country_select_params = params;
+  global.window.wc_country_select_params = params;
+}
+
+/**
+ * Classic-checkout markup with a DIFFERENT gateway (`cod`) checked by
+ * default and the Two gateway present but unchecked, its payment box
+ * carrying the empty, hidden tile slot `get_pay_box_description()` renders.
+ *
+ * @returns {void}
+ */
+function buildCheckoutForm() {
+  document.body.innerHTML = [
+    '<form name="checkout" class="checkout woocommerce-checkout">',
+    '  <p id="billing_country_field">',
+    '    <select id="billing_country" name="billing_country">',
+    '      <option value="GB" selected>UK</option>',
+    "    </select>",
+    "  </p>",
+    '  <p id="billing_company_display_field" class="billing_company_selectwoo form-row-wide hidden">',
+    '    <select id="billing_company_display" name="billing_company_display">' +
+      '<option value="">&nbsp;</option>' +
+      "</select>",
+    "  </p>",
+    '  <p id="billing_company_field">',
+    '    <label for="billing_company">Company name</label>',
+    '    <span class="woocommerce-input-wrapper">',
+    "      <input type='text' id='billing_company' name='billing_company' value='' />",
+    "    </span>",
+    "  </p>",
+    '  <p id="company_id_field" class="hidden">',
+    "    <input type='text' id='company_id' name='company_id' value='' />",
+    "  </p>",
+    '  <div id="order_review"></div>',
+    '  <div id="payment" class="woocommerce-checkout-payment">',
+    '    <ul class="wc_payment_methods payment_methods methods">',
+    '      <li class="wc_payment_method payment_method_' + OTHER_GATEWAY_ID + '">',
+    '        <input type="radio" id="payment_method_' +
+      OTHER_GATEWAY_ID +
+      '" name="payment_method" value="' +
+      OTHER_GATEWAY_ID +
+      '" checked />',
+    "      </li>",
+    '      <li class="wc_payment_method payment_method_' + GATEWAY_ID + '">',
+    '        <input type="radio" id="payment_method_' +
+      GATEWAY_ID +
+      '" name="payment_method" value="' +
+      GATEWAY_ID +
+      '" />',
+    '        <div class="payment_box payment_method_' + GATEWAY_ID + '">',
+    '          <div class="twoinc-company-search-tile-slot hidden"></div>',
+    "        </div>",
+    "      </li>",
+    "    </ul>",
+    "  </div>",
+    "</form>"
+  ].join("\n");
+}
+
+/**
+ * Evaluate the plugin source with `window.twoinc` already installed, so the
+ * trailing bootstrap IIFE actually runs (mirrors `wc-harness.js`'s
+ * `loadPluginSource`, but deliberately WITHOUT its "load first, install
+ * `window.twoinc` after" ordering — see this file's own doc comment for why
+ * that ordering is exactly what this suite must not use).
+ *
+ * @returns {void}
+ */
+function loadPluginSourceWithBootstrap() {
+  const src = fs.readFileSync(path.join(REPO_ROOT, SOURCE_PATH), "utf8");
+  const indirectEval = eval;
+  indirectEval(src);
+}
+
+describe("payment-method switch onto the Two gateway (TWO-25326)", () => {
+  test("the search control appears in the payment tile after switching TO Two from a different default gateway", async () => {
+    buildCheckoutForm();
+    installJQuery();
+    installWcParams();
+
+    global.window.twoinc = {
+      gateway_id: GATEWAY_ID,
+      enable_company_search: "yes",
+      company_search_location: "payment_tile",
+      enable_order_intent: "yes",
+      enable_address_lookup: "no",
+      supported_buyer_countries: ["GB"],
+      twoinc_checkout_host: "https://api.example.test",
+      client_name: "woocommerce",
+      client_version: "0.0.0-test",
+      text: {}
+    };
+    global.twoinc = global.window.twoinc;
+
+    loadPluginSourceWithBootstrap();
+
+    // Let the deferred jQuery-ready bootstrap actually run: jsdom/jQuery
+    // defer it at least a tick even when `document.readyState` is already
+    // 'complete' by the time this test body runs.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const $ = global.window.jQuery;
+
+    // Sanity check on the fixture itself: at page load, with the OTHER
+    // gateway selected and `company_search_location` "payment_tile" (i.e.
+    // the checkbox unchecked), the search control is correctly absent for
+    // this OTHER gateway — the "other payment methods" branch of
+    // `toggleBusinessFields()` working as designed. If this assertion starts
+    // failing, the bug below is no longer isolated to the switch.
+    expect($("#billing_company_display_field").hasClass("hidden")).toBe(true);
+
+    // The buyer switches to the Two gateway.
+    $("#payment_method_" + GATEWAY_ID)
+      .prop("checked", true)
+      .trigger("change");
+
+    expect($("#billing_company_display_field").hasClass("hidden")).toBe(false);
+    expect(
+      $("#billing_company_display_field").closest(".twoinc-company-search-tile-slot").length
+    ).toBe(1);
+    expect($(".twoinc-company-search-tile-slot").hasClass("hidden")).toBe(false);
+  });
+});

--- a/tests/js/company-summary.test.js
+++ b/tests/js/company-summary.test.js
@@ -40,7 +40,6 @@ describe("read-only captured-company summary", () => {
       gateway_id: GATEWAY_ID,
       supported_buyer_countries: ["GB"],
       enable_company_search: "yes",
-      enable_company_search_for_others: "yes",
       enable_address_lookup: "no",
       text: {}
     });

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -200,6 +200,7 @@ final class BrandConfigSpec
             'testCompanySearchLocationDerivedFromEnableCompanySearchBothDirections',
             'testCompanySearchLocationFallsBackToPaymentTileOnNullOrEmpty',
             'testCompanySearchLocationSettingDroppedFromUpgradedInstalls',
+            'testEnableCompanySearchForOthersSettingDroppedFromUpgradedInstalls',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -5435,6 +5436,43 @@ final class BrandConfigSpec
         $drop->setAccessible(true);
 
         $GLOBALS['__twoinc_test_options'][$key] = ['company_search_location' => 'payment_tile', 'api_key' => 'keep-me'];
+        $gateway->init_settings();
+        $drop->invoke($gateway);
+        TinyAssert::same(['api_key' => 'keep-me'], $GLOBALS['__twoinc_test_options'][$key]);
+    }
+
+    /**
+     * TWO-25326, Doug's ruling: the standalone "Enable company name search
+     * for other payment options" setting is removed outright — whether
+     * company search shows for OTHER payment methods now follows the same
+     * "Enable Company Search In Address Entry" checkbox directly, with no
+     * independent toggle. Mirrors
+     * testCompanySearchLocationSettingDroppedFromUpgradedInstalls above: the
+     * admin field must be gone, and drop_removed_settings() must clean the
+     * option key up on an install that saved it before removal.
+     */
+    private static function testEnableCompanySearchForOthersSettingDroppedFromUpgradedInstalls(): void
+    {
+        $gateway = new class () extends WC_Twoinc {
+            public function __construct()
+            {
+                $this->id = WC_Twoinc_Brand::get('gateway_id');
+            }
+        };
+        $gateway->init_form_fields();
+        TinyAssert::same(
+            false,
+            array_key_exists('enable_company_search_for_others', $gateway->form_fields)
+        );
+
+        $key = $gateway->get_option_key();
+        $drop = new ReflectionMethod(WC_Twoinc::class, 'drop_removed_settings');
+        $drop->setAccessible(true);
+
+        $GLOBALS['__twoinc_test_options'][$key] = [
+            'enable_company_search_for_others' => 'yes',
+            'api_key' => 'keep-me'
+        ];
         $gateway->init_settings();
         $drop->invoke($gateway);
         TinyAssert::same(['api_key' => 'keep-me'], $GLOBALS['__twoinc_test_options'][$key]);


### PR DESCRIPTION
## Bug 1 — search control not visible in payment tile

Root cause: with "Enable Company Search In Address Entry" unchecked (`company_search_location: payment_tile`), the search control never appeared in the payment tile at all when the buyer switched TO the Two gateway from a different default gateway — the ordinary case, since WooCommerce checks the first available gateway by default.

`toggleBusinessFields()` is the function that decides whether `#billing_company_display_field` is shown. `onUpdatedCheckout()` only relocates whatever is already there via `syncCompanySearchTileLocation()`; the only rebind of `toggleBusinessFields()` to a `payment_method` change lived *inside* `onUpdatedCheckout()` itself, with no matching `.off()` — bound too late to catch the first switch of a session (nothing forces `updated_checkout` to have fired before a buyer picks a payment method), and it accumulated a duplicate on every cycle besides. `syncCompanySearchTileLocation()`'s own "unhide only if a visible child moved in" guard then correctly kept the tile slot hidden around a still-hidden field — the exact symptom reported.

Fix: a single namespaced, delegated `payment_method` change listener bound once in `initialize()`, calling `toggleBusinessFields()` directly. The late/duplicating rebind is removed from `onUpdatedCheckout()`.

New regression test: `tests/js/company-search-payment-method-switch.test.js` drives the real bootstrap IIFE (the existing harness deliberately leaves it un-exercised) and fails against the pre-fix code — verified locally by reverting the JS change and re-running.

## Requirement 2 — remove "Enable company name search for other payment options"

Removed entirely per Doug's ruling: a second, independent toggle never made sense — it now just follows the main "Enable Company Search In Address Entry" checkbox (`company_search_location === 'address_area'`). Removed:
- the admin field registration
- the JS reads (`window.twoinc.enable_company_search_for_others`), replaced with a read of `company_search_location`
- the admin.js visibility wiring
- the README sample config entry

`drop_removed_settings()` purges the option key from upgraded installs (same mechanism as `enable_sole_trader`/`company_search_location`), covered by a new PHP test.

## Testing

- `npm run test:js`: 11 suites / 323 tests, all pass
- `php tests/unit/run.php`: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)