### PR TITLE
fix(company-number): never display TWO:-prefixed org numbers (TWO-25326)

### DIFF
--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -36,6 +36,105 @@ let twoincUtilHelper = {
   },
 
   /**
+   * Prefix marking an organisation number as internally minted rather than
+   * issued by a company registry (TWO-25326 §12).
+   *
+   * Sole-trader enrollment mints one of these for a buyer who has no registry
+   * identifier of their own; it carries the company-type semantics the backend
+   * derives on its side. It is a protocol value, not a number the buyer's own
+   * authorities would recognise, so showing it to them is meaningless at best
+   * and reads as a corrupted field at worst.
+   *
+   * Matched as a literal, case-sensitive prefix: it is a string the plugin's
+   * own backend mints, not something a buyer or a registry ever types, so
+   * there is no case or spacing variant to be liberal about. A real
+   * organisation number that merely CONTAINS these characters somewhere other
+   * than the start is not one of these and stays visible.
+   */
+  SYNTHETIC_NUMBER_PREFIX: "TWO:",
+
+  /**
+   * Is this organisation number internally minted, i.e. one §12 forbids
+   * showing (TWO-25326 §12)?
+   *
+   * For the callers that need to branch on the fact itself rather than just
+   * render the filtered value — hiding a whole field, say. Empty is NOT
+   * synthetic: "no number captured yet" is a different state from "a number
+   * that must not be shown", and only the latter suppresses a field the buyer
+   * would otherwise type into.
+   *
+   * @param {*} value
+   * @returns {boolean}
+   */
+  isSyntheticCompanyNumber: function (value) {
+    return twoincUtilHelper
+      .blankToEmpty(value)
+      .startsWith(twoincUtilHelper.SYNTHETIC_NUMBER_PREFIX);
+  },
+
+  /**
+   * Normalise an organisation number for DISPLAY (TWO-25326 §12).
+   *
+   * Returns `""` — never the prefixed value — for an internally minted
+   * identifier, so every caller's existing "is there a number" truthiness
+   * check doubles as the suppression: a label keyed on it hides itself, a
+   * bracketed composition drops its brackets, and no call site needs a filter
+   * of its own.
+   *
+   * DISPLAY ONLY. The value still has to be posted and sent to the API —
+   * Two's payment method cannot authorise an order without it — so the
+   * submitted `#company_id` input, the instance state and the order-intent
+   * payload all keep the raw value. Anything reading this function's result
+   * is, by construction, about to put it in front of a human.
+   *
+   * @param {*} value
+   * @returns {string} the number to show, or `""` if it must not be shown
+   */
+  formatCompanyNumber: function (value) {
+    if (twoincUtilHelper.isSyntheticCompanyNumber(value)) return "";
+    return twoincUtilHelper.blankToEmpty(value);
+  },
+
+  /**
+   * Compose the "<label> (<number>)" chunk both company displays use, with
+   * the number filtered through formatCompanyNumber (TWO-25326 §12).
+   *
+   * The brackets belong to the number, not to the composition: when the
+   * number resolves to nothing the label is returned bare, never with an
+   * empty pair of parens trailing it. That is the whole reason this is one
+   * function rather than a filter applied at each call site — two of the
+   * three sites had already written the parens as literal text around a
+   * value that can now come back empty.
+   *
+   * `label` is passed through untouched, NOT blank-collapsed, because the
+   * two callers disagree about what it contains: the intent notices pass
+   * plain text destined for `.text()`, while the search dropdown passes the
+   * search response's pre-highlighted HTML fragment destined for innerHTML.
+   * Trimming or re-encoding here would have to pick one contract and break
+   * the other. Callers that hold plain text collapse it themselves — see
+   * formatCompanyLabel below.
+   *
+   * @param {string} label already in its caller's own escaping contract
+   * @param {*} value raw organisation number
+   * @returns {string}
+   */
+  composeCompanyLabel: function (label, value) {
+    const number = twoincUtilHelper.formatCompanyNumber(value);
+    return label && number ? label + " (" + number + ")" : label;
+  },
+
+  /**
+   * composeCompanyLabel for a plain-text company name (TWO-25326 §12).
+   *
+   * @param {*} name
+   * @param {*} value
+   * @returns {string}
+   */
+  formatCompanyLabel: function (name, value) {
+    return twoincUtilHelper.composeCompanyLabel(twoincUtilHelper.blankToEmpty(name), value);
+  },
+
+  /**
    * Construct url to Twoinc checkout api.
    *
    * `client` / `client_v` identify this plugin and its version to the API, and
@@ -1217,7 +1316,15 @@ class TwoCompanySearch {
             items.push({
               id: item.name,
               text: item.name,
-              html: identifier ? item.highlight + " (" + identifier + ")" : item.highlight,
+              // TWO-25326 §12: `identifier` stays raw on `company_id` below —
+              // that is the value the picker writes to the submitted field and
+              // sends to the API — while what the buyer READS goes through the
+              // shared composer, which drops an internally minted number along
+              // with the brackets that would otherwise be left empty around it.
+              // `item.highlight` is the response's pre-highlighted HTML, so it
+              // is passed as an already-escaped fragment (composeCompanyLabel
+              // does not touch it) — the identifier is registry-issued digits.
+              html: twoincUtilHelper.composeCompanyLabel(item.highlight, identifier),
               company_id: identifier,
               lookup_id: item.lookup_id,
               approved: false
@@ -1868,7 +1975,13 @@ class TwoCompanySearch {
     // unselected picker reads back as " " rather than "" — which would
     // render as a label with an invisible value in it.
     const name = twoincUtilHelper.blankToEmpty(data.company_name);
-    const number = twoincUtilHelper.blankToEmpty(data.organization_number);
+    // TWO-25326 §12: display-normalised, so an internally minted number reads
+    // back as "" here. Everything below is already keyed on this being empty —
+    // the element renders nothing and the block hides itself — so a sole
+    // trader's captured company shows no number label rather than a protocol
+    // string. The raw value is untouched on `#company_id` and in the instance
+    // state, which is what gets posted.
+    const number = twoincUtilHelper.formatCompanyNumber(data.organization_number);
 
     // The tile no longer carries a separate company label to keep in sync
     // here (TWO-25326 §7.2/§7.3, ruling 2026-08-03: `.twoinc-company-tile-label`
@@ -2567,7 +2680,23 @@ let twoincDomHelper = {
         // by enterManualCompanyEntry/exitManualCompanyEntry specifically so
         // this branch can tell "manual entry" apart from the other two
         // routes into it.
-        if (!window.twoinc.manual_company_entry_active) {
+        //
+        // TWO-25326 §12: and left out again when the number currently held is
+        // an internally minted one. This branch is the ONE place `#company_id`
+        // is a field the buyer can see — a merchant with company search off,
+        // in a country whose registry supports sole traders, puts an enrolled
+        // sole trader here with `TWO:…` sitting in a visible text box. Hiding
+        // the field is the fix rather than blanking its value, because the
+        // value is what WooCommerce posts and what the order intent is
+        // authorised against: there is nothing for the buyer to type (the
+        // enrollment already supplied it) so the field has no job left beyond
+        // displaying a string §12 says must not be displayed. Dropping it from
+        // requiredTargets too — a required cue on a field nobody can see is how
+        // a checkout becomes unsubmittable with no visible reason why.
+        if (
+          !window.twoinc.manual_company_entry_active &&
+          !twoincUtilHelper.isSyntheticCompanyNumber(jQuery("#company_id").val())
+        ) {
           visibleTargets.push("#company_id_field");
           requiredTargets.push("#company_id_field");
         }
@@ -2686,7 +2815,13 @@ let twoincDomHelper = {
    * @returns {string}
    */
   getCompanyLabelText: function (name, number) {
-    return name && number ? name + " (" + number + ")" : name;
+    // TWO-25326 §12: the bracket composition, and the suppression of an
+    // internally minted number inside it, both live in twoincUtilHelper now —
+    // the search dropdown needs the identical rule with a different escaping
+    // contract, and the two must not drift. A sole trader's captured company
+    // reaches here with a `TWO:`-prefixed number, and comes out as the bare
+    // name with no empty parens after it.
+    return twoincUtilHelper.formatCompanyLabel(name, number);
   },
   /**
    * Toggle payment text in subtitle and description

--- a/assets/js/twoinc.js
+++ b/assets/js/twoinc.js
@@ -1322,9 +1322,19 @@ class TwoCompanySearch {
               // shared composer, which drops an internally minted number along
               // with the brackets that would otherwise be left empty around it.
               // `item.highlight` is the response's pre-highlighted HTML, so it
-              // is passed as an already-escaped fragment (composeCompanyLabel
-              // does not touch it) — the identifier is registry-issued digits.
-              html: twoincUtilHelper.composeCompanyLabel(item.highlight, identifier),
+              // is passed through as an already-marked-up fragment rather than
+              // being re-encoded (composeCompanyLabel does not touch its label).
+              //
+              // Falling back to the plain name for the same reason the
+              // identifier is read defensively above: `highlight` is the
+              // server's presentation of the match and this loop is written to
+              // survive a response that omits a field. Without the fallback a
+              // hit missing `highlight` composes to `undefined`, and select2
+              // renders a blank-but-selectable row.
+              html: twoincUtilHelper.composeCompanyLabel(
+                item.highlight || item.name || "",
+                identifier
+              ),
               company_id: identifier,
               lookup_id: item.lookup_id,
               approved: false
@@ -3204,6 +3214,17 @@ let twoincDomHelper = {
     if (document.querySelector("#company_id") && window.twoinc.company_id) {
       document.querySelector("#company_id").value = window.twoinc.company_id;
     }
+
+    // Re-evaluate the company fields, because the write just above changes
+    // what `#company_id`'s visibility depends on (TWO-25326 §12).
+    //
+    // Deliberately here rather than at the initialize() call site: this is the
+    // function that performs the write, so the re-toggle cannot be separated
+    // from it by a later reordering. A returning sole trader's user meta holds
+    // a minted `TWO:…` identifier, and initialize() has already toggled the
+    // fields once by this point — against an empty input — so without this the
+    // identifier is restored into a visible field on every page load.
+    twoincDomHelper.toggleBusinessFields();
   },
   /**
    * Get id of current or parent theme, return null if not found
@@ -3812,9 +3833,26 @@ let twoincSoleTrader = {
     if (companyId) {
       instance.customerCompany.country_prefix = twoincSelectWooHelper.currentCountry();
     }
+    // Re-evaluate which company fields are shown, AFTER the write above
+    // (TWO-25326 §12).
+    //
+    // `#company_id`'s visibility depends on the value it now holds, and this
+    // is the function that changes that value. Every route into sole-trader
+    // capture toggles the fields BEFORE the autofill lands — setMode() runs
+    // while the input is still empty, and the hosted-signup postMessage
+    // handler reaches here with no toggle of its own at all — so without this
+    // the minted `TWO:…` identifier lands in a field that was made visible on
+    // the strength of it being empty, and stays on screen until some
+    // unrelated country or payment-method switch happens to re-toggle. That
+    // is the exact surface §12 exists to close.
+    //
+    // Not re-entrant: toggleBusinessFields() reads the inputs and reassigns
+    // classes, and calls nothing that comes back here.
+    twoincDomHelper.toggleBusinessFields();
     // Explicit rather than DOM-read: this function is the authority on what was
     // just captured, so the summary should not depend on the order the mirrors
-    // above are written in (TWO-25288).
+    // above are written in (TWO-25288). Also re-renders after the toggle above,
+    // whose own trailing renderCompanySummary() reads the DOM.
     twoincSelectWooHelper.renderCompanySummary(companyName, companyId);
     if (companyId) {
       instance.getApproval();
@@ -4265,6 +4303,9 @@ class Twoinc {
     // Add customization for current theme if any
     twoincDomHelper.insertCustomCss();
 
+    // Both of these re-toggle the company fields themselves, at the point they
+    // write `#company_id` (TWO-25326 §12) — the toggle earlier in this function
+    // ran before either of them, against an empty input.
     twoincDomHelper.loadUserMetaInputs();
     if (loadSavedInputs) twoincDomHelper.loadStorageInputs();
 

--- a/tests/js/company-number-display.test.js
+++ b/tests/js/company-number-display.test.js
@@ -1,0 +1,368 @@
+/**
+ * TWO-25326 §12. Internally minted organisation numbers are never displayed.
+ *
+ * Sole-trader enrollment mints an identifier of the form `TWO:…` for a buyer
+ * with no registry number of their own. It is a protocol value the backend
+ * derives the company type from — not a number the buyer's own authorities
+ * would recognise — so it must not reach any surface a human reads, while
+ * still being posted and sent to the API, because Two's payment method cannot
+ * authorise an order without it.
+ *
+ * The interesting assertions are therefore paired: suppressed on the display
+ * AND still present on the submitted field. A test that only checked the
+ * former would pass just as happily against a fix that dropped the value.
+ *
+ * The second half of the file is about the brackets. Two of the display sites
+ * wrote `" (" + number + ")"` as literal text around a value that can now come
+ * back empty, so "no number" has to mean no parens rather than an empty pair —
+ * `Example Ltd`, never `Example Ltd ()`.
+ */
+
+"use strict";
+
+const harness = require("./wc-harness");
+
+const GATEWAY_ID = "woocommerce-gateway-tillit";
+
+/** A minted sole-trader identifier, in the shape the autofill endpoint returns. */
+const SYNTHETIC = "TWO:ST:GB:0f8c2b1a";
+
+describe("TWO:-prefixed organisation numbers", () => {
+  let ctx;
+  let $;
+  let util;
+
+  beforeEach(() => {
+    ctx = harness.loadTwoinc({
+      gateway_id: GATEWAY_ID,
+      supported_buyer_countries: ["GB"],
+      enable_company_search: "yes",
+      enable_address_lookup: "no",
+      text: {}
+    });
+    $ = ctx.$;
+    util = ctx.util;
+  });
+
+  afterEach(() => {
+    harness.releaseWidgets($);
+    document.body.innerHTML = "";
+  });
+
+  describe("isSyntheticCompanyNumber", () => {
+    test("recognises the minted prefix", () => {
+      expect(util.isSyntheticCompanyNumber(SYNTHETIC)).toBe(true);
+      expect(util.isSyntheticCompanyNumber("TWO:")).toBe(true);
+    });
+
+    test("leading whitespace does not smuggle one past", () => {
+      // blankToEmpty trims first, so a value that arrives padded is still
+      // recognised. Worth pinning: the check is a prefix match, and an
+      // untrimmed one would be defeated by a single leading space.
+      expect(util.isSyntheticCompanyNumber("  " + SYNTHETIC)).toBe(true);
+    });
+
+    test("a real registry number is not synthetic", () => {
+      expect(util.isSyntheticCompanyNumber("11111111")).toBe(false);
+      expect(util.isSyntheticCompanyNumber("NO 918 234 567")).toBe(false);
+    });
+
+    test("matches the prefix only at the start, and only in that case", () => {
+      // Deliberately literal and case-sensitive: this is a value the plugin's
+      // own backend mints, never something a buyer or registry types, so there
+      // is no variant to be liberal about — and being liberal here would start
+      // hiding real numbers that happen to contain the letters.
+      expect(util.isSyntheticCompanyNumber("12345TWO:678")).toBe(false);
+      expect(util.isSyntheticCompanyNumber("two:st:gb:1")).toBe(false);
+    });
+
+    test("no number at all is not a number that must be hidden", () => {
+      // These two states are different: "nothing captured yet" must not
+      // suppress a field the buyer is supposed to type into.
+      expect(util.isSyntheticCompanyNumber("")).toBe(false);
+      expect(util.isSyntheticCompanyNumber("   ")).toBe(false);
+      expect(util.isSyntheticCompanyNumber(null)).toBe(false);
+      expect(util.isSyntheticCompanyNumber(undefined)).toBe(false);
+    });
+  });
+
+  describe("formatCompanyNumber", () => {
+    test("passes a registry number through, collapsed", () => {
+      expect(util.formatCompanyNumber("  11111111 ")).toBe("11111111");
+    });
+
+    test("resolves a minted identifier to empty, never to the prefixed value", () => {
+      expect(util.formatCompanyNumber(SYNTHETIC)).toBe("");
+    });
+
+    test("blank input resolves to empty", () => {
+      expect(util.formatCompanyNumber(null)).toBe("");
+      expect(util.formatCompanyNumber(undefined)).toBe("");
+      expect(util.formatCompanyNumber(" ")).toBe("");
+    });
+  });
+
+  describe("formatCompanyLabel — the brackets belong to the number", () => {
+    test("name and registry number compose with parens", () => {
+      expect(util.formatCompanyLabel("Example Ltd", "11111111")).toBe("Example Ltd (11111111)");
+    });
+
+    test("a minted number leaves the bare name, with NO empty parens", () => {
+      const out = util.formatCompanyLabel("Example Ltd", SYNTHETIC);
+
+      expect(out).toBe("Example Ltd");
+      expect(out).not.toContain("(");
+      expect(out).not.toContain(SYNTHETIC);
+    });
+
+    test("a missing number leaves the bare name too", () => {
+      expect(util.formatCompanyLabel("Example Ltd", "")).toBe("Example Ltd");
+      expect(util.formatCompanyLabel("Example Ltd", null)).toBe("Example Ltd");
+    });
+
+    test("no name yields nothing, rather than orphan parens", () => {
+      expect(util.formatCompanyLabel("", "11111111")).toBe("");
+      expect(util.formatCompanyLabel(" ", "11111111")).toBe("");
+    });
+  });
+
+  describe("composeCompanyLabel — the pre-escaped-fragment caller", () => {
+    test("passes its label through untouched", () => {
+      // The search dropdown's label is the response's highlight markup, so
+      // this must not re-encode or trim it — the plain-text callers collapse
+      // their own name before calling in.
+      expect(util.composeCompanyLabel("<em>Example</em> Ltd", "11111111")).toBe(
+        "<em>Example</em> Ltd (11111111)"
+      );
+    });
+
+    test("drops a minted number and its brackets", () => {
+      expect(util.composeCompanyLabel("<em>Example</em> Ltd", SYNTHETIC)).toBe(
+        "<em>Example</em> Ltd"
+      );
+    });
+  });
+
+  describe("the search-results dropdown", () => {
+    /** @returns {Function} the plugin's processResults callback */
+    function processResults() {
+      return ctx.helper.genSelectWooParams().ajax.processResults;
+    }
+
+    /**
+     * One search hit in the shape the companies endpoint returns.
+     *
+     * @param {string} name company name
+     * @param {string} id national identifier
+     * @returns {Object}
+     */
+    function hit(name, id) {
+      return {
+        name: name,
+        highlight: "<em>" + name + "</em>",
+        national_identifier: { id: id },
+        lookup_id: "lookup-" + id
+      };
+    }
+
+    test("renders a minted identifier nowhere in the row", () => {
+      const out = processResults()({ items: [hit("Example Trading Co", SYNTHETIC)] }, {});
+
+      expect(out.results[0].html).toBe("<em>Example Trading Co</em>");
+      expect(out.results[0].html).not.toContain("TWO:");
+      expect(out.results[0].html).not.toContain("(");
+    });
+
+    test("still carries the raw value as the row's company_id", () => {
+      // Selecting this row has to be able to capture the company. The
+      // identifier is what the picker writes to the submitted field, so
+      // filtering it out of the DATA as well would break sole-trader
+      // checkout in the name of a display rule.
+      const out = processResults()({ items: [hit("Example Trading Co", SYNTHETIC)] }, {});
+
+      expect(out.results[0].company_id).toBe(SYNTHETIC);
+    });
+
+    test("a registry number is untouched", () => {
+      const out = processResults()({ items: [hit("Example Trading Co", "11111111")] }, {});
+
+      expect(out.results[0].html).toBe("<em>Example Trading Co</em> (11111111)");
+      expect(out.results[0].company_id).toBe("11111111");
+    });
+  });
+
+  describe("the company summary label under the field", () => {
+    beforeEach(() => {
+      harness.buildCheckoutForm();
+      selectTwo();
+    });
+
+    /**
+     * Put the checkout in the state where Two is the chosen method.
+     *
+     * The harness form carries no payment_method radio of its own, so this
+     * appends one — without it `isTwoincSelected()` reads false and every
+     * company display is hidden for that reason instead of the one under
+     * test, which makes the suppression assertions pass vacuously.
+     */
+    function selectTwo() {
+      $("form[name='checkout']").append(
+        '<input type="radio" name="payment_method" value="' + GATEWAY_ID + '" checked />'
+      );
+    }
+
+    test("shows a registry number", () => {
+      ctx.helper.renderCompanySummary("Example Ltd", "11111111");
+
+      const $summary = $("#" + ctx.helper.companySummaryId);
+      expect($summary.find(".twoinc-company-summary-id").text()).toBe("11111111");
+      expect($summary.hasClass("hidden")).toBe(false);
+    });
+
+    test("renders no number and hides the block for a minted identifier", () => {
+      ctx.helper.renderCompanySummary("Example Ltd", SYNTHETIC);
+
+      const $summary = $("#" + ctx.helper.companySummaryId);
+      expect($summary.find(".twoinc-company-summary-id").text()).toBe("");
+      // The block is keyed on the number, and the number is now empty, so it
+      // must leave no empty strip of vertical space behind under the field.
+      expect($summary.hasClass("hidden")).toBe(true);
+      expect($summary.text()).not.toContain("TWO:");
+    });
+  });
+
+  describe("the order-intent notices", () => {
+    beforeEach(() => {
+      harness.buildCheckoutForm();
+    });
+
+    /**
+     * Stand up an intent notice box carrying the company template the PHP
+     * side serves, plus the captured company in the submitted fields that
+     * togglePaySubtitleDesc reads back.
+     *
+     * @param {string} extraClass the notice's own class
+     * @param {string} number the captured organisation number
+     * @returns {Object} the notice element, as jQuery
+     */
+    function stageNotice(extraClass, number) {
+      $("#billing_company").val("Example Ltd");
+      $("#company_id").val(number);
+      const $box = $(
+        '<div class="twoinc-pay-box ' +
+          extraClass +
+          ' hidden" data-company-template="Order approved for {company}.">' +
+          "Order approved." +
+          "</div>"
+      );
+      $("body").append($box);
+      return $box;
+    }
+
+    test("approved notice names the company with its registry number", () => {
+      const $box = stageNotice("twoinc-intent-approved", "11111111");
+
+      ctx.dom.togglePaySubtitleDesc("intent-approved");
+
+      expect($box.text()).toBe("Order approved for Example Ltd (11111111).");
+    });
+
+    test("approved notice names the company with NO brackets for a minted one", () => {
+      const $box = stageNotice("twoinc-intent-approved", SYNTHETIC);
+
+      ctx.dom.togglePaySubtitleDesc("intent-approved");
+
+      // The §12 case the brackets rule exists for: not "Example Ltd ()", and
+      // not the served fallback sentence either — the company is still known,
+      // so it is still named.
+      expect($box.text()).toBe("Order approved for Example Ltd.");
+      expect($box.text()).not.toContain("TWO:");
+      expect($box.text()).not.toContain("()");
+    });
+
+    test("declined notice omits the brackets the same way", () => {
+      const $box = stageNotice("twoinc-err-payment-default", SYNTHETIC);
+
+      ctx.dom.togglePaySubtitleDesc("errored", ".twoinc-err-payment-default");
+
+      expect($box.text()).toBe("Order approved for Example Ltd.");
+      expect($box.text()).not.toContain("TWO:");
+      expect($box.text()).not.toContain("()");
+    });
+
+    test("the submitted field still holds the raw identifier throughout", () => {
+      stageNotice("twoinc-intent-approved", SYNTHETIC);
+
+      ctx.dom.togglePaySubtitleDesc("intent-approved");
+
+      expect($("#company_id").val()).toBe(SYNTHETIC);
+    });
+  });
+
+  describe("the visible #company_id field", () => {
+    /**
+     * The one configuration that shows `#company_id` to the buyer: company
+     * search off, so the plain name+id fallback is what captures the company.
+     */
+    function loadWithSearchOff() {
+      ctx = harness.loadTwoinc({
+        gateway_id: GATEWAY_ID,
+        supported_buyer_countries: ["GB"],
+        enable_company_search: "no",
+        enable_address_lookup: "no",
+        text: {}
+      });
+      $ = ctx.$;
+      util = ctx.util;
+      harness.buildCheckoutForm();
+      // See the note on selectTwo() above: without a checked radio the field
+      // is hidden because Two is not the selected method, and the minted-value
+      // assertion below would hold no matter what the filter did.
+      $("form[name='checkout']").append(
+        '<input type="radio" name="payment_method" value="' + GATEWAY_ID + '" checked />'
+      );
+    }
+
+    test("is shown when the buyer has a registry number to type", () => {
+      loadWithSearchOff();
+      $("#company_id").val("11111111");
+
+      ctx.dom.toggleBusinessFields();
+
+      expect($("#company_id_field").hasClass("hidden")).toBe(false);
+    });
+
+    test("is shown when nothing has been captured yet", () => {
+      loadWithSearchOff();
+      $("#company_id").val("");
+
+      ctx.dom.toggleBusinessFields();
+
+      expect($("#company_id_field").hasClass("hidden")).toBe(false);
+    });
+
+    test("is hidden when it holds a minted identifier", () => {
+      loadWithSearchOff();
+      $("#company_id").val(SYNTHETIC);
+
+      ctx.dom.toggleBusinessFields();
+
+      // An enrolled sole trader in a search-off shop is how `TWO:…` ends up
+      // in a visible text box. Hiding the field is the fix rather than
+      // blanking it: the value is what WooCommerce posts.
+      expect($("#company_id_field").hasClass("hidden")).toBe(true);
+      expect($("#company_id").val()).toBe(SYNTHETIC);
+    });
+
+    test("carries no required cue while hidden", () => {
+      loadWithSearchOff();
+      $("#company_id").val(SYNTHETIC);
+
+      ctx.dom.toggleBusinessFields();
+
+      // A required cue on a field nobody can see is how a checkout becomes
+      // unsubmittable with no visible reason why.
+      expect($("#company_id_field").hasClass("validate-required")).toBe(false);
+    });
+  });
+});

