### PR TITLE
fix: clear stale merchant ID/short name when API key verification fails

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -107,6 +107,18 @@ jQuery(function ($) {
     $("#twoinc-merchant-short-name").text(shortName ? " · " + shortName : "");
     $("#twoinc-merchant-info").show();
     $("#twoinc-signup-prompt").hide();
+    $("#twoinc-merchant-invalid-notice").hide();
+  }
+
+  // A failed verification must not leave the previously fetched Merchant ID
+  // on screen — that reads as "the integration is fine" when it isn't. Swap
+  // it for an explicit invalid-key notice instead (this call site is the fix
+  // for the settings page silently keeping stale merchant info on a broken
+  // key).
+  function showMerchantInfoInvalid() {
+    $("#twoinc-merchant-info").hide();
+    $("#twoinc-signup-prompt").hide();
+    $("#twoinc-merchant-invalid-notice").show();
   }
 
   function verifyApiKey(apiKey) {
@@ -131,10 +143,12 @@ jQuery(function ($) {
           updateMerchantInfo(response.data);
         } else {
           showVerificationStatus("invalid");
+          showMerchantInfoInvalid();
         }
       },
       error: function () {
         showVerificationStatus("invalid");
+        showMerchantInfoInvalid();
       }
     });
   }

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -4173,6 +4173,10 @@ if (!class_exists('WC_Twoinc')) {
                         <div id="twoinc-signup-prompt" style="margin-top: 8px; color: #666; font-size: 13px;<?php echo $merchant_id ? ' display: none;' : ''; ?>">
                             <strong><?php printf(__('Don\'t have an API key? Get one by signing up <a href=\'%s\'>here</a>.', 'twoinc-payment-gateway'), esc_url(WC_Twoinc_Brand::get('sign_up_url'))); ?></strong>
                         </div>
+                        <?php // Hidden by default; shown by admin.js in place of the merchant info above when the live re-verification (always run on page load) finds the stored key no longer valid, so a broken key can't hide behind a stale cached Merchant ID (TWO-25326 follow-up). ?>
+                        <div id="twoinc-merchant-invalid-notice" style="margin-top: 8px; color: #dc3232; font-size: 13px; display: none;">
+                            <strong><?php _e('This API key could not be verified. It may be invalid, or Two may be temporarily unreachable.', 'twoinc-payment-gateway'); ?></strong>
+                        </div>
                         <?php echo $this->get_description_html($data); // WPCS: XSS ok.
                         ?>
                     </fieldset>

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -4175,7 +4175,7 @@ if (!class_exists('WC_Twoinc')) {
                         </div>
                         <?php // Hidden by default; shown by admin.js in place of the merchant info above when the live re-verification (always run on page load) finds the stored key no longer valid, so a broken key can't hide behind a stale cached Merchant ID (TWO-25326 follow-up). ?>
                         <div id="twoinc-merchant-invalid-notice" style="margin-top: 8px; color: #dc3232; font-size: 13px; display: none;">
-                            <strong><?php _e('This API key could not be verified. It may be invalid, or Two may be temporarily unreachable.', 'twoinc-payment-gateway'); ?></strong>
+                            <strong><?php printf(__('This API key could not be verified. It may be invalid, or %s may be temporarily unreachable.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')); ?></strong>
                         </div>
                         <?php echo $this->get_description_html($data); // WPCS: XSS ok.
                         ?>

--- a/tests/js/admin-harness.js
+++ b/tests/js/admin-harness.js
@@ -157,7 +157,7 @@ function buildSettingsPage(options) {
   const apiKeyBlock =
     opts.apiKey === undefined
       ? ""
-      : '    <tr><td>' +
+      : "    <tr><td>" +
         '<input type="text" id="' +
         FIELD_PREFIX +
         'api_key" value="' +

--- a/tests/js/admin-harness.js
+++ b/tests/js/admin-harness.js
@@ -31,7 +31,9 @@
  *   - `wp.media` is referenced only inside a click handler, never at load.
  *   - the inline-fee AJAX returns early unless the term container carries
  *     `data-fees`, and the API-key check returns early unless the key field
- *     holds a value. Neither is set, so no network call is ever attempted.
+ *     holds a value. Neither is set, so no network call is ever attempted —
+ *     UNLESS `options.apiKey` is passed (see buildSettingsPage), which opts a
+ *     test into the API-key markup and value on purpose.
  */
 
 "use strict";
@@ -148,9 +150,36 @@ function buildSettingsPage(options) {
     })
     .join("\n");
 
+  // Mirrors generate_api_key_with_verification_html()'s markup — only built
+  // when a test opts in via options.apiKey, so the default page stays free of
+  // the API-key field and admin.js's page-load verifyApiKey() never fires for
+  // suites that don't want it.
+  const apiKeyBlock =
+    opts.apiKey === undefined
+      ? ""
+      : '    <tr><td>' +
+        '<input type="text" id="' +
+        FIELD_PREFIX +
+        'api_key" value="' +
+        opts.apiKey +
+        '" />' +
+        '<span id="api-key-verification-icon" style="display:none">' +
+        '<span id="api-key-valid" style="display:none"></span>' +
+        '<span id="api-key-invalid" style="display:none"></span>' +
+        '<span id="api-key-loading" style="display:none"></span>' +
+        "</span>" +
+        '<div id="twoinc-merchant-info" style="display:none">' +
+        '<span id="twoinc-merchant-id"></span>' +
+        '<span id="twoinc-merchant-short-name"></span>' +
+        "</div>" +
+        '<div id="twoinc-signup-prompt"></div>' +
+        '<div id="twoinc-merchant-invalid-notice" style="display:none"></div>' +
+        "</td></tr>";
+
   document.body.innerHTML = [
     '<form method="post">',
     '  <table class="form-table"><tbody>',
+    apiKeyBlock,
     '    <tr><td><div class="twoinc-term-checkboxes">' + checkboxes + "</div></td></tr>",
     '    <tr><td><input type="text" id="' +
       FIELD_PREFIX +
@@ -232,12 +261,19 @@ function assertBootstrapped($) {
  * against it, and wait for its jQuery-ready bootstrap to complete.
  *
  * @param {Object} [options] passed through to buildSettingsPage, plus
- *   `merchantTerms` for the backend-offered set admin.js intersects against
+ *   `merchantTerms` for the backend-offered set admin.js intersects against,
+ *   and `stubAjax($)` — called right after jQuery is installed but before
+ *   admin.js's ready callback can run, so a test can stub `$.ajax` ahead of
+ *   the page-load `verifyApiKey()` call that fires when `options.apiKey` is
+ *   set (see buildSettingsPage).
  * @returns {Promise<{$: Function, adminSettings: Object}>}
  */
 async function loadAdmin(options) {
   const opts = options || {};
   const $ = installJQuery();
+  if (typeof opts.stubAjax === "function") {
+    opts.stubAjax($);
+  }
   buildSettingsPage(opts);
   const adminSettings = {
     gateway_id: GATEWAY_ID,

--- a/tests/js/api-key-verification.test.js
+++ b/tests/js/api-key-verification.test.js
@@ -1,0 +1,72 @@
+/**
+ * A stored API key that fails re-verification on page load must not leave
+ * the previously fetched Merchant ID / short name on screen — that reads as
+ * "the integration is fine" when it is actually broken, and made a recent
+ * live incident take longer than it should have to diagnose from the
+ * settings page alone.
+ *
+ * `admin.js` always re-verifies a stored key on page load (see the bottom of
+ * the "API Key verification functionality" block). These tests drive that
+ * exact path via a stubbed `$.ajax` and assert the merchant-info block is
+ * replaced by the invalid-key notice — not left showing the stale value the
+ * PHP template rendered server-side.
+ */
+
+"use strict";
+
+const { loadAdmin } = require("./admin-harness");
+
+describe("API key verification — merchant info display", () => {
+  test("stored key that fails verification clears merchant info and shows the invalid notice", async () => {
+    const { $ } = await loadAdmin({
+      apiKey: "an-old-stored-key",
+      checked: [30],
+      stubAjax: function (jq) {
+        jq.ajax = jest.fn(function (settings) {
+          settings.success({ success: false, data: { message: "API key is invalid" } });
+          return { done: function () {}, fail: function () {} };
+        });
+      }
+    });
+
+    expect($("#twoinc-merchant-info").css("display")).toBe("none");
+    expect($("#twoinc-signup-prompt").css("display")).toBe("none");
+    expect($("#twoinc-merchant-invalid-notice").css("display")).not.toBe("none");
+  });
+
+  test("stored key that errors at the transport level also clears merchant info", async () => {
+    const { $ } = await loadAdmin({
+      apiKey: "an-old-stored-key",
+      checked: [30],
+      stubAjax: function (jq) {
+        jq.ajax = jest.fn(function (settings) {
+          settings.error({}, "error", "Network error");
+          return { done: function () {}, fail: function () {} };
+        });
+      }
+    });
+
+    expect($("#twoinc-merchant-info").css("display")).toBe("none");
+    expect($("#twoinc-merchant-invalid-notice").css("display")).not.toBe("none");
+  });
+
+  test("stored key that verifies successfully shows merchant info, not the invalid notice", async () => {
+    const { $ } = await loadAdmin({
+      apiKey: "an-old-stored-key",
+      checked: [30],
+      stubAjax: function (jq) {
+        jq.ajax = jest.fn(function (settings) {
+          settings.success({
+            success: true,
+            data: { merchant_id: "42", merchant_short_name: "Acme" }
+          });
+          return { done: function () {}, fail: function () {} };
+        });
+      }
+    });
+
+    expect($("#twoinc-merchant-info").css("display")).not.toBe("none");
+    expect($("#twoinc-merchant-invalid-notice").css("display")).toBe("none");
+    expect($("#twoinc-merchant-id").text()).toBe("42");
+  });
+});


### PR DESCRIPTION
## Summary

The admin settings page kept showing the previously-fetched merchant ID and
short name even after the stored API key failed re-verification. `verify_api_key()`
only persists `merchant_id` / `merchant_short_name` on a 200 response and
leaves the cached option values untouched on any failure, and the page-load
JS re-verification (`admin.js`) only toggled the red/green status icon —
never touching the merchant info panel — so a broken key left the settings
page looking healthy.

- Added a hidden-by-default "API key could not be verified" notice next to
  the existing merchant-info / signup-prompt blocks in
  `generate_api_key_with_verification_html()`.
- `admin.js` now hides the merchant-info panel and shows that notice whenever
  the verify AJAX call reports failure or errors at the transport level, on
  both page load and live key-typing verification.

## Test plan

- [x] `npx jest --config tests/js/jest.config.js` — full JS suite green (326 tests), including new `tests/js/api-key-verification.test.js` covering: verify failure, transport error, and successful verification.
- [x] `php tests/unit/run.php` — full PHP suite green, unaffected by this change.
- [x] Manual read-through of `generate_api_key_with_verification_html()` render output and `admin.js` DOM wiring to confirm the notice element IDs match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
