### PR TITLE
fix(company-search): sentence-case address-entry search label (TWO-25326)

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -2537,7 +2537,7 @@ let twoincDomHelper = {
         // WooCommerce's OWN native company field is a completely separate
         // concern from where OUR search control lives (bug found by Doug
         // 2026-08-04, live-verified against the checkbox-off/payment_tile
-        // state): unchecking "Enable Company Search In Address Entry" moves
+        // state): unchecking "Enable company search in address entry" moves
         // the search control into the payment tile, but must never take
         // WooCommerce's stock field away from the address area — the two
         // coexist, search in the tile, native field where WC always puts
@@ -2577,7 +2577,7 @@ let twoincDomHelper = {
       // longer a setting of its own (TWO-25326, Doug's ruling: a separate
       // `enable_company_search_for_others` toggle was one control too many —
       // there is no scenario where a merchant wants this to disagree with
-      // "Enable Company Search In Address Entry"). It now follows that same
+      // "Enable company search in address entry"). It now follows that same
       // admin checkbox directly, via `company_search_location`
       // ('address_area' means checked): checked shows the search field for
       // other payment methods too, unchecked does not.
@@ -4985,7 +4985,7 @@ jQuery(function () {
         // country change). The old one-shot check left company search
         // unwired for the whole session. Re-check on every
         // updated_checkout; and when company search is enabled for other
-        // methods — the same "Enable Company Search In Address Entry"
+        // methods — the same "Enable company search in address entry"
         // checkbox, no separate setting any more (TWO-25326) — wire it
         // immediately: that state exists precisely for checkouts where this
         // gateway isn't offered.

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -688,7 +688,7 @@ if (!class_exists('WC_Twoinc')) {
             // a second, independent toggle for whether company search shows
             // on OTHER payment methods was one control too many — there is
             // no scenario where a merchant wants that to disagree with
-            // "Enable Company Search In Address Entry" itself, so the
+            // "Enable company search in address entry" itself, so the
             // behaviour now follows that same checkbox directly (see
             // `WC_Twoinc_Checkout::prepare_twoinc_object()` and
             // `twoincDomHelper.toggleBusinessFields()` in twoinc.js).
@@ -3930,7 +3930,7 @@ if (!class_exists('WC_Twoinc')) {
                     'title'       => __('Auto-complete settings', 'twoinc-payment-gateway')
                 ],
                 'enable_company_search' => [
-                    'title'       => __('Enable Company Search In Address Entry', 'twoinc-payment-gateway'),
+                    'title'       => __('Enable company search in address entry', 'twoinc-payment-gateway'),
                     'description' => __('When enabled, the buyer may search for their company within the address entry section of the checkout. Otherwise, company search will be visible within the payment method.', 'twoinc-payment-gateway'),
                     'desc_tip'    => true,
                     'label'       => ' ',

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -483,7 +483,7 @@ final class BrandConfigSpec
      * TWO-25326 §7.1, correction 2026-08-04 round 3 (Doug's ruling). The ONE
      * company-search control must always be registered by
      * update_company_fields() — the checkbox this ticket is about
-     * ("Enable Company Search In Address Entry") only ever decides WHERE it
+     * ("Enable company search in address entry") only ever decides WHERE it
      * renders (address area vs payment tile, via `company_search_location`
      * — see derive_company_search_location() and
      * twoincDomHelper.syncCompanySearchTileLocation() in twoinc.js), never
@@ -5445,7 +5445,7 @@ final class BrandConfigSpec
      * TWO-25326, Doug's ruling: the standalone "Enable company name search
      * for other payment options" setting is removed outright — whether
      * company search shows for OTHER payment methods now follows the same
-     * "Enable Company Search In Address Entry" checkbox directly, with no
+     * "Enable company search in address entry" checkbox directly, with no
      * independent toggle. Mirrors
      * testCompanySearchLocationSettingDroppedFromUpgradedInstalls above: the
      * admin field must be gone, and drop_removed_settings() must clean the


### PR DESCRIPTION
Sentence-case the "Enable Company Search In Address Entry" admin label to match house style.

## What changed
- `class/WC_Twoinc.php`: label -> "Enable company search in address entry" (no trailing period)
- `tests/unit/run.php`: doc-comment references to the old string updated to match

## Convention check
PrestaShop's equivalent label was sentence-cased in PR #138. Checked other admin labels on the same WooCommerce settings page — most verb-phrase labels already use sentence case with no trailing period (e.g. "Skip user validation at order confirmation", "Pre-approve buyer during checkout", "Clear settings on deactivation of plug-in", "Display input tooltips"). No label on the page carries a trailing period, so the period was dropped from Doug's literal wording to stay consistent with the actual codebase convention.

No translation files (.pot/.po) reference this string yet — it hadn't been extracted for translation. No test asserts the exact string as a value; only doc-comment prose quoted it, which was updated for accuracy.

## Test plan
- [x] `make test-unit` — all pass
- [x] `npm run test:js` — 323 passed