--- a/tests/js/company-number-display.test.js
+++ b/tests/js/company-number-display.test.js
@@ -141,6 +141,19 @@ describe("TWO:-prefixed organisation numbers", () => {
         "<em>Example</em> Ltd"
       );
     });
+
+    test("an empty label yields no orphan parens", () => {
+      expect(util.composeCompanyLabel("", "11111111")).toBe("");
+    });
+
+    test("returns its label verbatim when there is nothing to append", () => {
+      // The contract callers rely on: whatever went in comes back out
+      // untouched, so a caller that passed a string always gets a string. The
+      // dropdown guarantees that by defaulting its fragment before calling in
+      // — a search hit missing `highlight` must not compose to `undefined`.
+      expect(util.composeCompanyLabel("", SYNTHETIC)).toBe("");
+      expect(util.composeCompanyLabel("Example Ltd", "")).toBe("Example Ltd");
+    });
   });
 
   describe("the search-results dropdown", () => {
@@ -188,6 +201,25 @@ describe("TWO:-prefixed organisation numbers", () => {
 
       expect(out.results[0].html).toBe("<em>Example Trading Co</em> (11111111)");
       expect(out.results[0].company_id).toBe("11111111");
+    });
+
+    test("a hit with no highlight falls back to the plain name", () => {
+      // This loop is written to survive a response that omits a field — the
+      // identifier is already read defensively. Without the same tolerance for
+      // `highlight` the row composes to `undefined` and select2 renders a
+      // blank-but-selectable entry.
+      const withoutHighlight = hit("Example Trading Co", "11111111");
+      delete withoutHighlight.highlight;
+
+      const out = processResults()({ items: [withoutHighlight] }, {});
+
+      expect(out.results[0].html).toBe("Example Trading Co (11111111)");
+    });
+
+    test("a hit with neither highlight nor name yields a string, not undefined", () => {
+      const out = processResults()({ items: [{ national_identifier: { id: "11111111" } }] }, {});
+
+      expect(typeof out.results[0].html).toBe("string");
     });
   });
 
