### PR TITLE
fix(api-key): differentiate verification failures and hide checkout on failure

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -110,15 +110,50 @@ jQuery(function ($) {
     $("#twoinc-merchant-invalid-notice").hide();
   }
 
+  // Maps the categorized failure the AJAX handler reports (see
+  // WC_Twoinc::categorize_verification_result()) to admin-facing text — no
+  // raw response body/content, just enough to tell "my key is wrong" apart
+  // from "Two's API is down" (TWO-25326 follow-up: today's incident showed
+  // every non-200 response, 5xx and network failures included, displayed
+  // identically as "API key is invalid").
+  function invalidNoticeText(status, code) {
+    switch (status) {
+      case "invalid_key":
+        return "This API key is invalid or has expired.";
+      case "service_error":
+        return (
+          "Two's API returned a service error (HTTP " +
+          code +
+          "). This is likely temporary on Two's side — try again shortly."
+        );
+      case "unreachable":
+        return "Could not reach Two's API (network or connectivity error). Try again shortly.";
+      case "not_configured":
+        return "Enter an API key above to enable Two.";
+      case "request_failed":
+        // The AJAX request to THIS SITE's admin-ajax.php failed before Two
+        // was ever contacted (jQuery's error callback fires on any
+        // transport-level failure — a WordPress-side 500, an expired
+        // nonce, a proxy/WAF block — not specifically "Two is
+        // unreachable"). Reviewed round 1: the "unreachable" wording here
+        // would have wrongly pointed an admin at Two for a WP-side problem.
+        return "Could not complete verification — try again shortly.";
+      default:
+        return code
+          ? "Two's API returned an unexpected response (HTTP " + code + ")."
+          : "This API key could not be verified.";
+    }
+  }
+
   // A failed verification must not leave the previously fetched Merchant ID
-  // on screen — that reads as "the integration is fine" when it isn't. Swap
-  // it for an explicit invalid-key notice instead (this call site is the fix
-  // for the settings page silently keeping stale merchant info on a broken
-  // key).
-  function showMerchantInfoInvalid() {
+  // on screen — that reads as "the integration is fine" when it isn't.
+  // Swap it for the categorized invalid-key notice instead (this call site
+  // is also the fix for the settings page silently keeping stale merchant
+  // info on a broken key).
+  function showMerchantInfoInvalid(status, code) {
     $("#twoinc-merchant-info").hide();
     $("#twoinc-signup-prompt").hide();
-    $("#twoinc-merchant-invalid-notice").show();
+    $("#twoinc-merchant-invalid-notice").text(invalidNoticeText(status, code)).show();
   }
 
   function verifyApiKey(apiKey) {
@@ -143,12 +178,13 @@ jQuery(function ($) {
           updateMerchantInfo(response.data);
         } else {
           showVerificationStatus("invalid");
-          showMerchantInfoInvalid();
+          const data = response.data || {};
+          showMerchantInfoInvalid(data.status, data.code);
         }
       },
       error: function () {
         showVerificationStatus("invalid");
-        showMerchantInfoInvalid();
+        showMerchantInfoInvalid("request_failed", null);
       }
     });
   }

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -2109,10 +2109,29 @@ if (!class_exists('WC_Twoinc')) {
          */
         public function verify_api_key_action()
         {
-            $this->verify_api_key();
+            $result = $this->verify_api_key();
+            // This admin-page load is a fresh, live re-check of the STORED
+            // key — strictly more current than whatever the checkout-side
+            // cache (get_api_key_verification_status()) might be holding.
+            // Feed it forward so a merchant who just fixed a broken key
+            // doesn't have to wait out API_KEY_VERIFICATION_TTL for
+            // checkout to notice (TWO-25326 follow-up, review round 1).
+            $this->cache_verification_result($this->get_option('api_key'), $result);
         }
 
-        public function verify_api_key($api_key = null)
+        /**
+         * @param mixed $api_key  string|null, as verify_api_key() takes.
+         * @param int   $timeout  seconds. Callers evaluated inline in a
+         *   customer-facing request (get_api_key_verification_status() on a
+         *   cache miss) must pass a short timeout — WordPress's own
+         *   wp_remote_request() default the underlying make_request() falls
+         *   back to is 30s, which would otherwise block that page render for
+         *   up to 30s while Two is unreachable (TWO-25326 follow-up, review
+         *   round 1). Admin-initiated checks (the settings page, on load or
+         *   on typing) keep the longer default since a slower-but-certain
+         *   answer is the right trade there.
+         */
+        public function verify_api_key($api_key = null, $timeout = 30)
         {
             $api_key_to_use = $api_key ?: $this->get_option('api_key');
 
@@ -2125,7 +2144,7 @@ if (!class_exists('WC_Twoinc')) {
                 return;
             }
 
-            $response = $this->make_request("/v1/merchant/verify_api_key", [], 'GET', [], $api_key_to_use);
+            $response = $this->make_request("/v1/merchant/verify_api_key", [], 'GET', [], $api_key_to_use, $timeout);
 
             if (!$response || is_wp_error($response)) {
                 // Transport-level failure (network/timeout/no response) —
@@ -2151,6 +2170,15 @@ if (!class_exists('WC_Twoinc')) {
                 }
                 return ['body' => $body, 'code' => $code];
             }
+            // A truthy, non-WP_Error response that lacks a 'body' key at all
+            // is malformed/unexpected — NOT the same as "not configured"
+            // (categorize_verification_result() would otherwise conflate
+            // the two, since both fell through to an implicit null return
+            // before this branch existed — TWO-25326 follow-up, review
+            // round 1). Not reproducible via a real wp_remote_request()
+            // response today, but a mocked/future make_request() could hit
+            // it, and the distinction is free to make explicit.
+            return ['error' => 'malformed_response', 'code' => null];
         }
 
         /**
@@ -2208,6 +2236,17 @@ if (!class_exists('WC_Twoinc')) {
         const API_KEY_VERIFICATION_TTL = 300;
 
         /**
+         * Timeout (seconds) for the live call get_api_key_verification_status()
+         * makes on a cache miss. Short and explicit because that call can
+         * land inline in a customer-facing request — unlike the admin
+         * settings page's own re-verification, which can afford
+         * verify_api_key()'s longer default (TWO-25326 follow-up, review
+         * round 1). Mirrors WC_Twoinc_FX::FETCH_TIMEOUT's reasoning for the
+         * same constraint.
+         */
+        const API_KEY_VERIFICATION_TIMEOUT = 5;
+
+        /**
          * Request-scoped memo so a single page load never reads the
          * transient (or fires a live call) more than once. Instance
          * property (not static): the gateway is a per-request singleton in
@@ -2238,34 +2277,64 @@ if (!class_exists('WC_Twoinc')) {
                 return $this->api_key_verification_memo = ['status' => 'not_configured', 'code' => null, 'body' => null];
             }
 
-            $cache_key = 'twoinc_api_key_status_' . md5($api_key);
-            $cached = get_transient($cache_key);
+            $cached = get_transient(self::verification_cache_key($api_key));
             if (is_array($cached) && isset($cached['status'])) {
                 return $this->api_key_verification_memo = $cached;
             }
 
-            $result = $this->verify_api_key();
-            $status = self::categorize_verification_result($result);
-            $status['body'] = ($status['status'] === 'ok' && isset($result['body'])) ? $result['body'] : null;
-            set_transient($cache_key, $status, self::API_KEY_VERIFICATION_TTL);
-            return $this->api_key_verification_memo = $status;
+            // Short, explicit timeout: this can run inline in a
+            // customer-facing request (cart/checkout/mini-cart — anywhere
+            // WooCommerce core evaluates is_available()) on a cold cache.
+            // The transient above only bounds how OFTEN this fires, not how
+            // LONG a single miss can take — inheriting verify_api_key()'s
+            // 30s admin-page default would let one unreachable-Two request
+            // block that render for up to 30s (TWO-25326 follow-up, review
+            // round 1). Mirrors WC_Twoinc_FX::FETCH_TIMEOUT's reasoning for
+            // the same "inline in a request path" constraint.
+            $result = $this->verify_api_key(null, self::API_KEY_VERIFICATION_TIMEOUT);
+            return $this->cache_verification_result($api_key, $result);
         }
 
         /**
-         * Whether the currently stored API key is confirmed live-usable
-         * right now (subject to the TTL cache above). Both gates that must
-         * not trust a merely-present key — is_available() and the
-         * checkout-side company-search/payment-tile bootstrap — key off
-         * this, not off get_option('api_key') / get_merchant_id() alone
-         * (TWO-25326 follow-up: a key that verified successfully in the
-         * past leaves merchant_id cached in options indefinitely, so that
-         * alone cannot tell "still valid" from "was valid").
+         * Categorizes $result and stores it under $api_key's cache slot —
+         * the single place both the cache-miss path above AND a fresher
+         * live check elsewhere (verify_api_key_action() on the settings
+         * page, twoinc_ajax_verify_api_key()) feed their outcome into, so a
+         * merchant who just fixed their key on the settings page doesn't
+         * have to wait out the TTL for checkout to notice (TWO-25326
+         * follow-up, review round 1).
          *
-         * @return bool
+         * @param string     $api_key
+         * @param array|null $result verify_api_key()'s return value.
+         *
+         * @return array{status: string, code: int|null, body: array|null}
          */
-        public function is_api_key_verified()
+        public function cache_verification_result($api_key, $result)
         {
-            return $this->get_api_key_verification_status()['status'] === 'ok';
+            $status = self::categorize_verification_result($result);
+            $status['body'] = ($status['status'] === 'ok' && isset($result['body'])) ? $result['body'] : null;
+            if ($api_key) {
+                set_transient(self::verification_cache_key($api_key), $status, self::API_KEY_VERIFICATION_TTL);
+            }
+            if ($api_key === $this->get_option('api_key')) {
+                $this->api_key_verification_memo = $status;
+            }
+            return $status;
+        }
+
+        /**
+         * Brand-scoped transient key for one API key's cached verification
+         * status. Routed through WC_Twoinc_Brand::prefixed_name() to match
+         * the naming convention the plugin's other transient/option keys
+         * already follow (see WC_Twoinc_FX), rather than a bare literal.
+         *
+         * @param string $api_key
+         *
+         * @return string
+         */
+        private static function verification_cache_key($api_key)
+        {
+            return WC_Twoinc_Brand::prefixed_name('api_key_status_' . md5($api_key));
         }
 
         /**
@@ -2283,7 +2352,31 @@ if (!class_exists('WC_Twoinc')) {
             if (!parent::is_available()) {
                 return false;
             }
-            return $this->is_api_key_verified();
+            $status = $this->get_api_key_verification_status();
+            if ($status['status'] === 'ok') {
+                return true;
+            }
+            // Removing the gateway is invisible to the merchant — log the
+            // reason once per request so a verification failure doesn't
+            // read as the gateway simply vanishing (mirrors
+            // apply_brand_availability_gate()'s own "log once" pattern
+            // below; TWO-25326 follow-up, review round 1 — this is exactly
+            // the "couldn't tell why" gap the rest of this PR fixes on the
+            // admin page, so it must not reappear unlogged here).
+            static $logged = false;
+            if (!$logged && function_exists('wc_get_logger')) {
+                $logged = true;
+                wc_get_logger()->info(
+                    sprintf(
+                        '%s hidden from checkout: API key verification status "%s"%s',
+                        $this->id,
+                        $status['status'],
+                        $status['code'] ? " (HTTP {$status['code']})" : ''
+                    ),
+                    ['source' => 'twoinc-payment-gateway']
+                );
+            }
+            return false;
         }
 
 

--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -2117,13 +2117,22 @@ if (!class_exists('WC_Twoinc')) {
             $api_key_to_use = $api_key ?: $this->get_option('api_key');
 
             if (!$api_key_to_use || !$this->get_twoinc_checkout_host()) {
+                // Nothing configured to verify — distinct from an actual
+                // network failure below (TWO-25326 follow-up: an admin
+                // needs to tell "not set up" apart from "Two is
+                // unreachable"). categorize_verification_result() reads
+                // this null the same way it always has.
                 return;
             }
 
             $response = $this->make_request("/v1/merchant/verify_api_key", [], 'GET', [], $api_key_to_use);
 
             if (!$response || is_wp_error($response)) {
-                return;
+                // Transport-level failure (network/timeout/no response) —
+                // never a 401/403, so it must not be reported as "invalid
+                // key" (TWO-25326 follow-up). categorize_verification_result()
+                // maps this to 'unreachable'.
+                return ['error' => 'unreachable', 'code' => null];
             }
             if (isset($response['body'])) {
                 $body = json_decode($response['body'], true);
@@ -2142,6 +2151,139 @@ if (!class_exists('WC_Twoinc')) {
                 }
                 return ['body' => $body, 'code' => $code];
             }
+        }
+
+        /**
+         * Categorizes verify_api_key()'s return value into buckets an admin
+         * can act on ("is my key wrong, or is Two down") without exposing
+         * the raw response body anywhere (TWO-25326 follow-up — today's
+         * incident showed every non-200 response, including 5xx and
+         * network failures, was reported identically as "API key is
+         * invalid", which sent the admin chasing the wrong fix).
+         *
+         * Shared by the settings-page AJAX handler
+         * (twoinc_ajax_verify_api_key in tillit-payment-gateway.php) and
+         * get_api_key_verification_status() below, so both surfaces agree.
+         *
+         * @param array|null $result verify_api_key()'s return value.
+         *
+         * @return array{status: string, code: int|null} status is one of:
+         *   'ok', 'invalid_key' (401/403), 'service_error' (5xx),
+         *   'unreachable' (network/timeout/no response), 'error' (any
+         *   other non-200 code), 'not_configured' (no key/host set).
+         */
+        public static function categorize_verification_result($result)
+        {
+            if (!is_array($result)) {
+                return ['status' => 'not_configured', 'code' => null];
+            }
+            if (isset($result['error']) && $result['error'] === 'unreachable') {
+                return ['status' => 'unreachable', 'code' => null];
+            }
+            $code = isset($result['code']) ? (int) $result['code'] : null;
+            if ($code === 200) {
+                return ['status' => 'ok', 'code' => $code];
+            }
+            if ($code === 401 || $code === 403) {
+                return ['status' => 'invalid_key', 'code' => $code];
+            }
+            if ($code !== null && $code >= 500) {
+                return ['status' => 'service_error', 'code' => $code];
+            }
+            return ['status' => 'error', 'code' => $code];
+        }
+
+        /**
+         * TTL for the cached verification status consulted by
+         * is_available() and the checkout script bootstrap
+         * (WC_Twoinc_Checkout::inject_cart_details()) — both can be
+         * evaluated many times per page load (cart totals, order-review
+         * refreshes), and a live HTTP call on every evaluation would be
+         * needlessly expensive (TWO-25326 follow-up). Mirrors the
+         * TTL-cache shape already used for sole-trader company types
+         * (WC_Twoinc_Sole_Trader::CACHE_TTL_SECONDS), scaled down since a
+         * wrong key or an outage should surface within minutes, not an
+         * hour.
+         */
+        const API_KEY_VERIFICATION_TTL = 300;
+
+        /**
+         * Request-scoped memo so a single page load never reads the
+         * transient (or fires a live call) more than once. Instance
+         * property (not static): the gateway is a per-request singleton in
+         * production, so this is equivalent there, but a static property
+         * shared by name across every WC_Twoinc instance would leak one
+         * test's (or, in theory, one API key's) cached verdict into
+         * another's.
+         */
+        private $api_key_verification_memo = null;
+
+        /**
+         * Cached, categorized outcome of a live verify_api_key() call
+         * against the CURRENTLY STORED api_key. Keyed by a hash of the key
+         * itself, so a changed key always misses the cache and re-verifies
+         * immediately; an unchanged key that starts failing (or recovers)
+         * is re-checked at most every API_KEY_VERIFICATION_TTL seconds.
+         *
+         * @return array{status: string, code: int|null, body: array|null}
+         */
+        public function get_api_key_verification_status()
+        {
+            if ($this->api_key_verification_memo !== null) {
+                return $this->api_key_verification_memo;
+            }
+
+            $api_key = $this->get_option('api_key');
+            if (!$api_key) {
+                return $this->api_key_verification_memo = ['status' => 'not_configured', 'code' => null, 'body' => null];
+            }
+
+            $cache_key = 'twoinc_api_key_status_' . md5($api_key);
+            $cached = get_transient($cache_key);
+            if (is_array($cached) && isset($cached['status'])) {
+                return $this->api_key_verification_memo = $cached;
+            }
+
+            $result = $this->verify_api_key();
+            $status = self::categorize_verification_result($result);
+            $status['body'] = ($status['status'] === 'ok' && isset($result['body'])) ? $result['body'] : null;
+            set_transient($cache_key, $status, self::API_KEY_VERIFICATION_TTL);
+            return $this->api_key_verification_memo = $status;
+        }
+
+        /**
+         * Whether the currently stored API key is confirmed live-usable
+         * right now (subject to the TTL cache above). Both gates that must
+         * not trust a merely-present key — is_available() and the
+         * checkout-side company-search/payment-tile bootstrap — key off
+         * this, not off get_option('api_key') / get_merchant_id() alone
+         * (TWO-25326 follow-up: a key that verified successfully in the
+         * past leaves merchant_id cached in options indefinitely, so that
+         * alone cannot tell "still valid" from "was valid").
+         *
+         * @return bool
+         */
+        public function is_api_key_verified()
+        {
+            return $this->get_api_key_verification_status()['status'] === 'ok';
+        }
+
+        /**
+         * The Two payment method must not be offered at checkout when the
+         * stored API key cannot currently be verified — for ANY reason
+         * (invalid/expired key, Two's API returning 5xx, a network/routing
+         * failure reaching it, …). A buyer could otherwise select a
+         * payment method that is not actually functional (TWO-25326
+         * follow-up, from today's routing-failure incident).
+         *
+         * @return bool
+         */
+        public function is_available()
+        {
+            if (!parent::is_available()) {
+                return false;
+            }
+            return $this->is_api_key_verified();
         }
 
 
@@ -4173,10 +4315,8 @@ if (!class_exists('WC_Twoinc')) {
                         <div id="twoinc-signup-prompt" style="margin-top: 8px; color: #666; font-size: 13px;<?php echo $merchant_id ? ' display: none;' : ''; ?>">
                             <strong><?php printf(__('Don\'t have an API key? Get one by signing up <a href=\'%s\'>here</a>.', 'twoinc-payment-gateway'), esc_url(WC_Twoinc_Brand::get('sign_up_url'))); ?></strong>
                         </div>
-                        <?php // Hidden by default; shown by admin.js in place of the merchant info above when the live re-verification (always run on page load) finds the stored key no longer valid, so a broken key can't hide behind a stale cached Merchant ID (TWO-25326 follow-up). ?>
-                        <div id="twoinc-merchant-invalid-notice" style="margin-top: 8px; color: #dc3232; font-size: 13px; display: none;">
-                            <strong><?php printf(__('This API key could not be verified. It may be invalid, or %s may be temporarily unreachable.', 'twoinc-payment-gateway'), WC_Twoinc_Brand::get('product_name')); ?></strong>
-                        </div>
+                        <?php // Hidden by default; populated + shown by admin.js when the live re-verification on page load (or on typing a new key) cannot confirm the key. Text is set dynamically per failure category — invalid key vs Two service error vs unreachable — so an admin isn't stuck guessing "is my key wrong or is Two down" (TWO-25326 follow-up, supersedes an earlier static-text version of this same notice). ?>
+                        <div id="twoinc-merchant-invalid-notice" style="margin-top: 8px; color: #dc3232; font-size: 13px; display: none;"></div>
                         <?php echo $this->get_description_html($data); // WPCS: XSS ok.
                         ?>
                     </fieldset>

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -555,9 +555,15 @@ if (!class_exists('WC_Twoinc_Checkout')) {
             // itself on a broken integration, for ANY verification failure
             // (invalid key, Two 5xx, network/routing failure — TWO-25326
             // follow-up). Uses the same cached check as is_available(), so
-            // "payment method hidden" and "company search hidden" can never
-            // disagree with each other, and this stops firing a live HTTP
-            // call on every checkout render.
+            // on CLASSIC checkout — this hook only fires there; there is no
+            // WooCommerce Blocks/Store API integration in this plugin today
+            // — "payment method hidden" and "company search hidden" can
+            // never disagree with each other. On block-based checkout,
+            // is_available() alone still hides the payment method; this
+            // suppression has no block-checkout equivalent to disagree
+            // with, since window.twoinc was never injected there before
+            // this PR either (review round 1). This also stops firing a
+            // live HTTP call on every checkout render.
             $status = $this->wc_twoinc->get_api_key_verification_status();
             if ($status['status'] !== 'ok') {
                 return;

--- a/class/WC_Twoinc_Checkout.php
+++ b/class/WC_Twoinc_Checkout.php
@@ -546,13 +546,24 @@ if (!class_exists('WC_Twoinc_Checkout')) {
                 return;
             }
 
-            // Ensure that the API key valid
-            $result = $this->wc_twoinc->verify_api_key();
-            if (isset($result['code']) && $result['code'] !== 200) {
+            // window.twoinc must not be printed at all when the stored API
+            // key cannot currently be verified — the payment-tile bootstrap
+            // AND the address-block company-search widget are both gated
+            // entirely behind window.twoinc's presence (see the top-level
+            // `if (window.twoinc)` guard in twoinc.js), so withholding it
+            // here is what stops company search from rendering/enabling
+            // itself on a broken integration, for ANY verification failure
+            // (invalid key, Two 5xx, network/routing failure — TWO-25326
+            // follow-up). Uses the same cached check as is_available(), so
+            // "payment method hidden" and "company search hidden" can never
+            // disagree with each other, and this stops firing a live HTTP
+            // call on every checkout render.
+            $status = $this->wc_twoinc->get_api_key_verification_status();
+            if ($status['status'] !== 'ok') {
                 return;
             }
 
-            $twoinc_obj = json_encode(WC_Twoinc_Helper::utf8ize($this->prepare_twoinc_object($result['body'])), JSON_UNESCAPED_UNICODE);
+            $twoinc_obj = json_encode(WC_Twoinc_Helper::utf8ize($this->prepare_twoinc_object($status['body'])), JSON_UNESCAPED_UNICODE);
             if ($twoinc_obj) {
                 printf('<script>window.twoinc = %s;</script>', $twoinc_obj);
             }

--- a/tests/js/api-key-verification.test.js
+++ b/tests/js/api-key-verification.test.js
@@ -1,40 +1,62 @@
 /**
- * A stored API key that fails re-verification on page load must not leave
- * the previously fetched Merchant ID / short name on screen — that reads as
- * "the integration is fine" when it is actually broken, and made a recent
- * live incident take longer than it should have to diagnose from the
- * settings page alone.
+ * TWO-25326 follow-up (2026-08-05 incident). Before this change, EVERY
+ * non-200 response from /v1/merchant/verify_api_key — an actual 401/403
+ * invalid key, a Two 5xx, or a network/routing failure reaching Two at all
+ * — was reported to the admin identically as "API key is invalid". That
+ * made a routing failure look exactly like a merchant typo, and cost real
+ * time diagnosing today's incident from the settings page alone.
  *
  * `admin.js` always re-verifies a stored key on page load (see the bottom of
  * the "API Key verification functionality" block). These tests drive that
  * exact path via a stubbed `$.ajax` and assert the merchant-info block is
- * replaced by the invalid-key notice — not left showing the stale value the
- * PHP template rendered server-side.
+ * replaced by a notice whose TEXT differs per failure category — not a
+ * single generic "invalid" message, and not the raw response body/content.
  */
 
 "use strict";
 
 const { loadAdmin } = require("./admin-harness");
 
-describe("API key verification — merchant info display", () => {
-  test("stored key that fails verification clears merchant info and shows the invalid notice", async () => {
+function stubAjaxError(status, code) {
+  return function (jq) {
+    jq.ajax = jest.fn(function (settings) {
+      settings.success({
+        success: false,
+        data: { message: "API key could not be verified", status: status, code: code }
+      });
+      return { done: function () {}, fail: function () {} };
+    });
+  };
+}
+
+describe("API key verification — categorized failure display", () => {
+  test("401/403 shows an invalid-key message", async () => {
     const { $ } = await loadAdmin({
       apiKey: "an-old-stored-key",
       checked: [30],
-      stubAjax: function (jq) {
-        jq.ajax = jest.fn(function (settings) {
-          settings.success({ success: false, data: { message: "API key is invalid" } });
-          return { done: function () {}, fail: function () {} };
-        });
-      }
+      stubAjax: stubAjaxError("invalid_key", 401)
     });
 
     expect($("#twoinc-merchant-info").css("display")).toBe("none");
     expect($("#twoinc-signup-prompt").css("display")).toBe("none");
     expect($("#twoinc-merchant-invalid-notice").css("display")).not.toBe("none");
+    expect($("#twoinc-merchant-invalid-notice").text()).toMatch(/invalid or has expired/i);
   });
 
-  test("stored key that errors at the transport level also clears merchant info", async () => {
+  test('a 5xx shows a Two-service-error message, not "invalid key"', async () => {
+    const { $ } = await loadAdmin({
+      apiKey: "an-old-stored-key",
+      checked: [30],
+      stubAjax: stubAjaxError("service_error", 503)
+    });
+
+    const text = $("#twoinc-merchant-invalid-notice").text();
+    expect(text).toMatch(/service error/i);
+    expect(text).toMatch(/503/);
+    expect(text).not.toMatch(/invalid or has expired/i);
+  });
+
+  test("a transport-level (network) error also shows an unreachable message, distinct from invalid key", async () => {
     const { $ } = await loadAdmin({
       apiKey: "an-old-stored-key",
       checked: [30],
@@ -46,8 +68,10 @@ describe("API key verification — merchant info display", () => {
       }
     });
 
+    const text = $("#twoinc-merchant-invalid-notice").text();
+    expect(text).toMatch(/could not reach/i);
+    expect(text).not.toMatch(/invalid or has expired/i);
     expect($("#twoinc-merchant-info").css("display")).toBe("none");
-    expect($("#twoinc-merchant-invalid-notice").css("display")).not.toBe("none");
   });
 
   test("stored key that verifies successfully shows merchant info, not the invalid notice", async () => {

--- a/tests/js/api-key-verification.test.js
+++ b/tests/js/api-key-verification.test.js
@@ -56,7 +56,7 @@ describe("API key verification — categorized failure display", () => {
     expect(text).not.toMatch(/invalid or has expired/i);
   });
 
-  test("a transport-level (network) error also shows an unreachable message, distinct from invalid key", async () => {
+  test("a transport-level failure talking to admin-ajax.php shows a neutral message — it hasn't reached Two yet, so it must not blame Two's API", async () => {
     const { $ } = await loadAdmin({
       apiKey: "an-old-stored-key",
       checked: [30],
@@ -69,8 +69,9 @@ describe("API key verification — categorized failure display", () => {
     });
 
     const text = $("#twoinc-merchant-invalid-notice").text();
-    expect(text).toMatch(/could not reach/i);
+    expect(text).toMatch(/could not complete verification/i);
     expect(text).not.toMatch(/invalid or has expired/i);
+    expect(text).not.toMatch(/two's api/i);
     expect($("#twoinc-merchant-info").css("display")).toBe("none");
   });
 

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -382,6 +382,13 @@ class WC_Payment_Gateway
 
     public $plugin_id = 'woocommerce_';
 
+    // Mirrors WC_Settings_API::get_option's own $enabled semantics closely
+    // enough for is_available() below: core defaults an unset gateway to
+    // disabled, not enabled, so this stub does too rather than defaulting to
+    // 'yes' and silently making every gateway "available" in tests that
+    // never touch it.
+    public $enabled = 'no';
+
     // Mirrors WC_Settings_API::get_post_data (the submitted settings form),
     // injectable per test for cross-field save validation.
     public $test_post_data = [];
@@ -389,6 +396,15 @@ class WC_Payment_Gateway
     // Declared rather than left dynamic: get_option() below reads it for the
     // field defaults, and WC_Twoinc::init_form_fields() assigns it.
     public $form_fields = [];
+
+    // Mirrors core's own is_available() closely enough for WC_Twoinc's
+    // override to call parent::is_available() safely — core also checks
+    // cart totals/needs_setup, deliberately not reproduced here since no
+    // test in this suite depends on that path.
+    public function is_available()
+    {
+        return 'yes' === $this->enabled;
+    }
 
     public function get_post_data()
     {
@@ -893,6 +909,14 @@ function set_transient($key, $value, $expiration = 0)
 function get_transient($key)
 {
     return $GLOBALS['__twoinc_test_transients'][$key] ?? false;
+}
+
+// Defaults to true: most tests exercising checkout-hooked methods do so
+// AS IF on the checkout page, and only a test specifically about the
+// is_checkout() guard needs to override it.
+function is_checkout()
+{
+    return $GLOBALS['__twoinc_test_is_checkout'] ?? true;
 }
 
 function delete_transient($key)

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -201,6 +201,12 @@ final class BrandConfigSpec
             'testCompanySearchLocationFallsBackToPaymentTileOnNullOrEmpty',
             'testCompanySearchLocationSettingDroppedFromUpgradedInstalls',
             'testEnableCompanySearchForOthersSettingDroppedFromUpgradedInstalls',
+            'testCategorizeVerificationResultDistinguishesFailureReasons',
+            'testVerifyApiKeyDistinguishesUnreachableFromNotConfigured',
+            'testApiKeyVerificationStatusCachedAcrossCallsWithinTtl',
+            'testIsAvailableFalseWhenApiKeyVerificationFails',
+            'testIsAvailableTrueOnlyWhenEnabledAndVerified',
+            'testCheckoutWindowTwoincSuppressedOnVerificationFailure',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -6047,6 +6053,306 @@ final class BrandConfigSpec
         } finally {
             unset($GLOBALS['__twoinc_test_plugin_version']);
         }
+    }
+
+    /**
+     * TWO-25326 follow-up (2026-08-05 incident). Before this change, EVERY
+     * non-200 response — an actual 401/403, a Two 5xx, or a network
+     * failure that never got a response at all — was treated identically
+     * as "invalid key" everywhere this plugin surfaces the outcome. These
+     * assert categorize_verification_result() actually tells them apart.
+     */
+    private static function testCategorizeVerificationResultDistinguishesFailureReasons(): void
+    {
+        TinyAssert::same('ok', WC_Twoinc::categorize_verification_result(['body' => ['id' => '1'], 'code' => 200])['status']);
+        TinyAssert::same('invalid_key', WC_Twoinc::categorize_verification_result(['body' => [], 'code' => 401])['status']);
+        TinyAssert::same('invalid_key', WC_Twoinc::categorize_verification_result(['body' => [], 'code' => 403])['status']);
+        TinyAssert::same('service_error', WC_Twoinc::categorize_verification_result(['body' => [], 'code' => 500])['status']);
+        TinyAssert::same('service_error', WC_Twoinc::categorize_verification_result(['body' => [], 'code' => 503])['status']);
+        TinyAssert::same('unreachable', WC_Twoinc::categorize_verification_result(['error' => 'unreachable', 'code' => null])['status']);
+        TinyAssert::same('not_configured', WC_Twoinc::categorize_verification_result(null)['status']);
+        $other = WC_Twoinc::categorize_verification_result(['body' => [], 'code' => 404]);
+        TinyAssert::same('error', $other['status']);
+        TinyAssert::same(404, $other['code']);
+    }
+
+    /**
+     * verify_api_key() itself must not collapse "not configured" (no
+     * key/host) and "unreachable" (a real network/timeout failure talking
+     * to Two) into the same falsy return — that is exactly the distinction
+     * an admin diagnosing today's routing incident needed.
+     */
+    private static function testVerifyApiKeyDistinguishesUnreachableFromNotConfigured(): void
+    {
+        $gateway = new class () extends WC_Twoinc {
+            public $options = ['api_key' => 'key'];
+            public $host = 'https://api.example';
+            public $wp_error_response = true;
+
+            public function __construct()
+            {
+            }
+
+            public function get_twoinc_checkout_host()
+            {
+                return $this->host;
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $this->options[$key] ?? $empty_value ?? '';
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+            {
+                return $this->wp_error_response ? new WP_Error('http_request_failed', 'timed out') : false;
+            }
+        };
+
+        TinyAssert::same('unreachable', WC_Twoinc::categorize_verification_result($gateway->verify_api_key())['status']);
+
+        // No host configured at all: a fundamentally different situation
+        // from a reachable host that times out, and must stay distinct.
+        $gateway->host = '';
+        TinyAssert::same(null, $gateway->verify_api_key());
+        TinyAssert::same('not_configured', WC_Twoinc::categorize_verification_result($gateway->verify_api_key())['status']);
+    }
+
+    /**
+     * is_available() / the checkout bootstrap must not fire a live
+     * verify_api_key() HTTP call on every evaluation — get_api_key_verification_status()
+     * is expected to serve the second call from its transient cache
+     * without touching make_request() again.
+     */
+    private static function testApiKeyVerificationStatusCachedAcrossCallsWithinTtl(): void
+    {
+        $gateway = new class () extends WC_Twoinc {
+            public $options = ['api_key' => 'key'];
+            public $responses = [];
+            public $make_request_calls = 0;
+
+            public function __construct()
+            {
+            }
+
+            public function get_twoinc_checkout_host()
+            {
+                return 'https://api.example';
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $this->options[$key] ?? $empty_value ?? '';
+            }
+
+            public function update_option($key, $value = '')
+            {
+                $this->options[$key] = $value;
+                return true;
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+            {
+                $this->make_request_calls++;
+                return array_shift($this->responses);
+            }
+        };
+
+        $gateway->responses[] = ['response' => ['code' => 200], 'body' => json_encode(['id' => '42', 'short_name' => 'Acme'])];
+
+        $first = $gateway->get_api_key_verification_status();
+        TinyAssert::same('ok', $first['status']);
+        TinyAssert::same(1, $gateway->make_request_calls);
+
+        $second = $gateway->get_api_key_verification_status();
+        TinyAssert::same('ok', $second['status']);
+        TinyAssert::same(1, $gateway->make_request_calls); // still 1: served from cache, no second HTTP call
+
+        // A different gateway instance (a fresh api_key => a different
+        // cache key) is NOT served from the first instance's cache.
+        $other = new class () extends WC_Twoinc {
+            public $options = ['api_key' => 'a-different-key'];
+            public $responses = [];
+            public $make_request_calls = 0;
+
+            public function __construct()
+            {
+            }
+
+            public function get_twoinc_checkout_host()
+            {
+                return 'https://api.example';
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $this->options[$key] ?? $empty_value ?? '';
+            }
+
+            public function update_option($key, $value = '')
+            {
+                $this->options[$key] = $value;
+                return true;
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+            {
+                $this->make_request_calls++;
+                return array_shift($this->responses);
+            }
+        };
+        $other->responses[] = new WP_Error('http_request_failed', 'timed out');
+        $other_status = $other->get_api_key_verification_status();
+        TinyAssert::same('unreachable', $other_status['status']);
+        TinyAssert::same(1, $other->make_request_calls);
+    }
+
+    /**
+     * The Two payment method must not be listed as available when the
+     * stored key cannot currently be verified — for ANY of the failure
+     * categories, not only an actual 401/403 (TWO-25326 follow-up: today's
+     * incident was a routing failure, which must hide the gateway exactly
+     * as an actually-invalid key would).
+     */
+    private static function testIsAvailableFalseWhenApiKeyVerificationFails(): void
+    {
+        $make_gateway = static function ($response) {
+            return new class ($response) extends WC_Twoinc {
+                public $options = ['api_key' => 'key'];
+                public $enabled = 'yes';
+                private $response;
+
+                public function __construct($response)
+                {
+                    $this->response = $response;
+                }
+
+                public function get_twoinc_checkout_host()
+                {
+                    return 'https://api.example';
+                }
+
+                public function get_option($key, $empty_value = null)
+                {
+                    return $this->options[$key] ?? $empty_value ?? '';
+                }
+
+                public function update_option($key, $value = '')
+                {
+                    $this->options[$key] = $value;
+                    return true;
+                }
+
+                public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+                {
+                    return $this->response;
+                }
+            };
+        };
+
+        TinyAssert::same(false, $make_gateway(['response' => ['code' => 401], 'body' => json_encode([])])->is_available());
+        $GLOBALS['__twoinc_test_transients'] = [];
+        TinyAssert::same(false, $make_gateway(['response' => ['code' => 503], 'body' => json_encode([])])->is_available());
+        $GLOBALS['__twoinc_test_transients'] = [];
+        TinyAssert::same(false, $make_gateway(new WP_Error('http_request_failed', 'timed out'))->is_available());
+    }
+
+    /**
+     * is_available() must AND the two independent conditions together: a
+     * disabled-but-verified gateway stays hidden (unchanged core
+     * behaviour), and an enabled gateway with a verified key is the only
+     * combination that is actually available.
+     */
+    private static function testIsAvailableTrueOnlyWhenEnabledAndVerified(): void
+    {
+        $gateway = new class () extends WC_Twoinc {
+            public $options = ['api_key' => 'key'];
+            public $enabled = 'no';
+
+            public function __construct()
+            {
+            }
+
+            public function get_twoinc_checkout_host()
+            {
+                return 'https://api.example';
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $this->options[$key] ?? $empty_value ?? '';
+            }
+
+            public function update_option($key, $value = '')
+            {
+                $this->options[$key] = $value;
+                return true;
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+            {
+                return ['response' => ['code' => 200], 'body' => json_encode(['id' => '42'])];
+            }
+        };
+
+        // Verified key, but the merchant has disabled the gateway itself.
+        TinyAssert::same(false, $gateway->is_available());
+
+        $gateway->enabled = 'yes';
+        $GLOBALS['__twoinc_test_transients'] = [];
+        TinyAssert::same(true, $gateway->is_available());
+    }
+
+    /**
+     * `window.twoinc` is what the payment-tile bootstrap AND the
+     * address-block company-search widget both gate on entirely (see the
+     * top-level `if (window.twoinc)` guard in twoinc.js) — so withholding
+     * it on a verification failure is what stops company search from
+     * rendering/enabling itself on a broken integration, for ANY failure
+     * reason (TWO-25326 follow-up).
+     */
+    private static function testCheckoutWindowTwoincSuppressedOnVerificationFailure(): void
+    {
+        $GLOBALS['__twoinc_test_is_checkout'] = true;
+
+        $gateway = new class () extends WC_Twoinc {
+            public $options = ['api_key' => 'key'];
+            public $responses = [];
+
+            public function __construct()
+            {
+            }
+
+            public function get_twoinc_checkout_host()
+            {
+                return 'https://api.example';
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $this->options[$key] ?? $empty_value ?? '';
+            }
+
+            public function update_option($key, $value = '')
+            {
+                $this->options[$key] = $value;
+                return true;
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+            {
+                return array_shift($this->responses);
+            }
+        };
+        $gateway->responses[] = ['response' => ['code' => 401], 'body' => json_encode(['message' => 'invalid'])];
+
+        $checkout = new WC_Twoinc_Checkout($gateway);
+        ob_start();
+        $checkout->inject_cart_details();
+        $output = ob_get_clean();
+
+        TinyAssert::same('', trim($output));
+        unset($GLOBALS['__twoinc_test_is_checkout']);
     }
 }
 

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -207,6 +207,9 @@ final class BrandConfigSpec
             'testIsAvailableFalseWhenApiKeyVerificationFails',
             'testIsAvailableTrueOnlyWhenEnabledAndVerified',
             'testCheckoutWindowTwoincSuppressedOnVerificationFailure',
+            'testVerifyApiKeyMalformedResponseNotMiscategorizedAsNotConfigured',
+            'testAdminLiveVerificationWarmsCheckoutCache',
+            'testCachedStatusMissTimeoutIsShortNotAdminDefault',
         ];
         foreach ($tests as $test) {
             self::reset();
@@ -6353,6 +6356,144 @@ final class BrandConfigSpec
 
         TinyAssert::same('', trim($output));
         unset($GLOBALS['__twoinc_test_is_checkout']);
+    }
+
+    /**
+     * Review round 1 (Vader): a truthy, non-WP_Error response that lacks a
+     * 'body' key at all must not fall through to the same null
+     * verify_api_key() returns for "not configured" — that would tell an
+     * admin to "enter an API key" when one is already configured and a
+     * response WAS received, just an unexpected/malformed one.
+     */
+    private static function testVerifyApiKeyMalformedResponseNotMiscategorizedAsNotConfigured(): void
+    {
+        $gateway = new class () extends WC_Twoinc {
+            public $options = ['api_key' => 'key'];
+
+            public function __construct()
+            {
+            }
+
+            public function get_twoinc_checkout_host()
+            {
+                return 'https://api.example';
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $this->options[$key] ?? $empty_value ?? '';
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+            {
+                // Truthy, not a WP_Error, but no 'body' key — the
+                // malformed/unexpected shape probed in review round 1.
+                return ['response' => ['code' => 503]];
+            }
+        };
+
+        $result = $gateway->verify_api_key();
+        $category = WC_Twoinc::categorize_verification_result($result)['status'];
+        TinyAssert::same(false, $category === 'not_configured');
+        TinyAssert::same('error', $category);
+    }
+
+    /**
+     * Review round 1 (Han): the settings page's own live re-check
+     * (verify_api_key_action() / the AJAX handler, via
+     * cache_verification_result()) must feed the SAME cache
+     * get_api_key_verification_status() reads, so a merchant who just
+     * fixed their key doesn't wait out API_KEY_VERIFICATION_TTL for
+     * checkout to notice.
+     */
+    private static function testAdminLiveVerificationWarmsCheckoutCache(): void
+    {
+        $gateway = new class () extends WC_Twoinc {
+            public $options = ['api_key' => 'key'];
+            public $make_request_calls = 0;
+
+            public function __construct()
+            {
+            }
+
+            public function get_twoinc_checkout_host()
+            {
+                return 'https://api.example';
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $this->options[$key] ?? $empty_value ?? '';
+            }
+
+            public function update_option($key, $value = '')
+            {
+                $this->options[$key] = $value;
+                return true;
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+            {
+                $this->make_request_calls++;
+                return ['response' => ['code' => 200], 'body' => json_encode(['id' => '42', 'short_name' => 'Acme'])];
+            }
+        };
+
+        // Simulates the settings-page load: a fresh, live, uncached check —
+        // exactly what verify_api_key_action() does.
+        $gateway->verify_api_key_action();
+        TinyAssert::same(1, $gateway->make_request_calls);
+
+        // The checkout-facing cache must already be warm from that — no
+        // second HTTP call.
+        $status = $gateway->get_api_key_verification_status();
+        TinyAssert::same('ok', $status['status']);
+        TinyAssert::same(1, $gateway->make_request_calls);
+    }
+
+    /**
+     * Review round 1 (Yoda): a cache-miss check evaluated inline in a
+     * customer-facing request (is_available(), inject_cart_details()) must
+     * use a short, explicit timeout — not verify_api_key()'s 30s
+     * admin-page default, which would block that page render for up to
+     * 30s while Two is unreachable.
+     */
+    private static function testCachedStatusMissTimeoutIsShortNotAdminDefault(): void
+    {
+        $gateway = new class () extends WC_Twoinc {
+            public $options = ['api_key' => 'key'];
+            public $seen_timeout = null;
+
+            public function __construct()
+            {
+            }
+
+            public function get_twoinc_checkout_host()
+            {
+                return 'https://api.example';
+            }
+
+            public function get_option($key, $empty_value = null)
+            {
+                return $this->options[$key] ?? $empty_value ?? '';
+            }
+
+            public function update_option($key, $value = '')
+            {
+                $this->options[$key] = $value;
+                return true;
+            }
+
+            public function make_request($endpoint, $payload = [], $method = 'POST', $params = [], $api_key_override = null, $timeout = 30)
+            {
+                $this->seen_timeout = $timeout;
+                return ['response' => ['code' => 200], 'body' => json_encode(['id' => '42'])];
+            }
+        };
+
+        $gateway->get_api_key_verification_status();
+        TinyAssert::same(WC_Twoinc::API_KEY_VERIFICATION_TIMEOUT, $gateway->seen_timeout);
+        TinyAssert::same(true, WC_Twoinc::API_KEY_VERIFICATION_TIMEOUT < 30);
     }
 }
 

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -336,10 +336,15 @@ function twoinc_ajax_verify_api_key()
         return;
     }
 
-    // Get the Two instance and verify the API key
+    // Get the Two instance and verify the API key. cache_verification_result()
+    // both categorizes the outcome AND warms the checkout-side cache
+    // (get_api_key_verification_status()) — this is the freshest live check
+    // this key has had, so a merchant who just fixed it here shouldn't have
+    // to wait out the checkout cache's TTL to see it take effect (TWO-25326
+    // follow-up, review round 1).
     $twoinc_instance = WC_Twoinc::get_instance();
     $result = $twoinc_instance->verify_api_key($api_key);
-    $category = WC_Twoinc::categorize_verification_result($result);
+    $category = $twoinc_instance->cache_verification_result($api_key, $result);
 
     if ($category['status'] === 'ok') {
         // Echo the merchant identity back so the settings page can refresh the

--- a/tillit-payment-gateway.php
+++ b/tillit-payment-gateway.php
@@ -339,8 +339,9 @@ function twoinc_ajax_verify_api_key()
     // Get the Two instance and verify the API key
     $twoinc_instance = WC_Twoinc::get_instance();
     $result = $twoinc_instance->verify_api_key($api_key);
+    $category = WC_Twoinc::categorize_verification_result($result);
 
-    if ($result && isset($result['code']) && $result['code'] == 200) {
+    if ($category['status'] === 'ok') {
         // Echo the merchant identity back so the settings page can refresh the
         // displayed Merchant ID + short name as soon as validation completes,
         // without a reload (the key being typed is not persisted here).
@@ -351,12 +352,15 @@ function twoinc_ajax_verify_api_key()
             'merchant_short_name' => isset($body['short_name']) ? (string) $body['short_name'] : '',
         ]);
     } else {
-        $debug_info = [
-            'result' => $result,
-            'api_key_length' => strlen($api_key),
-            'host' => $twoinc_instance->get_twoinc_checkout_host()
-        ];
-        wp_send_json_error(['message' => 'API key is invalid', 'debug' => $debug_info]);
+        // Surface the failure category + HTTP status so the settings page
+        // can tell "key is wrong" apart from "Two is down" (TWO-25326
+        // follow-up) — deliberately no response body/content here, only
+        // the categorized status and code.
+        wp_send_json_error([
+            'message' => 'API key could not be verified',
+            'status' => $category['status'],
+            'code' => $category['code'],
+        ]);
     }
 }
 


### PR DESCRIPTION
## Summary

Today's incident showed every non-200 response from `/v1/merchant/verify_api_key` — an actual 401/403, a Two 5xx, or a network/routing failure that never got a response at all — was treated identically as "API key is invalid" everywhere in the plugin. That made a routing failure indistinguishable from a merchant typo, and the Two payment method + address-block company-search control kept rendering at checkout regardless of whether the key could actually be verified.

- `WC_Twoinc::categorize_verification_result()` buckets a `verify_api_key()` result into `ok` / `invalid_key` (401/403) / `service_error` (5xx) / `unreachable` (network/timeout) / `not_configured` / `error` (other), shared by the settings-page AJAX handler and the new cached status check. No raw response body is surfaced anywhere — only the category and HTTP status.
- `get_api_key_verification_status()` caches that categorization behind a short (5 min) transient keyed by the API key itself, so `is_available()` and the checkout script bootstrap don't fire a live HTTP call on every evaluation — mirrors the TTL-cache shape already used by `WC_Twoinc_Sole_Trader`.
- `WC_Twoinc::is_available()` now requires a verified key (on top of the existing enabled check), so the payment method is not offered at checkout when verification fails for ANY reason.
- `WC_Twoinc_Checkout::inject_cart_details()` withholds `window.twoinc` entirely on the same condition. Since the whole company-search/payment-tile bootstrap in `twoinc.js` is gated behind `if (window.twoinc)`, this is also what stops the address-block company-search control from rendering/enabling itself on a broken integration.
- `admin.js` now shows the categorized reason (not the raw response body/content) in a new `#twoinc-merchant-invalid-notice` element on the settings page, so an admin can tell "my key is wrong" from "Two's API is down" without guessing.

Scope: WooCommerce only, per plan — Magento/Hyvä/PrestaShop parity is a later round.

Note: PR #444 (open, unmerged) touched the same settings-page markup/JS area for a related but narrower fix (clearing stale merchant info on failure). This PR's `#twoinc-merchant-invalid-notice` element supersedes that one with dynamic, category-specific text — landing whichever merges first will produce a small, easy merge conflict on the other; flagging for a merge-order call rather than closing #444 myself.

## Test plan

- [x] PHP unit suite (`php tests/unit/run.php`) green, including new tests for categorization, TTL caching, `is_available()` (both failure and success), and checkout-side suppression on failure.
- [x] JS suite (`npx jest --config tests/js/jest.config.js`) green, including a new suite asserting the admin notice text differs per failure category (invalid key vs 5xx vs network) and is absent on success.
- [x] `prettier --check` clean on touched JS.
