### PR TITLE
Sentence-case surcharge tax admin labels + translations

### DIFF
--- a/class/WC_Twoinc.php
+++ b/class/WC_Twoinc.php
@@ -4252,7 +4252,7 @@ if (!class_exists('WC_Twoinc')) {
                     'default'     => ''
                 ],
                 'surcharge_tax_treatment' => [
-                    'title'       => __('Surcharge Tax Treatment', 'twoinc-payment-gateway'),
+                    'title'       => __('Surcharge tax treatment', 'twoinc-payment-gateway'),
                     'desc_tip'    => __('How the surcharge line is taxed. Standard applies your store\'s default tax rules to the fee. Specific tax class taxes the fee under a WooCommerce tax class you select below — to leave the fee untaxed, create a tax class with a 0% rate and select it here.', 'twoinc-payment-gateway'),
                     // Visible (non-tooltip) description: carries the loud
                     // never-taxed error when the stored treatment is one this
@@ -4277,7 +4277,7 @@ if (!class_exists('WC_Twoinc')) {
                     'default'     => ''
                 ],
                 'surcharge_tax_class' => [
-                    'title'       => __('Surcharge Tax Class', 'twoinc-payment-gateway'),
+                    'title'       => __('Surcharge tax class', 'twoinc-payment-gateway'),
                     'desc_tip'    => __('The WooCommerce tax class applied to the surcharge when the tax treatment is "Specific tax class". Manage tax classes under WooCommerce → Settings → Tax.', 'twoinc-payment-gateway'),
                     // Visible (non-tooltip) description: carries the stale-
                     // selection warning when the stored class has been


### PR DESCRIPTION
## What changed
- `class/WC_Twoinc.php`: "Surcharge Tax Treatment" -> "Surcharge tax treatment", "Surcharge Tax Class" -> "Surcharge tax class" (TWO-25326), matching the sentence-case convention set in PR #443.
- Grepped the repo (PHP/JS/templates, doc comments, tests) for any other Title-Case occurrence of these two strings — found none. Dropdown option values inside `get_surcharge_tax_treatment_options()` / `get_surcharge_tax_class_options()` were left untouched (out of scope).

## Translations
Neither msgid was present in `languages/*.pot`/`*.po` before this change (not yet extracted for translation), so no translation files needed updating — same finding as PR #443 for its label.

## Tests
No existing test asserts the exact label text (tests reference the field *keys*, e.g. `surcharge_tax_treatment`, not the title strings), so there was no test-text convention to mirror — same as PR #443's finding.

## Test plan
- [x] `make test-unit` — all pass