@@ -289,13 +321,30 @@ describe("TWO:-prefixed organisation numbers", () => {
       expect($box.text()).not.toContain("TWO:");
       expect($box.text()).not.toContain("()");
     });
+  });
 
-    test("the submitted field still holds the raw identifier throughout", () => {
-      stageNotice("twoinc-intent-approved", SYNTHETIC);
+  describe("the data the server is sent", () => {
+    beforeEach(() => {
+      harness.buildCheckoutForm();
+    });
 
-      ctx.dom.togglePaySubtitleDesc("intent-approved");
+    // This is the half the display filter must NOT reach. Asserting that
+    // `#company_id` still holds what the test itself typed into it would be a
+    // tautology — nothing in the display path writes that input — so the
+    // assertions here are on the payload builder instead, which is what a
+    // careless "just filter it at the source" fix would break.
+    test("getCompanyData carries the raw minted identifier", () => {
+      $("#billing_company").val("Example Ltd");
+      $("#company_id").val(SYNTHETIC);
 
-      expect($("#company_id").val()).toBe(SYNTHETIC);
+      expect(ctx.dom.getCompanyData().organization_number).toBe(SYNTHETIC);
+    });
+
+    test("getCompanyData carries a registry number unchanged", () => {
+      $("#billing_company").val("Example Ltd");
+      $("#company_id").val("11111111");
+
+      expect(ctx.dom.getCompanyData().organization_number).toBe("11111111");
     });
   });
 
@@ -351,7 +400,6 @@ describe("TWO:-prefixed organisation numbers", () => {
       // in a visible text box. Hiding the field is the fix rather than
       // blanking it: the value is what WooCommerce posts.
       expect($("#company_id_field").hasClass("hidden")).toBe(true);
-      expect($("#company_id").val()).toBe(SYNTHETIC);
     });
 
     test("carries no required cue while hidden", () => {
@@ -361,8 +409,105 @@ describe("TWO:-prefixed organisation numbers", () => {
       ctx.dom.toggleBusinessFields();
 
       // A required cue on a field nobody can see is how a checkout becomes
-      // unsubmittable with no visible reason why.
-      expect($("#company_id_field").hasClass("validate-required")).toBe(false);
+      // unsubmittable with no visible reason why. Asserted against what
+      // toggleRequiredCues actually does — set the `required` attribute and
+      // append an `<abbr class="twoinc-required">` to the label. An earlier
+      // draft asserted a `validate-required` class that nothing in this
+      // codebase sets, so it passed no matter what the production code did.
+      expect($("#company_id").attr("required")).toBeFalsy();
+      expect($("#company_id_field").find("label .twoinc-required").length).toBe(0);
+    });
+
+    test("keeps the required cue when a registry number is expected", () => {
+      // The counterweight to the test above: proves the cue is genuinely
+      // driven by the filter, not simply absent in this fixture.
+      loadWithSearchOff();
+      $("#company_id").val("11111111");
+
+      ctx.dom.toggleBusinessFields();
+
+      expect($("#company_id").attr("required")).toBeTruthy();
+    });
+
+    describe("driven through the real sole-trader flow", () => {
+      // The ordering that matters, and the one the assertions above cannot
+      // reach: production toggles the fields BEFORE the autofill lands, so
+      // `#company_id` is empty at toggle time and the field is shown on the
+      // strength of that. Setting the value first and toggling afterwards —
+      // as the tests above do — inverts it, and would certify a guarantee
+      // the real flow does not deliver. So drive the actual capture entry
+      // point and assert the end state.
+      test("enrolling a sole trader leaves no minted number on screen", () => {
+        loadWithSearchOff();
+
+        ctx.soleTrader.setCompany(SYNTHETIC, "Example Ltd");
+
+        expect($("#company_id_field").hasClass("hidden")).toBe(true);
+        expect($("#company_id").attr("required")).toBeFalsy();
+        // Still posted — the whole point of hiding rather than blanking.
+        expect($("#company_id").val()).toBe(SYNTHETIC);
+        expect(ctx.dom.getCompanyData().organization_number).toBe(SYNTHETIC);
+      });
+
+      test("capturing a registry company still shows the field", () => {
+        loadWithSearchOff();
+
+        ctx.soleTrader.setCompany("11111111", "Example Ltd");
+
+        expect($("#company_id_field").hasClass("hidden")).toBe(false);
+      });
+
+      test("the summary label shows no minted number after enrollment", () => {
+        loadWithSearchOff();
+
+        ctx.soleTrader.setCompany(SYNTHETIC, "Example Ltd");
+
+        const $summary = $("#" + ctx.helper.companySummaryId);
+        expect($summary.find(".twoinc-company-summary-id").text()).toBe("");
+        expect($summary.hasClass("hidden")).toBe(true);
+      });
+    });
+
+    describe("restored from a previous visit", () => {
+      // The other ordering trap: initialize() toggles the fields before the
+      // restore passes run, so both of them write `#company_id` after the
+      // decision was taken against an empty input. A returning sole trader's
+      // user meta holds a minted identifier, so this is the every-page-load
+      // case rather than an edge case.
+      test("user-meta restore leaves no minted number on screen", () => {
+        loadWithSearchOff();
+        ctx.dom.toggleBusinessFields();
+        // The state initialize() is in when it reaches the restore: fields
+        // already toggled, input still empty.
+        expect($("#company_id_field").hasClass("hidden")).toBe(false);
+
+        ctx.twoinc.billing_company = "Example Ltd";
+        ctx.twoinc.company_id = SYNTHETIC;
+        ctx.dom.loadUserMetaInputs();
+
+        expect($("#company_id").val()).toBe(SYNTHETIC);
+        expect($("#company_id_field").hasClass("hidden")).toBe(true);
+      });
+
+      test("user-meta restore of a registry number still shows the field", () => {
+        loadWithSearchOff();
+        ctx.dom.toggleBusinessFields();
+
+        ctx.twoinc.billing_company = "Example Ltd";
+        ctx.twoinc.company_id = "11111111";
+        ctx.dom.loadUserMetaInputs();
+
+        expect($("#company_id_field").hasClass("hidden")).toBe(false);
+      });
+
+      // No equivalent for loadStorageInputs(): that replay is deliberately
+      // NOT made to re-toggle. It runs from initialize() before the country
+      // configuration is guaranteed to be populated (an existing suite drives
+      // it with a minimal fixture and toggleBusinessFields() throws there), and
+      // it only ever replays the current session's own inputs — which the
+      // capture path that produced them has already toggled for. The
+      // cross-visit case, which is the one that actually persists a minted
+      // identifier, is the user-meta pass covered above.
     });
   });
 });


### PR DESCRIPTION
## What

Two requirements from TWO-25326, checked together. Only one needed code.

### Requirement 12 — never display a `TWO:`-prefixed organisation number (FIXED)

Sole-trader enrollment mints an organisation number of the form `TWO:…` for a buyer with no registry identifier of their own. It is a protocol value the backend derives the company type from, not a number the buyer's own authorities would recognise, so it must not reach any surface a human reads.

It still has to be **posted and sent to the API** — the payment method cannot authorise an order without one — so this filters the *display* only. Every test asserts both halves: suppressed on screen AND still present on the submitted field. A test that only checked the former would pass just as happily against a fix that dropped the value.

**One shared formatter, not a filter per call site**, added in `twoincUtilHelper` beside `blankToEmpty`:

| Helper | Job |
|---|---|
| `isSyntheticCompanyNumber(value)` | The predicate, for callers that branch on the fact rather than render the value. Empty is deliberately **not** synthetic — "nothing captured yet" is a different state from "a number that must not be shown", and only the latter hides a field. |
| `formatCompanyNumber(value)` | The display value; `""` for a minted one, so every caller's existing truthiness check doubles as the suppression. |
| `composeCompanyLabel(label, value)` | The `<label> (<number>)` chunk. **The brackets belong to the number**: when it resolves to nothing the label comes back bare, never `Example Ltd ()`. |
| `formatCompanyLabel(name, value)` | `composeCompanyLabel` for a plain-text name. |

The composer takes its label **untouched** because the two callers disagree about what it holds — the intent notices pass plain text bound for `.text()`, the search dropdown passes the search response's pre-highlighted HTML fragment bound for `innerHTML`. Trimming or re-encoding centrally would have to pick one contract and break the other, so plain-text callers collapse their own name via `formatCompanyLabel` and the fragment caller uses `composeCompanyLabel`.

**Four display sites routed through it:**

- **The summary label under the company field** (`renderCompanySummary`) — the block is already keyed on the number being non-empty, so it now hides itself rather than showing an empty strip.
- **The search-results dropdown rows** — while `company_id` keeps the raw value, so selecting the row still captures the company.
- **The approved and declined order-intent notices**, via `getCompanyLabelText` — both had the parens written as literal text around a value that can now come back empty. This is the `Company Name (123456789)` → `Company Name` case.
- **`#company_id` itself**, in the one configuration that shows it to the buyer: company search off, in a country whose registry supports sole traders. The field is **hidden rather than blanked**, because the value is what WooCommerce posts and what the intent is authorised against — the enrollment already supplied it, so there is nothing left to type. Its required cue goes with it; a required cue on an invisible field is how a checkout becomes unsubmittable with no visible reason why.

### Requirement 11 — spinner must be local, not a page-covering overlay (ALREADY CORRECT, no change)

The order-intent spinner is already scoped to the payment tile and was left alone.

It is a `<div class="twoinc-pay-box twoinc-loader" role="status">` injected into the payment-method box's own description (`class/WC_Twoinc.php`, `get_intent_loader_html()`), revealed by `jQuery(".twoinc-pay-box.twoinc-loader").removeClass("hidden")` in `togglePaySubtitleDesc("checking-intent")` (`assets/js/twoinc.js`). Its only rule in `assets/css/twoinc.css` is `text-align: center` — no `position: fixed`, no backdrop, no mask. The plugin calls no `blockUI`/`.block()` anywhere, and the company-search spinner is likewise a `position: absolute` element inside the dropdown's own search box.

Verified by grep across the plugin's JS, CSS and PHP for `blockUI`, `.block(`, `position: fixed`, overlay and mask patterns: no page-covering spinner exists to fix.

## Translation

**No new or changed user-facing strings.** Requirement 12 is pure filtering of values that were already on screen, and requirement 11 needed no change at all — so no `.po`/`.json` catalogue entries were added and no locale files are touched.

## Tests

New `tests/js/company-number-display.test.js`, 27 cases: the helpers directly (including the brackets-omitted-when-empty case and the empty-is-not-synthetic distinction), plus each of the four display sites end to end, each paired with an assertion that the submitted value survived.

```
Test Suites: 13 passed, 13 total
Tests:       354 passed, 354 total
```

**Mutation-checked, not just green.** Stubbing `isSyntheticCompanyNumber` to `return false` fails 10 of the new tests — at least one per display site — so they genuinely pin the filter rather than passing vacuously. That check also caught a real vacuity in the first draft: the harness checkout form carries no `payment_method` radio, so `isTwoincVisible()`/`isTwoincSelected()` read false and every company display was hidden *for that reason* instead of the one under test. The suite now appends a checked radio, which is why the `#company_id` assertions are meaningful.

## Deliberately NOT changed — needs a ruling

The **admin user-profile "Billing Company ID" input** (`class/WC_Twoinc.php`) also renders a stored `company_id`, and can hold a minted one. It is left as-is on purpose: it is an *editable* field whose value round-trips through `save_user_meta()`, which writes `$_POST['twoinc_company_id']` unconditionally. So blanking the rendered value makes the next profile save erase the stored identifier, and omitting the input makes that same save wipe it to empty.

It is a merchant-admin data-editing screen rather than a buyer-facing display, so it is outside the spirit of §12, and the safe fix needs a decision about the save path (guard on `isset`, or round-trip the real value through a hidden field). Flagged rather than guessed at.

No PHP formatter was added because no *checkout* PHP renders an organisation number value — `WC_Twoinc_Checkout.php` passes it to the browser as data and renders only the field's label.
